### PR TITLE
improve nydus snapshotter container image

### DIFF
--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04 AS sourcer
 
-RUN apt update; apt install -y curl wget
+RUN apt update; apt install --no-install-recommends -y curl wget
 RUN export NYDUS_VERSION=$(curl --silent "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'); \
-    wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-x86_64.tgz; \
+    wget --no-check-certificate https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-x86_64.tgz; \
     tar xzf nydus-static-$NYDUS_VERSION-x86_64.tgz
 RUN mv nydus-static/* /; mv nydusd-fusedev nydusd
 
@@ -13,6 +13,9 @@ RUN mkdir -p /usr/local/bin/ /etc/nydus/ /var/lib/nydus/cache/
 COPY --from=sourcer /nydusd /nydus-image /usr/local/bin/
 COPY containerd-nydus-grpc /usr/local/bin/
 COPY nydusd-config.json /etc/nydus/config.json
+RUN apt update && \
+    apt install --no-install-recommends -y ca-certificates && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+CONTAINERD_ROOT="${CONTAINERD_ROOT:-/var/lib/containerd/}"
+
 set -eu
 
 if [ "$#" -eq 0 ]; then
@@ -7,10 +9,11 @@ if [ "$#" -eq 0 ]; then
 	    --log-level trace \
 	    --nydusd-path /usr/local/bin/nydusd \
 	    --config-path /etc/nydus/config.json \
-	    --root /var/lib/containerd-test/io.containerd.snapshotter.v1.nydus \
-	    --address /var/lib/containerd-test/io.containerd.snapshotter.v1.nydus/containerd-nydus-grpc.sock \
+	    --root ${CONTAINERD_ROOT}/io.containerd.snapshotter.v1.nydus \
+	    --address ${CONTAINERD_ROOT}/io.containerd.snapshotter.v1.nydus/containerd-nydus-grpc.sock \
 	    --enable-nydus-overlayfs \
+	    --daemon-mode shared \
 	    --log-to-stdout
 fi
 
-exec "$@"
+exec $@


### PR DESCRIPTION
A few improvements for the nydus-snapshotter image.

1. support customized containerd root path
2. use shared daemon mode
3. handle base image CA issue
4. do not install recommended packages
5. clean up apt cache

Signed-off-by: Peng Tao <bergwolf@hyper.sh>