### PR TITLE
fix image builder ssl issue and trigger build on pull_request and release

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,9 +1,14 @@
 name: nydus-snapshotter image
 
 on:
-  schedule:
-    # Every day at 00:33 clock UTC
-    - cron: "33 0 * * *"
+  push:
+    branches:
+      - 'main'
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+  pull_request:
+    branches:
+      - 'main'
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +40,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push nydus-snapshotter image
         run: |
+          TAG=$GITHUB_REF_NAME
+          [ "$TAG" == "main" ] && TAG="latest"
+          [ "$GITHUB_EVENT_NAME" == "pull_request" ] && TAG="local"
           cd misc/snapshotter
-          docker build -t ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:latest .
-          docker push ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:latest
+          docker build -t ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:$TAG .
+          # Only push for non pull_request
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+              docker push ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:$TAG
+          fi

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04 AS sourcer
 
-RUN apt update; apt install --no-install-recommends -y curl wget
+RUN apt update; apt install --no-install-recommends -y curl wget ca-certificates
 RUN export NYDUS_VERSION=$(curl --silent "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'); \
-    wget --no-check-certificate https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-x86_64.tgz; \
+    wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-x86_64.tgz; \
     tar xzf nydus-static-$NYDUS_VERSION-x86_64.tgz
 RUN mv nydus-static/* /; mv nydusd-fusedev nydusd
 


### PR DESCRIPTION
* `nydus-snapshotter:latest` is built and pushed on each push to main
* `nydus-snapshotter:$release_tag` is built and pushed on each release tag
* `nydus-snapshotter:local` is built on each pull request but not pushed, for testing purpose

Tested at https://github.com/bergwolf/nydus-snapshotter/actions/workflows/image.yml