### PR TITLE
cmd: remove nydusd-path and nydusimg-path startup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ fetching sha256:75002dfe... application/vnd.oci.image.manifest.v1+json
 fetching sha256:5a42e21c... application/vnd.oci.image.config.v1+json
 fetching sha256:eb1af2e1... application/vnd.oci.image.layer.v1.tar+gzip
 
-# Start container by `ctr`
+# Start container by `ctr-remote`
 $ sudo ctr-remote run --snapshotter nydus ghcr.io/dragonflyoss/image-service/nginx:nydus-latest
 
 # Start container by `nerdctl`
@@ -100,14 +100,14 @@ nerdctl --snapshotter nydus run ghcr.io/dragonflyoss/image-service/nginx:nydus-l
 
 ### Start Container in Kubernetes
 
-NOTE: A potential drawback using CRI is that we can hardly specify snapshotter to `nydus-snapshotter`. So we have to change containerd's default snapshotter in its configuration file like below:
+**NOTE:** A potential drawback using CRI is that we can hardly specify snapshotter to `nydus-snapshotter`. So we have to change containerd's default snapshotter in its configuration file like below:
 
 ```toml
 [plugins."io.containerd.grpc.v1.cri".containerd]
    snapshotter = "nydus"
 ```
 
-Use `crictl` to debug starting container via Kubernetes CRI. Dry run [steps](./docs/crictl_dry_run.md) of using `ctrctl` can be found in [documents](./docs).
+Use `crictl` to debug starting container via Kubernetes CRI. Dry run [steps](./docs/crictl_dry_run.md) of using `crictl` can be found in [documents](./docs).
 
 ## Community
 

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -18,13 +18,11 @@ import (
 )
 
 const (
-	defaultAddress        = "/run/containerd-nydus-grpc/containerd-nydus-grpc.sock"
-	defaultLogLevel       = logrus.InfoLevel
-	defaultRootDir        = "/var/lib/containerd-nydus-grpc"
-	defaultGCPeriod       = "24h"
-	defaultPublicKey      = "/signing/nydus-image-signing-public.key"
-	defaultNydusdPath     = "/bin/nydusd"
-	defaultNydusImagePath = "/bin/nydusd-img"
+	defaultAddress   = "/run/containerd-nydus-grpc/containerd-nydus-grpc.sock"
+	defaultLogLevel  = logrus.InfoLevel
+	defaultRootDir   = "/var/lib/containerd-nydus-grpc"
+	defaultGCPeriod  = "24h"
+	defaultPublicKey = "/signing/nydus-image-signing-public.key"
 )
 
 type Args struct {
@@ -96,7 +94,7 @@ func buildFlags(args *Args) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "gc-period",
 			Value:       defaultGCPeriod,
-			Usage:       "period for gc blob cache, for example, 1m, 2h",
+			Usage:       "period for gc blob cache, duration string(for example, 1m, 2h)",
 			Destination: &args.GCPeriod,
 		},
 		&cli.BoolFlag{
@@ -113,14 +111,14 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "nydusd-path",
-			Value:       defaultNydusdPath,
-			Usage:       "path to nydusd binary",
+			Value:       "",
+			Usage:       "path to nydusd binary, if not set will lookup in $PATH",
 			Destination: &args.NydusdBinaryPath,
 		},
 		&cli.StringFlag{
 			Name:        "nydusimg-path",
-			Value:       defaultNydusImagePath,
-			Usage:       "path to nydus-img binary path",
+			Value:       "",
+			Usage:       "path to nydus-img binary path, if not set will lookup in $PATH",
 			Destination: &args.NydusImageBinaryPath,
 		},
 		&cli.BoolFlag{
@@ -179,7 +177,7 @@ func buildFlags(args *Args) []cli.Flag {
 		&cli.BoolFlag{
 			Name:        "enable-nydus-overlayfs",
 			Value:       false,
-			Usage:       "whether to disable nydus-overlayfs to mount",
+			Usage:       "whether to enable nydus-overlayfs to mount",
 			Destination: &args.EnableNydusOverlayFS,
 		},
 	}
@@ -241,5 +239,5 @@ func Validate(args *Args, cfg *config.Config) error {
 		return errors.Wrapf(err, "parse gc period %v failed", args.GCPeriod)
 	}
 	cfg.GCPeriod = d
-	return nil
+	return cfg.SetupNydusBinaryPaths()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (
@@ -23,8 +24,8 @@ const (
 	defaultGCPeriod           = 24 * time.Hour
 
 	defaultNydusDaemonConfigPath string = "/etc/nydus/config.json"
-	defaultNydusdBinaryPath      string = "/usr/local/bin/nydusd"
-	defaultNydusImageBinaryPath  string = "/usr/local/bin/nydus-image"
+	nydusdBinaryName             string = "nydusd"
+	nydusImageBinaryName         string = "nydus-image"
 )
 
 type Config struct {
@@ -59,14 +60,6 @@ func (c *Config) FillupWithDefaults() error {
 		c.DaemonCfgPath = defaultNydusDaemonConfigPath
 	}
 
-	if c.NydusdBinaryPath == "" {
-		c.NydusdBinaryPath = defaultNydusdBinaryPath
-	}
-
-	if c.NydusImageBinaryPath == "" {
-		c.NydusImageBinaryPath = defaultNydusImageBinaryPath
-	}
-
 	if c.DaemonMode == "" {
 		c.DaemonMode = DefaultDaemonMode
 	}
@@ -87,5 +80,27 @@ func (c *Config) FillupWithDefaults() error {
 		return errors.Wrapf(err, "failed to load config file %q", c.DaemonCfgPath)
 	}
 	c.DaemonCfg = daemonCfg
+	return c.SetupNydusBinaryPaths()
+}
+
+func (c *Config) SetupNydusBinaryPaths() error {
+	// resolve nydusd path
+	if c.NydusdBinaryPath == "" {
+		path, err := exec.LookPath(nydusdBinaryName)
+		if err != nil {
+			return err
+		}
+		c.NydusdBinaryPath = path
+	}
+
+	// resolve nydus-image path
+	if c.NydusImageBinaryPath == "" {
+		path, err := exec.LookPath(nydusImageBinaryName)
+		if err != nil {
+			return err
+		}
+		c.NydusImageBinaryPath = path
+	}
+
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
 	go.etcd.io/bbolt v1.3.6
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40
 	google.golang.org/grpc v1.41.0
 )
 


### PR DESCRIPTION
Remove nydusd-path and nydusimg-path from startup options,
instead lookup them in PATH.

Fixes: #8

Signed-off-by: bin liu <liubin0329@gmail.com>