### PR TITLE
README.md: add disable_snapshot_annotations=false in cri env

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,12 @@ nerdctl --snapshotter nydus run ghcr.io/dragonflyoss/image-service/nginx:nydus-l
 
 ### Start Container in Kubernetes
 
-**NOTE:** A potential drawback using CRI is that we can hardly specify snapshotter to `nydus-snapshotter`. So we have to change containerd's default snapshotter in its configuration file like below:
+**NOTE:** A potential drawback using CRI is that we can hardly specify snapshotter to `nydus-snapshotter`. So we have to change containerd's default snapshotter in its configuration file and enable snapshot annotations like below:
 
 ```toml
 [plugins."io.containerd.grpc.v1.cri".containerd]
    snapshotter = "nydus"
+   disable_snapshot_annotations = false
 ```
 
 Use `crictl` to debug starting container via Kubernetes CRI. Dry run [steps](./docs/crictl_dry_run.md) of using `crictl` can be found in [documents](./docs).


### PR DESCRIPTION
As 'containerd config default' produce default configuration
which include disable_snapshot_annotations=true, but nydus-snapshotter
depend on snapshot annotation, so here we should set explicitly.

Signed-off-by: luodaowen.backend <luodaowen.backend@bytedance.com>