### PR TITLE
Provide make install to facilitate configuring nydus-snapshotter 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ clear:
 	rm -f bin/*
 	rm -rf _out
 
+
+.PHONY: install
+install: static-release
+	sudo install -D -m 755 bin/containerd-nydus-grpc /usr/local/bin/containerd-nydus-grpc
+	sudo install -D -m 755 misc/snapshotter/nydusd-config.json /etc/nydus/config.json
+	sudo install -D -m 644 misc/snapshotter/nydus-snapshotter.service /etc/systemd/system/nydus-snapshotter.service
+	sudo systemctl enable /etc/systemd/system/nydus-snapshotter.service
+
 .PHONY: vet
 vet:
 	go vet $(PACKAGES)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ Please follow instructions to [configure nydus](./docs/configure_nydus.md) confi
 
 Nydus-snapshotter is implemented as a [proxy plugin](https://github.com/containerd/containerd/blob/04985039cede6aafbb7dfb3206c9c4d04e2f924d/PLUGINS.md#proxy-plugins) (`containerd-nydus-grpc`) for containerd.
 
-A example of starting nydus-snapshotter:
+Assume your server systemd based, install nydus-snapshotter:
+Note: `nydusd` and `nydus-image` should be found from $PATH.
+```bash
+make install
+systemctl restart containerd
+```
 
+Or you can start nydus-snapshotter manually.
 ```bash
 # `nydusd-path` is the path to nydusd binary
 # `address` is the domain socket that you configured in containerd configuration file
@@ -62,7 +68,7 @@ $ ./containerd-nydus-grpc \
     --log-level info \
     --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
     --cache-dir /var/lib/nydus/cache \
-    --address /run/containerd/containerd-nydus-grpc.sock \
+    --address /run/containerd-nydus/containerd-nydus-grpc.sock \
     --nydusd-path /usr/local/bin/nydusd \
     --nydusimg-path /usr/local/bin/nydus-image \
     --log-to-stdout

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultAddress   = "/run/containerd-nydus-grpc/containerd-nydus-grpc.sock"
+	defaultAddress   = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 	defaultLogLevel  = logrus.InfoLevel
 	defaultRootDir   = "/var/lib/containerd-nydus-grpc"
 	defaultGCPeriod  = "24h"

--- a/misc/snapshotter/nydus-snapshotter.service
+++ b/misc/snapshotter/nydus-snapshotter.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=nydus snapshotter
+After=network.target
+Before=containerd.service
+
+[Service]
+Type=simple
+Environment=HOME=/root
+ExecStart=/usr/local/bin/containerd-nydus-grpc --config-path /etc/nydus/config.json
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Users just perform `make install` and download `nydusd` and `nydus-image` before they can use nydus-snapshotter