### PR TITLE
daemon: use one nydus client per Daemon

### DIFF
--- a/pkg/metric/serve.go
+++ b/pkg/metric/serve.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/metric/exporter"
-	"github.com/containerd/nydus-snapshotter/pkg/nydussdk"
 	"github.com/containerd/nydus-snapshotter/pkg/process"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -112,14 +111,7 @@ outer:
 				if d.ID == daemon.SharedNydusDaemonID {
 					continue
 				}
-
-				client, err := nydussdk.NewNydusClient(d.APISock())
-				if err != nil {
-					log.G(ctx).Errorf("failed to connect nydusd: %v", err)
-					continue
-				}
-
-				fsMetrics, err := client.GetFsMetric(s.pm.IsSharedDaemon(), d.SnapshotID)
+				fsMetrics, err := d.GetFsMetric(s.pm.IsSharedDaemon(), d.SnapshotID)
 				if err != nil {
 					log.G(ctx).Errorf("failed to get fs metric: %v", err)
 					continue

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -254,16 +254,16 @@ func (m *Manager) Reconnect(ctx context.Context) error {
 			WithField("mode", d.DaemonMode).
 			Info("found daemon in database")
 
+		d.Once = &sync.Once{}
 		// Do not check status on virtual daemons
 		if m.isOneDaemon() && d.ID != daemon.SharedNydusDaemonID {
 			daemons = append(daemons, d)
 			log.L.WithField("daemon", d.ID).Infof("found virtual daemon")
 			return nil
 		}
-
 		_, err := d.CheckStatus()
 		if err != nil {
-			log.L.WithField("daemon", d.ID).Warnf("failed to check daemon status")
+			log.L.WithField("daemon", d.ID).Warnf("failed to check daemon status: %v", err)
 			return nil
 		}
 		log.L.WithField("daemon", d.ID).Infof("found alive daemon")


### PR DESCRIPTION
Currently we create new nydusd client in CheckStatus(), SharedMount()
and SharedUmount(), but set max connection in underlying transport to
10. So we sometimes see 503 response when the number of connections
exceed 10.

So let's use one nydus client per Daemon to avoid such 503 error.

Fixes: #31
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>