### PR TITLE
Fix daemon state check

### DIFF
--- a/pkg/nydussdk/client.go
+++ b/pkg/nydussdk/client.go
@@ -34,7 +34,7 @@ const (
 )
 
 type Interface interface {
-	CheckStatus() (model.DaemonInfo, error)
+	CheckStatus() (*model.DaemonInfo, error)
 	SharedMount(sharedMountPoint, bootstrap, daemonConfig string) error
 	Umount(sharedMountPoint string) error
 	GetFsMetric(sharedDaemon bool, sid string) (*model.FsMetric, error)
@@ -57,22 +57,22 @@ func NewNydusClient(sock string) (Interface, error) {
 	}, nil
 }
 
-func (c *NydusClient) CheckStatus() (model.DaemonInfo, error) {
+func (c *NydusClient) CheckStatus() (*model.DaemonInfo, error) {
 	addr := fmt.Sprintf("http://unix%s", infoEndpoint)
 	resp, err := c.httpClient.Get(addr)
 	if err != nil {
-		return model.DaemonInfo{}, errors.Wrapf(err, "failed to do HTTP GET from %s", addr)
+		return nil, errors.Wrapf(err, "failed to do HTTP GET from %s", addr)
 	}
 	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return model.DaemonInfo{}, errors.Wrap(err, "failed to read status response")
+		return nil, errors.Wrap(err, "failed to read status response")
 	}
 	var info model.DaemonInfo
 	if err = json.Unmarshal(b, &info); err != nil {
-		return model.DaemonInfo{}, err
+		return nil, err
 	}
-	return info, nil
+	return &info, nil
 }
 
 func (c *NydusClient) Umount(sharedMountPoint string) error {

--- a/pkg/nydussdk/client_test.go
+++ b/pkg/nydussdk/client_test.go
@@ -39,7 +39,7 @@ func prepareNydusServer(t *testing.T) (string, func()) {
 		info := model.DaemonInfo{
 			ID:      "testid",
 			Version: BTI,
-			State:   "Running",
+			State:   "RUNNING",
 		}
 		w.Header().Set("Content-Type", "application/json")
 		j, _ := json.Marshal(info)
@@ -61,7 +61,7 @@ func TestNydusClient_CheckStatus(t *testing.T) {
 	require.Nil(t, err)
 	info, err := client.CheckStatus()
 	require.Nil(t, err)
-	assert.Equal(t, "Running", info.State)
+	assert.True(t, info.Running())
 	assert.Equal(t, "testid", info.ID)
 	assert.Equal(t, BTI, info.Version)
 }

--- a/pkg/nydussdk/model/model.go
+++ b/pkg/nydussdk/model/model.go
@@ -6,6 +6,8 @@
 
 package model
 
+import "strings"
+
 type BuildTimeInfo struct {
 	PackageVer string `json:"package_ver"`
 	GitCommit  string `json:"git_commit"`
@@ -18,6 +20,12 @@ type DaemonInfo struct {
 	ID      string        `json:"id"`
 	Version BuildTimeInfo `json:"version"`
 	State   string        `json:"state"`
+}
+
+func (info *DaemonInfo) Running() bool {
+	// Due to history reason, the daemon state returned by nydusd sock API has
+	// been changed from `Running` to `RUNNING`, so keeps compatibility here.
+	return strings.ToUpper(info.State) == "RUNNING"
 }
 
 type ErrorMessage struct {

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -261,9 +261,13 @@ func (m *Manager) Reconnect(ctx context.Context) error {
 			log.L.WithField("daemon", d.ID).Infof("found virtual daemon")
 			return nil
 		}
-		_, err := d.CheckStatus()
+		info, err := d.CheckStatus()
 		if err != nil {
 			log.L.WithField("daemon", d.ID).Warnf("failed to check daemon status: %v", err)
+			return nil
+		}
+		if !info.Running() {
+			log.L.WithField("daemon", d.ID).Warnf("daemon is not running: %v", info)
 			return nil
 		}
 		log.L.WithField("daemon", d.ID).Infof("found alive daemon")


### PR DESCRIPTION
Due to history reason, the daemon state returned by nydusd sock API
has been changed from `Running` to `RUNNING`, the fixup keeps compatibility
and fix nil error return on checking.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>