### PR TITLE
1. fix the bug that daemon status is not fully serialized; 2. add cleanup_on_close config option; 3. add StatusCode in handleMountError

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -48,6 +48,7 @@ type Args struct {
 	LogToStdout          bool
 	EnableNydusOverlayFS bool
 	NydusdThreadNum      int
+	CleanupOnClose       bool
 }
 
 type Flags struct {
@@ -186,6 +187,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "Nydusd daemon thread-num, default will be set to the number of CPUs",
 			Destination: &args.NydusdThreadNum,
 		},
+		&cli.BoolFlag{
+			Name:        "cleanup-on-close",
+			Value:       false,
+			Usage:       "whether to do cleanup when close snapshotter",
+			Destination: &args.CleanupOnClose,
+		},
 	}
 }
 
@@ -240,6 +247,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.DisableCacheManager = args.DisableCacheManager
 	cfg.EnableNydusOverlayFS = args.EnableNydusOverlayFS
 	cfg.NydusdThreadNum = args.NydusdThreadNum
+	cfg.CleanupOnClose = args.CleanupOnClose
 
 	d, err := time.ParseDuration(args.GCPeriod)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	DisableCacheManager  bool          `toml:"disable_cache_manager"`
 	EnableNydusOverlayFS bool          `toml:"enable_nydus_overlayfs"`
 	NydusdThreadNum      int           `toml:"nydusd_thread_num"`
+	CleanupOnClose       bool          `toml:"cleanup_on_close"`
 }
 
 func (c *Config) FillupWithDefaults() error {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -127,7 +127,7 @@ func WithPrefetchDaemon() NewDaemonOpt {
 
 func WithAPISock(apiSock string) NewDaemonOpt {
 	return func(d *Daemon) error {
-		d.apiSock = &apiSock
+		d.APISock = &apiSock
 		return nil
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -40,7 +40,7 @@ type Daemon struct {
 	Pid              int
 	ImageID          string
 	DaemonMode       string
-	apiSock          *string
+	APISock          *string
 	RootMountPoint   *string
 	CustomMountPoint *string
 	nydusdThreadNum  int
@@ -87,9 +87,9 @@ func (d *Daemon) NydusdThreadNum() string {
 	return ""
 }
 
-func (d *Daemon) APISock() string {
-	if d.apiSock != nil {
-		return *d.apiSock
+func (d *Daemon) GetAPISock() string {
+	if d.APISock != nil {
+		return *d.APISock
 	}
 	return filepath.Join(d.SocketDir, APISocketFileName)
 }
@@ -161,7 +161,7 @@ func (d *Daemon) IsPrefetchDaemon() bool {
 }
 
 func (d *Daemon) initClient() error {
-	client, err := nydussdk.NewNydusClient(d.APISock())
+	client, err := nydussdk.NewNydusClient(d.GetAPISock())
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nydus client")
 	}

--- a/pkg/filesystem/nydus/fs.go
+++ b/pkg/filesystem/nydus/fs.go
@@ -379,7 +379,7 @@ func (fs *filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 		daemon.WithSnapshotID(snapshotID),
 		daemon.WithRootMountPoint(*sharedDaemon.RootMountPoint),
 		daemon.WithSnapshotDir(fs.SnapshotRoot()),
-		daemon.WithAPISock(sharedDaemon.APISock()),
+		daemon.WithAPISock(sharedDaemon.GetAPISock()),
 		daemon.WithConfigDir(fs.ConfigRoot()),
 		daemon.WithLogDir(fs.logDir),
 		daemon.WithImageID(imageID),

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -132,7 +132,7 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 
 func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 	args := []string{
-		"--apisock", d.APISock(),
+		"--apisock", d.GetAPISock(),
 		"--log-level", d.LogLevel,
 	}
 	nydusdThreadNum := d.NydusdThreadNum()


### PR DESCRIPTION
1.  When writing daemon status to nydus.db, json serialization will only
    recognize member variables starting with uppercase letters, and
    lowercase ones will be ignored. We change these previously ignored ones
    to uppercase.

2. Previously, the Close() interface of nydus snapshotter performed Cleanup()
    on the filesystem. This behavior is not universal. In fact, on the
    contrary, in most cases, the default behavior of Close() should not affect
    the existing filesystem so that the filesystem can still work normally
    after Reconnect(). While in some special scenarios, the filesystem needs to
    be cleaned up with the close of the snapshotter.
    
    So we add introduce a new config option called 'cleanup_on_close' to
    control whether to clean up the filesystem under the nydus snapshotter when
    the snapshotter is closed, and clean up the nydusd daemon and snapshot at
    the same time.

3. Help to know what StatusCode is returned from nydusd.