### PR TITLE
converter: fix incomplete unpack

### DIFF
--- a/pkg/converter/utils.go
+++ b/pkg/converter/utils.go
@@ -26,13 +26,16 @@ func (c *writeCloser) Close() error {
 	if c.closed {
 		return nil
 	}
-	if err := c.action(); err != nil {
-		return err
-	}
+
 	if err := c.WriteCloser.Close(); err != nil {
 		return err
 	}
 	c.closed = true
+
+	if err := c.action(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The current `Convert` implementation has the following interface:

```
Convert(ctx context.Context, dest io.Writer, opt ConvertOption) (src io.WriteCloser, err error)
```

The caller writes the OCI tar stream to src and Convert converts
src to a nydus tar stream and writes it to dest.

The current implementation must wait for the OCI tar stream to be
unpacked into a directory before calling the builder (nydus-image)
to start the build, which takes advantage of `pr, pw := io.Pipe()`.

Before this commit, the `unpackOciTar` method did not fully read
the OCI tarball when `pw.Close()` was called, which means that the
build is started before the unpacking is complete, which may result
in some files being missing from the nydus image.

Fixup: use a channel to wait for the unpack to complete.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>