### PR TITLE
converter: improve pack performance by fifo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NYDUS_VERSION: v2.0.0-rc.2
+  NYDUS_VERSION: v2.0.0-rc.5
 
 jobs:
   build:
@@ -57,8 +57,8 @@ jobs:
       - name: Build
         run: |
           # Download nydus components
-          wget https://github.com/dragonflyoss/image-service/releases/download/${{ env.NYDUS_VERSION }}/nydus-static-${{ env.NYDUS_VERSION }}-x86_64.tgz
-          tar xzvf nydus-static-${{ env.NYDUS_VERSION }}-x86_64.tgz
+          wget https://github.com/dragonflyoss/image-service/releases/download/${{ env.NYDUS_VERSION }}/nydus-static-${{ env.NYDUS_VERSION }}-linux-amd64.tgz
+          tar xzvf nydus-static-${{ env.NYDUS_VERSION }}-linux-amd64.tgz
           mkdir -p /usr/bin
           sudo mv nydus-static/nydus-image nydus-static/nydusd-fusedev nydus-static/nydusify /usr/bin/
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -70,8 +70,8 @@ jobs:
           tar xzf crictl-${{ env.CRICTL_VERSION }}-linux-amd64.tar.gz -C /usr/local/bin/
           # install nydus-overlayfs
           NYDUS_VER=v$(curl -s "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | jq -r .tag_name | sed 's/^v//')
-          wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-x86_64.tgz
-          tar xzf nydus-static-$NYDUS_VER-x86_64.tgz
+          wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz
+          tar xzf nydus-static-$NYDUS_VER-linux-amd64.tgz
           sudo cp nydus-static/nydus-overlayfs /usr/local/sbin/
           # install containerd
           #CONTAINERD_VER=$(curl -s "https://api.github.com/repos/containerd/containerd/releases/latest" | jq -r .tag_name | sed 's/^v//')

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
+	github.com/containerd/fifo v1.0.0 // indirect
 	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,7 @@ github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=
 github.com/containerd/fifo v0.0.0-20201026212402-0724c46b320c/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=
 github.com/containerd/fifo v0.0.0-20210316144830-115abcc95a1d/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
+github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZHtSlv++smU=
 github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb1aZGrrohk=

--- a/misc/example/README.md
+++ b/misc/example/README.md
@@ -27,8 +27,8 @@ wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERS
 tar xzf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin/
 # install nydus-overlayfs
 NYDUS_VER=v$(curl -s "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | jq -r .tag_name | sed 's/^v//')
-wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-x86_64.tgz
-tar xzf nydus-static-$NYDUS_VER-x86_64.tgz
+wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz
+tar xzf nydus-static-$NYDUS_VER-linux-amd64.tgz
 sudo cp nydus-static/nydus-overlayfs /usr/local/sbin/
 ```
 

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:20.04 AS sourcer
 
 RUN apt update; apt install --no-install-recommends -y curl wget ca-certificates
 RUN export NYDUS_VERSION=$(curl --silent "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'); \
-    wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-x86_64.tgz; \
-    tar xzf nydus-static-$NYDUS_VERSION-x86_64.tgz
+    wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-linux-amd64.tgz; \
+    tar xzf nydus-static-$NYDUS_VERSION-linux-amd64.tgz
 RUN mv nydus-static/* /; mv nydusd-fusedev nydusd
 
 FROM ubuntu:20.04

--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -47,8 +47,6 @@ func Convert(option ConvertOption) error {
 		"warn",
 		"--prefetch-policy",
 		"fs",
-		"--bootstrap",
-		option.BootstrapPath,
 		"--blob",
 		option.BlobPath,
 		"--source-type",
@@ -57,9 +55,7 @@ func Convert(option ConvertOption) error {
 		"none",
 		"--fs-version",
 		option.RafsVersion,
-		"--blob-offset",
-		// Add blob offset for chunk info with size_of(tar_header) * 2.
-		"1024",
+		"--inline-bootstrap",
 	}
 	if option.RafsVersion == "6" {
 		// FIXME: these options should be handled automatically in builder (nydus-image).


### PR DESCRIPTION
In the previous convert implementation, the builder (nydus-image) would
dump the blob and bootstrap, and then the converter would pack the two
files into a tar format, which has a performance loss, this patch solves this
problem by introducing fifo file.

The converter creates a fifo file, the builder will write the blob and
bootstrap data to the fifo as the writer side, then the converter read
from the fifo and write directly to content store for faster conversion.

Related PR: https://github.com/dragonflyoss/image-service/pull/415

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>