### PR TITLE
Implement blob layer download in snapshotter

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -101,13 +101,19 @@ jobs:
           echo "delete pod"
           sudo crictl rmp -fa
       - name: Cleanup containerd and snapshotter
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
           echo "stop snapshotter"
           docker stop snapshotter
           docker rm snapshotter
           echo "stop containerd"
-          sudo pkill containerd
+          sudo pkill -f /usr/local/bin/containerd
           echo "delete containerd dir"
-          sudo rm -rf /var/lib/containerd
+          # After the snapshotter container is stopped, it seems that Nydud doesn't umount it
+          # so we need to umount it here, otherwise you cannot delete this directory. 
+          # Frankly, I don't know why Nydud didn't clean up these resources.
+          sudo umount -f /var/lib/containerd-test/io.containerd.snapshotter.v1.nydus/mnt
+          sudo rm -rf /var/lib/containerd-test/*
       - name: Test nydus-snapshotter image in localfs mode
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -85,7 +85,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           # start nydus-snapshotter
-          docker run -d --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CONTAINERD_ROOT=/var/lib/containerd-test -v /var/lib/containerd-test:/var/lib/containerd-test:shared -v ~/.docker/config.json:/root/.docker/config.json:shared ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:local
+          docker run -d --name snapshotter --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CONTAINERD_ROOT=/var/lib/containerd-test -v /var/lib/containerd-test:/var/lib/containerd-test:shared -v ~/.docker/config.json:/root/.docker/config.json:shared ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:local
           # start containerd
           sudo /usr/local/bin/containerd --config /etc/containerd/containerd-test-config.toml -l debug &
           # wait for containerd to start up
@@ -100,11 +100,19 @@ jobs:
           sudo crictl exec $container ls
           echo "delete pod"
           sudo crictl rmp -fa
+      - name: Cleanup containerd and snapshotter
+          echo "stop snapshotter"
+          docker stop snapshotter
+          docker rm snapshotter
+          echo "stop containerd"
+          sudo pkill containerd
+          echo "delete containerd dir"
+          sudo rm -rf /var/lib/containerd
       - name: Test nydus-snapshotter image in localfs mode
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           # start nydus-snapshotter
-          docker run -d --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e BACKEND_TYPE=localfs -e CONTAINERD_ROOT=/var/lib/containerd-test -v /var/lib/containerd-test:/var/lib/containerd-test:shared -v ~/.docker/config.json:/root/.docker/config.json:shared ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:local
+          docker run -d --name snapshotter --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e BACKEND_TYPE=localfs -e CONTAINERD_ROOT=/var/lib/containerd-test -v /var/lib/containerd-test:/var/lib/containerd-test:shared -v ~/.docker/config.json:/root/.docker/config.json:shared ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:local
           # start containerd
           sudo /usr/local/bin/containerd --config /etc/containerd/containerd-test-config.toml -l debug &
           # wait for containerd to start up

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -100,4 +100,22 @@ jobs:
           sudo crictl exec $container ls
           echo "delete pod"
           sudo crictl rmp -fa
-
+      - name: Test nydus-snapshotter image in localfs mode
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          # start nydus-snapshotter
+          docker run -d --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e BACKEND_TYPE=localfs -e CONTAINERD_ROOT=/var/lib/containerd-test -v /var/lib/containerd-test:/var/lib/containerd-test:shared -v ~/.docker/config.json:/root/.docker/config.json:shared ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:local
+          # start containerd
+          sudo /usr/local/bin/containerd --config /etc/containerd/containerd-test-config.toml -l debug &
+          # wait for containerd to start up
+          sleep 10
+          echo "Pull nydus-latest image"
+          sudo crictl pull ghcr.io/dragonflyoss/image-service/ubuntu:nydus-latest
+          docker logs `docker ps |grep  "nydus-snapshotter"|cut -d ' ' -f1`
+          echo "create new pod with nydus snapshotter"
+          sudo crictl run misc/example/container.yaml misc/example/pod.yaml
+          container=$(sudo crictl ps -q)
+          echo "check container liveness"
+          sudo crictl exec $container ls
+          echo "delete pod"
+          sudo crictl rmp -fa

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 bin/
 pkg/filesystem/stargz/testdata/db/
 coverage.txt
-
 .vscode/

--- a/cmd/containerd-nydus-grpc/app/snapshotter/main.go
+++ b/cmd/containerd-nydus-grpc/app/snapshotter/main.go
@@ -17,6 +17,8 @@ import (
 )
 
 func Start(ctx context.Context, cfg config.Config) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	rs, err := snapshot.NewSnapshotter(ctx, &cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize snapshotter")

--- a/cmd/containerd-nydus-grpc/app/snapshotter/serve.go
+++ b/cmd/containerd-nydus-grpc/app/snapshotter/serve.go
@@ -29,7 +29,6 @@ func Serve(ctx context.Context, rs snapshots.Snapshotter, options ServeOptions, 
 	if err != nil {
 		return err
 	}
-
 	rpc := grpc.NewServer()
 	snapshotsapi.RegisterSnapshotsServer(rpc, snapshotservice.FromSnapshotter(rs))
 	l, err := net.Listen("unix", options.ListeningSocketPath)

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir -p /usr/local/bin/ /etc/nydus/ /var/lib/nydus/cache/
 COPY --from=sourcer /nydusd /nydus-image /usr/local/bin/
 COPY containerd-nydus-grpc /usr/local/bin/
 COPY nydusd-config.json /etc/nydus/config.json
+COPY nydusd-config-localfs.json /etc/nydus/localfs.json
 RUN apt update && \
     apt install --no-install-recommends -y ca-certificates && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -3,12 +3,15 @@
 CONTAINERD_ROOT="${CONTAINERD_ROOT:-/var/lib/containerd/}"
 
 set -eu
-
+MODE="config"
 if [ "$#" -eq 0 ]; then
+	if [ ! -z ${BACKEND_TYPE} == "localfs" ];then 
+		MODE=${BACKEND_TYPE}
+	fi
 	containerd-nydus-grpc \
 	    --log-level trace \
 	    --nydusd-path /usr/local/bin/nydusd \
-	    --config-path /etc/nydus/config.json \
+	    --config-path /etc/nydus/${MODE}.json \
 	    --root ${CONTAINERD_ROOT}/io.containerd.snapshotter.v1.nydus \
 	    --address ${CONTAINERD_ROOT}/io.containerd.snapshotter.v1.nydus/containerd-nydus-grpc.sock \
 	    --enable-nydus-overlayfs \

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -3,15 +3,12 @@
 CONTAINERD_ROOT="${CONTAINERD_ROOT:-/var/lib/containerd/}"
 
 set -eu
-MODE="config"
+BACKEND_TYPE="${BACKEND_TYPE:-config}"
 if [ "$#" -eq 0 ]; then
-	if [ ! -z ${BACKEND_TYPE} ];then 
-		MODE=${BACKEND_TYPE}
-	fi
 	containerd-nydus-grpc \
 	    --log-level trace \
 	    --nydusd-path /usr/local/bin/nydusd \
-	    --config-path /etc/nydus/${MODE}.json \
+	    --config-path /etc/nydus/${BACKEND_TYPE}.json \
 	    --root ${CONTAINERD_ROOT}/io.containerd.snapshotter.v1.nydus \
 	    --address ${CONTAINERD_ROOT}/io.containerd.snapshotter.v1.nydus/containerd-nydus-grpc.sock \
 	    --enable-nydus-overlayfs \

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -5,7 +5,7 @@ CONTAINERD_ROOT="${CONTAINERD_ROOT:-/var/lib/containerd/}"
 set -eu
 MODE="config"
 if [ "$#" -eq 0 ]; then
-	if [ ! -z ${BACKEND_TYPE} == "localfs" ];then 
+	if [ ! -z ${BACKEND_TYPE} ];then 
 		MODE=${BACKEND_TYPE}
 	fi
 	containerd-nydus-grpc \

--- a/misc/snapshotter/nydusd-config-localfs.json
+++ b/misc/snapshotter/nydusd-config-localfs.json
@@ -3,7 +3,7 @@
       "backend": {
         "type": "localfs",
         "config": {
-            "Dir": "/tmp/"
+            "dir": "/tmp/"
         }
       },
       "cache": {

--- a/misc/snapshotter/nydusd-config-localfs.json
+++ b/misc/snapshotter/nydusd-config-localfs.json
@@ -1,0 +1,25 @@
+{
+    "device": {
+      "backend": {
+        "type": "localfs",
+        "config": {
+            "Dir": "/tmp/"
+        }
+      },
+      "cache": {
+        "type": "blobcache",
+        "config": {
+          "work_dir": "/var/lib/nydus/cache"
+        }
+      }
+    },
+    "mode": "direct",
+    "digest_validate": false,
+    "iostats_files": false,
+    "enable_xattr": true,
+    "fs_prefetch": {
+      "enable": true,
+      "threads_count": 2
+    }
+  }
+  

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -29,7 +29,9 @@ type FileSystem interface {
 	Cleanup(ctx context.Context) error
 	Support(ctx context.Context, labels map[string]string) bool
 	PrepareMetaLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error
+	PrepareBlobLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error
 	MountPoint(snapshotID string) (string, error)
 	BootstrapFile(snapshotID string) (string, error)
 	NewDaemonConfig(labels map[string]string) (config.DaemonConfig, error)
+	CleanupBlobLayer(ctx context.Context, key string, async bool) error
 }

--- a/pkg/filesystem/nydus/blob_manager.go
+++ b/pkg/filesystem/nydus/blob_manager.go
@@ -46,14 +46,14 @@ func (b *BlobManager) GetBlobDir() string {
 }
 
 func (b *BlobManager) cleanupBlob(id string) error {
-	id, err := b.decodeId(id)
+	id, err := b.decodeID(id)
 	if err != nil {
 		return err
 	}
 	return os.Remove(filepath.Join(b.blobDir, id))
 }
 
-func (b *BlobManager) decodeId(id string) (string, error) {
+func (b *BlobManager) decodeID(id string) (string, error) {
 	digest, err := digest.Parse(id)
 	if err != nil {
 		return "", errors.Wrapf(err, "invalid blob layer digest %s", id)

--- a/pkg/filesystem/nydus/blob_manager.go
+++ b/pkg/filesystem/nydus/blob_manager.go
@@ -46,10 +46,6 @@ func (b *BlobManager) GetBlobDir() string {
 }
 
 func (b *BlobManager) cleanupBlob(id string) error {
-	id, err := b.decodeID(id)
-	if err != nil {
-		return err
-	}
 	return os.Remove(filepath.Join(b.blobDir, id))
 }
 
@@ -62,6 +58,10 @@ func (b *BlobManager) decodeID(id string) (string, error) {
 }
 
 func (b *BlobManager) Remove(id string, async bool) error {
+	id, err := b.decodeID(id)
+	if err != nil {
+		return err
+	}
 	if async {
 		b.eventChan <- id
 		return nil

--- a/pkg/filesystem/nydus/blob_manager.go
+++ b/pkg/filesystem/nydus/blob_manager.go
@@ -1,0 +1,70 @@
+package nydus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/log"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+type BlobManager struct {
+	blobDir   string
+	eventChan chan string
+}
+
+func NewBlobManager(blobDir string) *BlobManager {
+	return &BlobManager{
+		blobDir: blobDir,
+		// TODO(tianqian.zyf): Remove hardcode chan buffer
+		eventChan: make(chan string, 8),
+	}
+}
+
+func (b *BlobManager) Run(ctx context.Context) error {
+	log.G(ctx).Info("blob manager goroutine start...")
+	for {
+		select {
+		case id := <-b.eventChan:
+			err := b.cleanupBlob(id)
+			if err != nil {
+				log.G(ctx).Warnf("delete blob %s failed", id)
+			} else {
+				log.G(ctx).Infof("delete blob %s success", id)
+			}
+		case <-ctx.Done():
+			log.G(ctx).Infof("exit from BlobManger")
+			return ctx.Err()
+		}
+	}
+}
+
+func (b *BlobManager) GetBlobDir() string {
+	return b.blobDir
+}
+
+func (b *BlobManager) cleanupBlob(id string) error {
+	id, err := b.decodeId(id)
+	if err != nil {
+		return err
+	}
+	return os.Remove(filepath.Join(b.blobDir, id))
+}
+
+func (b *BlobManager) decodeId(id string) (string, error) {
+	digest, err := digest.Parse(id)
+	if err != nil {
+		return "", errors.Wrapf(err, "invalid blob layer digest %s", id)
+	}
+	return digest.Encoded(), nil
+}
+
+func (b *BlobManager) Remove(id string, async bool) error {
+	if async {
+		b.eventChan <- id
+		return nil
+	}
+	return b.cleanupBlob(id)
+}

--- a/pkg/filesystem/nydus/blob_manager_test.go
+++ b/pkg/filesystem/nydus/blob_manager_test.go
@@ -35,30 +35,30 @@ func Test_Remove(t *testing.T) {
 	}
 }
 
-func Test_decodeId(t *testing.T) {
+func Test_decodeID(t *testing.T) {
 	blobMgr := NewBlobManager("dir")
 	tests := []struct {
 		name     string
 		id       string
-		decodeId string
+		decodeID string
 		hasError bool
 	}{
 		{
 			name:     "ok",
 			id:       "sha256:038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146",
-			decodeId: "038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146",
+			decodeID: "038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146",
 			hasError: false,
 		},
 		{
 			name:     "not ok",
 			id:       "038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146",
-			decodeId: "",
+			decodeID: "",
 			hasError: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			realId, err := blobMgr.decodeId(tt.id)
+			realID, err := blobMgr.decodeID(tt.id)
 			if tt.hasError {
 				if err == nil {
 					t.Fatal("expect has error, but actual is nil")
@@ -67,7 +67,7 @@ func Test_decodeId(t *testing.T) {
 				if err != nil {
 					t.Fatalf("expect doesn't have error, but actual is %s", err)
 				}
-				if realId != tt.decodeId {
+				if realID != tt.decodeID {
 					t.Fatalf("expect doesn't have error, but actual is %s", err)
 				}
 			}

--- a/pkg/filesystem/nydus/blob_manager_test.go
+++ b/pkg/filesystem/nydus/blob_manager_test.go
@@ -1,0 +1,76 @@
+package nydus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func Test_Remove(t *testing.T) {
+	dir, err := os.MkdirTemp(os.TempDir(), "blb")
+	if err != nil {
+		t.Fatalf("failed to make dir %s", dir)
+	}
+	defer os.RemoveAll(dir)
+	id := "038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146"
+	file, err := os.Create(filepath.Join(dir, id))
+	if err != nil {
+		t.Fatalf("failed to create dir %s", dir)
+	}
+	file.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	blobMgr := NewBlobManager(dir)
+	go func() {
+		blobMgr.Run(ctx)
+	}()
+	blobMgr.Remove(id, true)
+	// wait to deleted the file
+	time.Sleep(time.Millisecond * 100)
+	_, err = os.Stat(filepath.Join(dir, "sha256:"+id))
+	if err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expect the blob file not exits, but actual exists")
+	}
+}
+
+func Test_decodeId(t *testing.T) {
+	blobMgr := NewBlobManager("dir")
+	tests := []struct {
+		name     string
+		id       string
+		decodeId string
+		hasError bool
+	}{
+		{
+			name:     "ok",
+			id:       "sha256:038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146",
+			decodeId: "038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146",
+			hasError: false,
+		},
+		{
+			name:     "not ok",
+			id:       "038f2b2815ae3c309b77bf34bf6ce988c922b7718773b4c98d5cd2b76c35a146",
+			decodeId: "",
+			hasError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			realId, err := blobMgr.decodeId(tt.id)
+			if tt.hasError {
+				if err == nil {
+					t.Fatal("expect has error, but actual is nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expect doesn't have error, but actual is %s", err)
+				}
+				if realId != tt.decodeId {
+					t.Fatalf("expect doesn't have error, but actual is %s", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/filesystem/nydus/config.go
+++ b/pkg/filesystem/nydus/config.go
@@ -154,3 +154,13 @@ func WithNydusdThreadNum(nydusdThreadNum int) NewFSOpt {
 		return nil
 	}
 }
+
+func WithImageMode(cfg config.DaemonConfig) NewFSOpt {
+	return func(d *filesystem) error {
+		if cfg.Device.Backend.BackendType == "localfs" &&
+			len(cfg.Device.Backend.Config.Dir) != 0 {
+			d.imageMode = PreLoad
+		}
+		return nil
+	}
+}

--- a/pkg/filesystem/nydus/fs.go
+++ b/pkg/filesystem/nydus/fs.go
@@ -157,8 +157,7 @@ func (fs *filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Sna
 		log.G(ctx).Debugf("%s blob layer already exists", blobPath)
 		return nil
 	} else if !os.IsNotExist(err) {
-		log.G(ctx).Errorf("Unexpected error %v, we can't handle it", err)
-		return err
+		return errors.Wrap(err, "Unexpected error, we can't handle it")
 	}
 
 	readerCloser, err := fs.resolver.Resolve(ref, layerDigest, labels)

--- a/pkg/filesystem/nydus/fs.go
+++ b/pkg/filesystem/nydus/fs.go
@@ -92,12 +92,12 @@ type filesystem struct {
 	blobMgr          *BlobManager
 }
 
-func getBlobPath(cfg config.DeviceConfig, blobDigest string) (string, error) {
+func getBlobPath(dir string, blobDigest string) (string, error) {
 	digest, err := digest.Parse(blobDigest)
 	if err != nil {
 		return "", errors.Wrapf(err, "invalid layer digest %s", blobDigest)
 	}
-	return filepath.Join(cfg.Backend.Config.Dir, digest.Encoded()), nil
+	return filepath.Join(dir, digest.Encoded()), nil
 }
 
 // NewFileSystem initialize Filesystem instance
@@ -148,7 +148,7 @@ func (fs *filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Sna
 	if ref == "" || layerDigest == "" {
 		return fmt.Errorf("can not find ref and digest from label %+v", labels)
 	}
-	blobPath, err := getBlobPath(fs.daemonCfg.Device, layerDigest)
+	blobPath, err := getBlobPath(fs.blobMgr.GetBlobDir(), layerDigest)
 	if err != nil {
 		return errors.Wrap(err, "failed to get blob path")
 	}

--- a/pkg/filesystem/nydus/fs.go
+++ b/pkg/filesystem/nydus/fs.go
@@ -156,6 +156,9 @@ func (fs *filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Sna
 	if err == nil {
 		log.G(ctx).Debugf("%s blob layer already exists", blobPath)
 		return nil
+	} else if !os.IsNotExist(err) {
+		log.G(ctx).Errorf("Unexpected error %v, we can't handle it", err)
+		return err
 	}
 
 	readerCloser, err := fs.resolver.Resolve(ref, layerDigest, labels)

--- a/pkg/filesystem/stargz/fs.go
+++ b/pkg/filesystem/stargz/fs.go
@@ -57,6 +57,14 @@ func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (fs.FileSystem, error) 
 	return &fs, nil
 }
 
+func (fs *filesystem) CleanupBlobLayer(ctx context.Context, key string, async bool) error {
+	return nil
+}
+
+func (fs *filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error {
+	return nil
+}
+
 func (f *filesystem) PrepareMetaLayer(ctx context.Context, s storage.Snapshot, labels map[string]string) error {
 	start := time.Now()
 	defer func() {

--- a/pkg/filesystem/stargz/fs.go
+++ b/pkg/filesystem/stargz/fs.go
@@ -57,11 +57,11 @@ func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (fs.FileSystem, error) 
 	return &fs, nil
 }
 
-func (fs *filesystem) CleanupBlobLayer(ctx context.Context, key string, async bool) error {
+func (f *filesystem) CleanupBlobLayer(ctx context.Context, key string, async bool) error {
 	return nil
 }
 
-func (fs *filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error {
+func (f *filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error {
 	return nil
 }
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -1,8 +1,9 @@
 /*
+/*
  * Copyright (c) 2020. Ant Group. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
 
 package snapshot
 
@@ -120,6 +121,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		nydus.WithLogDir(cfg.LogDir),
 		nydus.WithLogToStdout(cfg.LogToStdout),
 		nydus.WithNydusdThreadNum(cfg.NydusdThreadNum),
+		nydus.WithImageMode(cfg.DaemonCfg),
 	}
 
 	if !cfg.DisableCacheManager {
@@ -313,6 +315,14 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 					return nil, err
 				}
 			}
+			_, isDataLater := base.Labels[label.NydusDataLayer]
+			if isDataLater {
+				err = o.fs.PrepareBlobLayer(ctx, s, base.Labels)
+				if err != nil {
+					logCtx.Errorf("failed to prepare nydus data layer of snapshot ID %s, err: %v", s.ID, err)
+					return nil, err
+				}
+			}
 			err := o.Commit(ctx, target, key, append(opts, snapshots.WithLabels(base.Labels))...)
 			if err == nil || errdefs.IsAlreadyExists(err) {
 				return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
@@ -438,9 +448,18 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		}
 	}()
 
+	_, snap, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to get snapshot")
+	}
+
 	_, _, err = storage.Remove(ctx, key)
 	if err != nil {
 		return errors.Wrap(err, "failed to remove")
+	}
+	var cleanupBlob bool
+	if _, ok := snap.Labels[label.NydusDataLayer]; ok {
+		cleanupBlob = true
 	}
 
 	if !o.asyncRemove {
@@ -460,11 +479,22 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 						log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
 					}
 				}
+				if cleanupBlob {
+					if err := o.fs.CleanupBlobLayer(ctx, key, false); err != nil {
+						log.G(ctx).WithError(err).WithField("id", key).Warn("failed to remove blob")
+					}
+				}
 			}
 		}()
-
+	} else {
+		defer func() {
+			if cleanupBlob {
+				if err := o.fs.CleanupBlobLayer(ctx, key, true); err != nil {
+					log.G(ctx).WithError(err).WithField("id", key).Warn("failed to remove blob")
+				}
+			}
+		}()
 	}
-
 	return t.Commit()
 }
 
@@ -796,7 +826,6 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 		// When it quits, there will be nothing inside
 		cleanup = append(cleanup, o.snapshotDir(d))
 	}
-
 	return cleanup, nil
 }
 


### PR DESCRIPTION
Ref: #48 

When the backend type in the daemon config is localfs, the snapshotter will automatically download the blob layer to the cache directory.

Signed-off-by: zyfjeff <tianqian.zyf@alibaba-inc.com>