### PR TITLE
add support for erofs with fscache

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -40,6 +40,7 @@ type Args struct {
 	NydusImageBinaryPath string
 	SharedDaemon         bool
 	DaemonMode           string
+	DaemonBackend        string
 	AsyncRemove          bool
 	EnableMetrics        bool
 	MetricsFile          string
@@ -140,6 +141,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Value:       config.DefaultDaemonMode,
 			Usage:       "daemon mode to use, could be \"multiple\", \"shared\" or \"none\"",
 			Destination: &args.DaemonMode,
+		},
+		&cli.StringFlag{
+			Name:        "daemon-backend",
+			Value:       config.DaemonBackendFusedev,
+			Usage:       "daemon fs backend, could be \"fusedev\", \"erofs\"",
+			Destination: &args.DaemonBackend,
 		},
 		&cli.BoolFlag{
 			Name:        "async-remove",
@@ -248,6 +255,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.EnableNydusOverlayFS = args.EnableNydusOverlayFS
 	cfg.NydusdThreadNum = args.NydusdThreadNum
 	cfg.CleanupOnClose = args.CleanupOnClose
+	cfg.DaemonBackend = args.DaemonBackend
 
 	d, err := time.ParseDuration(args.GCPeriod)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,11 @@ const (
 	nydusImageBinaryName         string = "nydus-image"
 )
 
+const (
+	DaemonBackendFusedev string = "fusedev"
+	DaemonBackendErofs   string = "erofs"
+)
+
 type Config struct {
 	Address              string        `toml:"-"`
 	ConvertVpcRegistry   bool          `toml:"-"`
@@ -41,6 +46,7 @@ type Config struct {
 	NydusdBinaryPath     string        `toml:"nydusd_binary_path"`
 	NydusImageBinaryPath string        `toml:"nydus_image_binary"`
 	DaemonMode           string        `toml:"daemon_mode"`
+	DaemonBackend        string        `toml:"daemon_backend"`
 	AsyncRemove          bool          `toml:"async_remove"`
 	EnableMetrics        bool          `toml:"enable_metrics"`
 	MetricsFile          string        `toml:"metrics_file"`

--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -23,6 +23,14 @@ const (
 	backendTypeRegistry = "registry"
 )
 
+type FSPrefetch struct {
+	Enable        bool `json:"enable"`
+	PrefetchAll   bool `json:"prefetch_all"`
+	ThreadsCount  int  `json:"threads_count"`
+	MergingSize   int  `json:"merging_size"`
+	BandwidthRate int  `json:"bandwidth_rate"`
+}
+
 type ErofsDaemonConfig struct {
 	// These fields is only for erofs daemon.
 	Type     string `json:"type"`
@@ -38,6 +46,7 @@ type ErofsDaemonConfig struct {
 		} `json:"cache_config"`
 		MetadataPath string `json:"metadata_path"`
 	} `json:"config"`
+	FSPrefetch `json:"fs_prefetch,omitempty"`
 }
 
 type DaemonConfig struct {
@@ -46,13 +55,8 @@ type DaemonConfig struct {
 	DigestValidate bool         `json:"digest_validate"`
 	IOStatsFiles   bool         `json:"iostats_files,omitempty"`
 	EnableXattr    bool         `json:"enable_xattr,omitempty"`
-	FSPrefetch     struct {
-		Enable       bool `json:"enable"`
-		PrefetchAll  bool `json:"prefetch_all"`
-		ThreadsCount int  `json:"threads_count"`
-		MergingSize  int  `json:"merging_size"`
-	} `json:"fs_prefetch,omitempty"`
 
+	FSPrefetch `json:"fs_prefetch,omitempty"`
 	ErofsDaemonConfig
 }
 

--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/containerd/nydus-snapshotter/pkg/utils/erofs"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/registry"
 )
 
@@ -21,6 +22,23 @@ const (
 	backendTypeOss      = "oss"
 	backendTypeRegistry = "registry"
 )
+
+type ErofsDaemonConfig struct {
+	// These fields is only for erofs daemon.
+	Type     string `json:"type"`
+	ID       string `json:"id"`
+	DomainID string `json:"domain_id"`
+	Config   struct {
+		ID            string        `json:"id"`
+		BackendType   string        `json:"backend_type"`
+		BackendConfig BackendConfig `json:"backend_config"`
+		CacheType     string        `json:"cache_type"`
+		CacheConfig   struct {
+			WorkDir string `json:"workdir"`
+		} `json:"cache_config"`
+		MetadataPath string `json:"metadata_path"`
+	} `json:"config"`
+}
 
 type DaemonConfig struct {
 	Device         DeviceConfig `json:"device"`
@@ -34,47 +52,51 @@ type DaemonConfig struct {
 		ThreadsCount int  `json:"threads_count"`
 		MergingSize  int  `json:"merging_size"`
 	} `json:"fs_prefetch,omitempty"`
+
+	ErofsDaemonConfig
+}
+
+type BackendConfig struct {
+	// Localfs backend configs
+	BlobFile     string `json:"blob_file,omitempty"`
+	Dir          string `json:"dir,omitempty"`
+	ReadAhead    bool   `json:"readahead"`
+	ReadAheadSec int    `json:"readahead_sec,omitempty"`
+
+	// Registry backend configs
+	Host               string `json:"host,omitempty"`
+	Repo               string `json:"repo,omitempty"`
+	Auth               string `json:"auth,omitempty"`
+	RegistryToken      string `json:"registry_token,omitempty"`
+	BlobURLScheme      string `json:"blob_url_scheme,omitempty"`
+	BlobRedirectedHost string `json:"blob_redirected_host,omitempty"`
+
+	// OSS backend configs
+	EndPoint        string `json:"endpoint,omitempty"`
+	AccessKeyID     string `json:"access_key_id,omitempty"`
+	AccessKeySecret string `json:"access_key_secret,omitempty"`
+	BucketName      string `json:"bucket_name,omitempty"`
+	ObjectPrefix    string `json:"object_prefix,omitempty"`
+
+	// Shared by registry and oss backend
+	Scheme string `json:"scheme,omitempty"`
+
+	// Below configs are common configs shared by all backends
+	Proxy struct {
+		URL           string `json:"url,omitempty"`
+		Fallback      bool   `json:"fallback"`
+		PingURL       string `json:"ping_url,omitempty"`
+		CheckInterval int    `json:"check_interval,omitempty"`
+	} `json:"proxy,omitempty"`
+	Timeout        int `json:"timeout,omitempty"`
+	ConnectTimeout int `json:"connect_timeout,omitempty"`
+	RetryLimit     int `json:"retry_limit,omitempty"`
 }
 
 type DeviceConfig struct {
 	Backend struct {
-		BackendType string `json:"type"`
-		Config      struct {
-			// Localfs backend configs
-			BlobFile     string `json:"blob_file,omitempty"`
-			Dir          string `json:"dir,omitempty"`
-			ReadAhead    bool   `json:"readahead"`
-			ReadAheadSec int    `json:"readahead_sec,omitempty"`
-
-			// Registry backend configs
-			Host               string `json:"host,omitempty"`
-			Repo               string `json:"repo,omitempty"`
-			Auth               string `json:"auth,omitempty"`
-			RegistryToken      string `json:"registry_token,omitempty"`
-			BlobURLScheme      string `json:"blob_url_scheme,omitempty"`
-			BlobRedirectedHost string `json:"blob_redirected_host,omitempty"`
-
-			// OSS backend configs
-			EndPoint        string `json:"endpoint,omitempty"`
-			AccessKeyID     string `json:"access_key_id,omitempty"`
-			AccessKeySecret string `json:"access_key_secret,omitempty"`
-			BucketName      string `json:"bucket_name,omitempty"`
-			ObjectPrefix    string `json:"object_prefix,omitempty"`
-
-			// Shared by registry and oss backend
-			Scheme string `json:"scheme,omitempty"`
-
-			// Below configs are common configs shared by all backends
-			Proxy struct {
-				URL           string `json:"url,omitempty"`
-				Fallback      bool   `json:"fallback"`
-				PingURL       string `json:"ping_url,omitempty"`
-				CheckInterval int    `json:"check_interval,omitempty"`
-			} `json:"proxy,omitempty"`
-			Timeout        int `json:"timeout,omitempty"`
-			ConnectTimeout int `json:"connect_timeout,omitempty"`
-			RetryLimit     int `json:"retry_limit,omitempty"`
-		} `json:"config"`
+		BackendType string        `json:"type"`
+		Config      BackendConfig `json:"config"`
 	} `json:"backend"`
 	Cache struct {
 		CacheType  string `json:"type"`
@@ -97,7 +119,7 @@ func LoadConfig(configFile string, cfg *DaemonConfig) error {
 	return nil
 }
 
-func SaveConfig(c DaemonConfig, configFile string) error {
+func SaveConfig(c interface{}, configFile string) error {
 	b, err := json.Marshal(c)
 	if err != nil {
 		return nil
@@ -105,13 +127,18 @@ func SaveConfig(c DaemonConfig, configFile string) error {
 	return ioutil.WriteFile(configFile, b, 0755)
 }
 
-func NewDaemonConfig(cfg DaemonConfig, imageID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
+func NewDaemonConfig(daemonBackend string, cfg DaemonConfig, imageID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
 	image, err := registry.ParseImage(imageID)
 	if err != nil {
 		return DaemonConfig{}, errors.Wrapf(err, "failed to parse image %s", imageID)
 	}
 
-	switch backend := cfg.Device.Backend.BackendType; backend {
+	backend := cfg.Device.Backend.BackendType
+	if daemonBackend == DaemonBackendErofs {
+		backend = cfg.Config.BackendType
+	}
+
+	switch backend {
 	case backendTypeRegistry:
 		registryHost := image.Host
 		if vpcRegistry {
@@ -124,15 +151,23 @@ func NewDaemonConfig(cfg DaemonConfig, imageID string, vpcRegistry bool, labels 
 		// If no auth is provided, don't touch auth from provided nydusd configuration file.
 		// We don't validate the original nydusd auth from configuration file since it can be empty
 		// when repository is public.
+		backendConfig := &cfg.Device.Backend.Config
+		if daemonBackend == DaemonBackendErofs {
+			backendConfig = &cfg.Config.BackendConfig
+			fscacheID := erofs.FscacheID(imageID)
+			cfg.ID = fscacheID
+			cfg.DomainID = fscacheID
+			cfg.Config.ID = fscacheID
+		}
 		if keyChain != nil {
 			if keyChain.TokenBase() {
-				cfg.Device.Backend.Config.RegistryToken = keyChain.Password
+				backendConfig.RegistryToken = keyChain.Password
 			} else {
-				cfg.Device.Backend.Config.Auth = keyChain.ToBase64()
+				backendConfig.Auth = keyChain.ToBase64()
 			}
 		}
-		cfg.Device.Backend.Config.Host = registryHost
-		cfg.Device.Backend.Config.Repo = image.Repo
+		backendConfig.Host = registryHost
+		backendConfig.Repo = image.Repo
 	// Localfs and OSS backends don't need any update, just use the provided config in template
 	case backendTypeLocalfs:
 	case backendTypeOss:

--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"os"
 	"time"
 
 	"github.com/containerd/containerd/log"
@@ -23,6 +24,11 @@ type Opt struct {
 }
 
 func NewManager(opt Opt) (*Manager, error) {
+	// Ensure cache directory exists
+	if err := os.MkdirAll(opt.CacheDir, 0755); err != nil {
+		return nil, errors.Wrapf(err, "failed to create cache dir %s", opt.CacheDir)
+	}
+
 	db, err := store.NewCacheStore(opt.Database)
 	if err != nil {
 		return nil, err

--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -5,22 +5,25 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/pkg/store"
 	"github.com/pkg/errors"
 )
 
 type Manager struct {
-	db       DB
-	store    *Store
-	cacheDir string
-	period   time.Duration
-	eventCh  chan struct{}
+	db            DB
+	store         *Store
+	cacheDir      string
+	period        time.Duration
+	eventCh       chan struct{}
+	daemonBackend string
 }
 
 type Opt struct {
-	CacheDir string
-	Period   time.Duration
-	Database *store.Database
+	CacheDir      string
+	Period        time.Duration
+	Database      *store.Database
+	DaemonBackend string
 }
 
 func NewManager(opt Opt) (*Manager, error) {
@@ -37,14 +40,24 @@ func NewManager(opt Opt) (*Manager, error) {
 
 	eventCh := make(chan struct{})
 	m := &Manager{
-		db:       db,
-		store:    s,
-		cacheDir: opt.CacheDir,
-		period:   opt.Period,
-		eventCh:  eventCh,
+		db:            db,
+		store:         s,
+		cacheDir:      opt.CacheDir,
+		period:        opt.Period,
+		eventCh:       eventCh,
+		daemonBackend: opt.DaemonBackend,
 	}
+
+	// For erofs backend, the cache is maintained by the kernel fscache module,
+	// so here we ignore gc for now, and in the future we need another design
+	// to remove the cache.
+	if opt.DaemonBackend == config.DaemonBackendErofs {
+		return m, nil
+	}
+
 	go m.runGC()
 	log.L.Info("gc goroutine start...")
+
 	return m, nil
 }
 
@@ -53,6 +66,9 @@ func (m *Manager) CacheDir() string {
 }
 
 func (m *Manager) SchedGC() {
+	if m.daemonBackend == config.DaemonBackendErofs {
+		return
+	}
 	m.eventCh <- struct{}{}
 }
 

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -138,3 +138,10 @@ func WithNydusdThreadNum(nydusdThreadNum int) NewDaemonOpt {
 		return nil
 	}
 }
+
+func WithDaemonBackend(daemonBackend string) NewDaemonOpt {
+	return func(d *Daemon) error {
+		d.DaemonBackend = daemonBackend
+		return nil
+	}
+}

--- a/pkg/filesystem/nydus/config.go
+++ b/pkg/filesystem/nydus/config.go
@@ -108,6 +108,18 @@ func WithDaemonMode(daemonMode string) NewFSOpt {
 	}
 }
 
+func WithDaemonBackend(daemonBackend string) NewFSOpt {
+	return func(d *filesystem) error {
+		switch daemonBackend {
+		case config.DaemonBackendErofs:
+			d.daemonBackend = config.DaemonBackendErofs
+		default:
+			d.daemonBackend = config.DaemonBackendFusedev
+		}
+		return nil
+	}
+}
+
 func WithLogLevel(logLevel string) NewFSOpt {
 	return func(d *filesystem) error {
 		if logLevel == "" {

--- a/pkg/filesystem/nydus/fs.go
+++ b/pkg/filesystem/nydus/fs.go
@@ -576,6 +576,7 @@ func (fs *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]s
 			return errors.Wrap(err, "get bootstrap path")
 		}
 		cfg.Config.MetadataPath = bootstrapPath
+		cfg.ErofsDaemonConfig.FSPrefetch = cfg.FSPrefetch
 		return config.SaveConfig(cfg.ErofsDaemonConfig, d.ConfigFile())
 	}
 

--- a/pkg/filesystem/nydus/fs.go
+++ b/pkg/filesystem/nydus/fs.go
@@ -73,6 +73,7 @@ type filesystem struct {
 	daemonCfg        config.DaemonConfig
 	resolver         *Resolver
 	vpcRegistry      bool
+	daemonBackend    string
 	nydusdBinaryPath string
 	mode             fspkg.Mode
 	logLevel         string
@@ -115,6 +116,7 @@ func (fs *filesystem) newSharedDaemon() (*daemon.Daemon, error) {
 		daemon.WithLogLevel(fs.logLevel),
 		daemon.WithLogToStdout(fs.logToStdout),
 		daemon.WithNydusdThreadNum(fs.nydusdThreadNum),
+		daemon.WithDaemonBackend(fs.daemonBackend),
 		modeOpt,
 	)
 	if err != nil {
@@ -384,7 +386,7 @@ func (fs *filesystem) NewDaemonConfig(labels map[string]string) (config.DaemonCo
 		return config.DaemonConfig{}, fmt.Errorf("no image ID found in label")
 	}
 
-	cfg, err := config.NewDaemonConfig(fs.daemonCfg, imageID, fs.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(fs.daemonBackend, fs.daemonCfg, imageID, fs.vpcRegistry, labels)
 	if err != nil {
 		return config.DaemonConfig{}, err
 	}
@@ -512,6 +514,7 @@ func (fs *filesystem) createNewDaemon(snapshotID string, imageID string) (*daemo
 		daemon.WithLogToStdout(fs.logToStdout),
 		daemon.WithCustomMountPoint(customMountPoint),
 		daemon.WithNydusdThreadNum(fs.nydusdThreadNum),
+		daemon.WithDaemonBackend(fs.daemonBackend),
 	); err != nil {
 		return nil, err
 	}
@@ -549,6 +552,7 @@ func (fs *filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 		daemon.WithLogLevel(fs.logLevel),
 		daemon.WithLogToStdout(fs.logToStdout),
 		daemon.WithNydusdThreadNum(fs.nydusdThreadNum),
+		daemon.WithDaemonBackend(fs.daemonBackend),
 	); err != nil {
 		return nil, err
 	}
@@ -560,9 +564,19 @@ func (fs *filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 
 // generateDaemonConfig generate Daemon configuration
 func (fs *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]string) error {
-	cfg, err := config.NewDaemonConfig(fs.daemonCfg, d.ImageID, fs.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(d.DaemonBackend, fs.daemonCfg, d.ImageID, fs.vpcRegistry, labels)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
+	}
+
+	if d.DaemonBackend == config.DaemonBackendErofs {
+		cfg.Config.CacheConfig.WorkDir = d.ErofsWorkDir()
+		bootstrapPath, err := d.BootstrapFile()
+		if err != nil {
+			return errors.Wrap(err, "get bootstrap path")
+		}
+		cfg.Config.MetadataPath = bootstrapPath
+		return config.SaveConfig(cfg.ErofsDaemonConfig, d.ConfigFile())
 	}
 
 	if fs.cacheMgr != nil {

--- a/pkg/filesystem/stargz/fs.go
+++ b/pkg/filesystem/stargz/fs.go
@@ -194,7 +194,7 @@ func (f *filesystem) mount(d *daemon.Daemon, labels map[string]string) error {
 }
 
 func (f *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]string) error {
-	cfg, err := config.NewDaemonConfig(f.daemonCfg, d.ImageID, f.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(d.DaemonBackend, f.daemonCfg, d.ImageID, f.vpcRegistry, labels)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
 	}

--- a/pkg/utils/erofs/erofs_linux.go
+++ b/pkg/utils/erofs/erofs_linux.go
@@ -1,0 +1,84 @@
+//go:build linux
+// +build linux
+
+package erofs
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+func getDevices(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open bootstrap")
+	}
+	defer f.Close()
+
+	devices := make([]string, 0)
+	_, err = f.Seek(1024, io.SeekStart)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to seek bootstrap")
+	}
+	byte4 := make([]byte, 4)
+	_, err = f.Read(byte4)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read super magic")
+	}
+	if binary.LittleEndian.Uint32(byte4) != 0xe0f5e1e2 {
+		return nil, errors.New("bad erofs magic")
+	}
+	_, err = f.Seek(1024+86, io.SeekStart)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to seek bootstrap")
+	}
+	_, err = f.Read(byte4)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read devt_slotoff")
+	}
+	nrDevices := binary.LittleEndian.Uint16(byte4[0:2])
+	pos := int64(binary.LittleEndian.Uint16(byte4[2:4])) * 128
+	for nrDevices > 0 {
+		tag := make([]byte, 64)
+		_, err = f.Seek(pos, io.SeekStart)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to seek bootstrap")
+		}
+		_, err = f.Read(tag)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read device tag")
+		}
+		devices = append(devices, string(tag))
+		nrDevices = nrDevices - 1
+		pos = pos + 128
+	}
+	return devices, nil
+}
+
+func Mount(bootstrapPath, fsID, mountPoint string) error {
+	devices, err := getDevices(bootstrapPath)
+	if err != nil {
+		return errors.Wrap(err, "get erofs devices from bootstrap")
+	}
+
+	mount := unix.Mount
+
+	opts := "fsid=" + fsID + ",device=" + strings.Join(devices, ",device=")
+	logrus.Infof("Mount erofs to %s with options %s", mountPoint, opts)
+	if err := mount("erofs", mountPoint, "erofs", 0, opts); err != nil {
+		return errors.Wrapf(err, "failed to mount erofs")
+	}
+
+	return nil
+}
+
+func FscacheID(imageID string) string {
+	return digest.FromString(imageID).Hex()[:4]
+}

--- a/pkg/utils/erofs/erofs_linux.go
+++ b/pkg/utils/erofs/erofs_linux.go
@@ -79,6 +79,10 @@ func Mount(bootstrapPath, fsID, mountPoint string) error {
 	return nil
 }
 
+func Umount(mountPoint string) error {
+	return unix.Unmount(mountPoint, 0)
+}
+
 func FscacheID(imageID string) string {
-	return digest.FromString(imageID).Hex()[:4]
+	return digest.FromString(imageID).Hex()
 }

--- a/pkg/utils/erofs/erofs_other.go
+++ b/pkg/utils/erofs/erofs_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+// +build !linux
+
+package erofs
+
+import "fmt"
+
+func Mount(bootstrapPath, fsID, mountPoint string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func FscacheID(imageID string) string {
+	panic("not implemented")
+}

--- a/pkg/utils/erofs/erofs_other.go
+++ b/pkg/utils/erofs/erofs_other.go
@@ -9,6 +9,10 @@ func Mount(bootstrapPath, fsID, mountPoint string) error {
 	return fmt.Errorf("not implemented")
 }
 
+func Umount(mountPoint string) error {
+	return fmt.Errorf("not implemented")
+}
+
 func FscacheID(imageID string) string {
 	panic("not implemented")
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -124,9 +124,10 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 
 	if !cfg.DisableCacheManager {
 		cacheMgr, err := cache.NewManager(cache.Opt{
-			Database: db,
-			Period:   cfg.GCPeriod,
-			CacheDir: cfg.CacheDir,
+			Database:      db,
+			Period:        cfg.GCPeriod,
+			CacheDir:      cfg.CacheDir,
+			DaemonBackend: cfg.DaemonBackend,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to new cache manager")

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -101,6 +101,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		NydusdBinaryPath: cfg.NydusdBinaryPath,
 		Database:         db,
 		DaemonMode:       cfg.DaemonMode,
+		CacheDir:         cfg.CacheDir,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to new process manager")
@@ -114,6 +115,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		nydus.WithVPCRegistry(cfg.ConvertVpcRegistry),
 		nydus.WithVerifier(verifier),
 		nydus.WithDaemonMode(cfg.DaemonMode),
+		nydus.WithDaemonBackend(cfg.DaemonBackend),
 		nydus.WithLogLevel(cfg.LogLevel),
 		nydus.WithLogDir(cfg.LogDir),
 		nydus.WithLogToStdout(cfg.LogToStdout),


### PR DESCRIPTION
Ref: https://github.com/dragonflyoss/image-service/blob/master/docs/nydus-fscache.md

Add boot option `--daemon-backend erofs` for snapshotter to support
erofs with fscache daemon (nydusd daemon subcommand).

This daemon backend must be used with shared daemon mode, so a general
command usage should like this:

```
containerd-nydus-grpc \
  --config-path //path/to/nydus-erofs-config.json \
  --daemon-mode shared \
  --daemon-backend erofs \
  --log-level info \
  --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
  --cache-dir /var/lib/nydus/cache \
  --address /run/containerd/containerd-nydus-grpc.sock \
  --nydusd-path /usr/bin/nydusd \
  --nydusimg-path /usr/bin/nydus-image \
  --log-to-stdout
```