### PR TITLE
config: support skip_verify backend option

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -62,7 +62,8 @@ type DeviceConfig struct {
 			ObjectPrefix    string `json:"object_prefix,omitempty"`
 
 			// Shared by registry and oss backend
-			Scheme string `json:"scheme,omitempty"`
+			Scheme     string `json:"scheme,omitempty"`
+			SkipVerify bool   `json:"skip_verify,omitempty"`
 
 			// Below configs are common configs shared by all backends
 			Proxy struct {

--- a/config/daemonconfig_test.go
+++ b/config/daemonconfig_test.go
@@ -20,6 +20,7 @@ func TestLoadConfig(t *testing.T) {
       "type": "registry",
       "config": {
         "scheme": "https",
+        "skip_verify": true,
         "host": "acr-nydus-registry-vpc.cn-hangzhou.cr.aliyuncs.com",
         "repo": "test/myserver",
         "auth": "",
@@ -59,5 +60,6 @@ func TestLoadConfig(t *testing.T) {
 	require.Equal(t, cfg.FSPrefetch.MergingSize, 131072)
 	require.Equal(t, cfg.FSPrefetch.ThreadsCount, 10)
 	require.Equal(t, cfg.Device.Backend.Config.BlobURLScheme, "http")
+	require.Equal(t, cfg.Device.Backend.Config.SkipVerify, true)
 	require.Equal(t, cfg.Device.Backend.Config.Proxy.CheckInterval, 5)
 }


### PR DESCRIPTION
Add `skip_verify: true` option to enable skipping SSL certificate
validation of HTTPS scheme for registry/oss backend.

Signed-off-by: Yan Song <yansong.ys@antfin.com>