### PR TITLE
daemon: ignore checks for nydus binary when DaemonMode=none

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,11 @@ func (c *Config) FillupWithDefaults() error {
 }
 
 func (c *Config) SetupNydusBinaryPaths() error {
+	// when using DaemonMode = none, nydusd and nydus-image binaries are not required
+	if c.DaemonMode == DaemonModeNone {
+		return nil
+	}
+
 	// resolve nydusd path
 	if c.NydusdBinaryPath == "" {
 		path, err := exec.LookPath(nydusdBinaryName)

--- a/pkg/filesystem/nydus/config.go
+++ b/pkg/filesystem/nydus/config.go
@@ -33,9 +33,9 @@ func WithMeta(root string) NewFSOpt {
 	}
 }
 
-func WithNydusdBinaryPath(p string) NewFSOpt {
+func WithNydusdBinaryPath(p string, daemonMode string) NewFSOpt {
 	return func(d *filesystem) error {
-		if p == "" {
+		if daemonMode != config.DaemonModeNone && p == "" {
 			return errors.New("nydusd binary path is required")
 		}
 		d.nydusdBinaryPath = p

--- a/pkg/filesystem/nydus/config_test.go
+++ b/pkg/filesystem/nydus/config_test.go
@@ -9,12 +9,13 @@ package nydus
 import (
 	"testing"
 
+	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWithNydusdBinaryPath(t *testing.T) {
 	var fs filesystem
-	opt := WithNydusdBinaryPath("/bin/nydusd")
+	opt := WithNydusdBinaryPath("/bin/nydusd", config.DaemonModeMultiple)
 	err := opt(&fs)
 	assert.Nil(t, err)
 	assert.Equal(t, "/bin/nydusd", fs.nydusdBinaryPath)

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -108,7 +108,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 
 	opts := []nydus.NewFSOpt{
 		nydus.WithProcessManager(pm),
-		nydus.WithNydusdBinaryPath(cfg.NydusdBinaryPath),
+		nydus.WithNydusdBinaryPath(cfg.NydusdBinaryPath, cfg.DaemonMode),
 		nydus.WithMeta(cfg.RootDir),
 		nydus.WithDaemonConfig(cfg.DaemonCfg),
 		nydus.WithVPCRegistry(cfg.ConvertVpcRegistry),


### PR DESCRIPTION
When using DaemonMode = none, nydusd and nydus-image binaries are not
required.

Signed-off-by: zhaoshang <zhaoshangsjtu@linux.alibaba.com>