### PR TITLE
Disable the logic for downloading bootstarp in snapshotter

### DIFF
--- a/pkg/filesystem/nydus/fs.go
+++ b/pkg/filesystem/nydus/fs.go
@@ -130,8 +130,7 @@ func (fs *filesystem) newSharedDaemon() (*daemon.Daemon, error) {
 
 func (fs *filesystem) Support(ctx context.Context, labels map[string]string) bool {
 	_, dataOk := labels[label.NydusDataLayer]
-	_, metaOk := labels[label.NydusMetaLayer]
-	return dataOk || metaOk
+	return dataOk
 }
 
 func isRafsV6(buf []byte) bool {


### PR DESCRIPTION
At present, snapshotter download bootstarp requires containerd to pass the auth information over,
this is not currently solved, so temporarily turn off this function.

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba.com>