### PR TITLE
log: fix logdir and output bug of snapshotter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 pkg/filesystem/stargz/testdata/db/
 coverage.txt
+
+.vscode/

--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -28,15 +28,16 @@ func main() {
 		Version: Version,
 		Flags:   flags.F,
 		Action: func(c *cli.Context) error {
-			ctx := logging.WithContext()
-			if err := logging.SetUp(flags.Args.LogLevel); err != nil {
-				return errors.Wrap(err, "failed to prepare logger")
-			}
-
 			var cfg config.Config
 			if err := command.Validate(flags.Args, &cfg); err != nil {
 				return errors.Wrap(err, "invalid argument")
 			}
+
+			ctx := logging.WithContext()
+			if err := logging.SetUp(flags.Args.LogLevel, flags.Args.LogToStdout, flags.Args.LogDir, flags.Args.RootDir); err != nil {
+				return errors.Wrap(err, "failed to prepare logger")
+			}
+
 			return snapshotter.Start(ctx, cfg)
 		},
 	}

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -103,7 +103,6 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "validate-signature",
-			Value:       false,
 			Usage:       "whether force validate image bootstrap",
 			Destination: &args.ValidateSignature,
 		},
@@ -127,13 +126,11 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "convert-vpc-registry",
-			Value:       false,
 			Usage:       "whether automatically convert the image to vpc registry to accelerate image pulling",
 			Destination: &args.ConvertVpcRegistry,
 		},
 		&cli.BoolFlag{
 			Name:        "shared-daemon",
-			Value:       false,
 			Usage:       "Deprecated, equivalent to \"--daemon-mode shared\"",
 			Destination: &args.SharedDaemon,
 		},
@@ -157,7 +154,6 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "enable-metrics",
-			Value:       false,
 			Usage:       "whether to collect metrics",
 			Destination: &args.EnableMetrics,
 		},
@@ -168,25 +164,21 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "enable-stargz",
-			Value:       false,
 			Usage:       "whether to support stargz image",
 			Destination: &args.EnableStargz,
 		},
 		&cli.BoolFlag{
 			Name:        "disable-cache-manager",
-			Value:       false,
 			Usage:       "whether to disable blob cache manager",
 			Destination: &args.DisableCacheManager,
 		},
 		&cli.BoolFlag{
 			Name:        "log-to-stdout",
-			Value:       false,
 			Usage:       "Print logs to standard out rather than files.",
 			Destination: &args.LogToStdout,
 		},
 		&cli.BoolFlag{
 			Name:        "enable-nydus-overlayfs",
-			Value:       false,
 			Usage:       "whether to enable nydus-overlayfs to mount",
 			Destination: &args.EnableNydusOverlayFS,
 		},

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -234,7 +235,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	// Always let options from CLI override those from configuration file.
 	cfg.LogToStdout = args.LogToStdout
 	if len(cfg.LogDir) == 0 {
-		cfg.LogDir = filepath.Join(cfg.RootDir, "logs")
+		cfg.LogDir = filepath.Join(cfg.RootDir, logging.DefaultLogDirName)
 	}
 	cfg.ValidateSignature = args.ValidateSignature
 	cfg.PublicKeyFile = args.PublicKeyFile

--- a/cmd/containerd-nydus-grpc/pkg/logging/setup.go
+++ b/cmd/containerd-nydus-grpc/pkg/logging/setup.go
@@ -8,17 +8,43 @@ package logging
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-func SetUp(logLevel string) error {
+const (
+	DefaultLogDirName  = "logs"
+	defaultLogFileName = "nydus-snapshotter.log"
+)
+
+func SetUp(logLevel string, logToStdout bool, logDir string, rootDir string) error {
 	lvl, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		return err
 	}
 	logrus.SetLevel(lvl)
+
+	if logToStdout {
+		logrus.SetOutput(os.Stdout)
+	} else {
+		if len(logDir) == 0 {
+			logDir = filepath.Join(rootDir, DefaultLogDirName)
+		}
+		if err := os.MkdirAll(logDir, 0755); err != nil {
+			return errors.Wrapf(err, "create log dir %s", logDir)
+		}
+		logFile := filepath.Join(logDir, defaultLogFileName)
+		f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0755)
+		if err != nil {
+			return errors.Wrapf(err, "open log file %s", logFile)
+		}
+		logrus.SetOutput(f)
+	}
+
 	logrus.SetFormatter(&logrus.TextFormatter{
 		TimestampFormat: log.RFC3339NanoFixed,
 		FullTimestamp:   true,

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
 	"github.com/pkg/errors"
 	exec "golang.org/x/sys/execabs"
 )
@@ -81,7 +82,7 @@ func (c *Config) FillupWithDefaults() error {
 	}
 
 	if len(c.LogDir) == 0 {
-		c.LogDir = filepath.Join(c.RootDir, "logs")
+		c.LogDir = filepath.Join(c.RootDir, logging.DefaultLogDirName)
 	}
 	var daemonCfg DaemonConfig
 	if err := LoadConfig(c.DaemonCfgPath, &daemonCfg); err != nil {


### PR DESCRIPTION
There are three log related parameters, namely LogLevel, LogDir and
LogToStdout.

Previously, both LogDir and LogToStdout are directly passed to
nydusd daemon, while LogLevel is shared by snapshotter and
nydusd daemon, so actually we can't control the output direction and
file path of the snapshotter log. Now we fix it.

In order to prevent the already running business from being affected on
a large scale, we will not modify the log control method of nydusd
daemon here and continue to let nydusd share the configuration of log
with snapshotter.

Now the default path of nydusd log is (if DaemonMode is not none):
/PATH/TO/ROOTDIR/logs/NYDUSD_DAEMON_ID/stderr.log

And the default path of snapshotter log is:
/PATH/TO/ROOTDIR/logs/nydus-snapshotter.log

Signed-off-by: zhaoshang <zhaoshangsjtu@linux.alibaba.com>