### PR TITLE
fscache: enable log-level settings

### DIFF
--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -142,6 +142,7 @@ func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 			"daemon",
 			"--apisock", d.GetAPISock(),
 			"--fscache", m.cacheDir,
+			"--log-level", d.LogLevel,
 		}
 	} else {
 		args = []string{


### PR DESCRIPTION
Log-level settings not work for fscache so add "--log-level" in fscache args to fix it.