### PR TITLE
erofs: drop "device=" options

### DIFF
--- a/pkg/utils/erofs/erofs_linux.go
+++ b/pkg/utils/erofs/erofs_linux.go
@@ -4,73 +4,16 @@
 package erofs
 
 import (
-	"encoding/binary"
-	"io"
-	"os"
-	"strings"
-
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
-func getDevices(path string) ([]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open bootstrap")
-	}
-	defer f.Close()
-
-	devices := make([]string, 0)
-	_, err = f.Seek(1024, io.SeekStart)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to seek bootstrap")
-	}
-	byte4 := make([]byte, 4)
-	_, err = f.Read(byte4)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read super magic")
-	}
-	if binary.LittleEndian.Uint32(byte4) != 0xe0f5e1e2 {
-		return nil, errors.New("bad erofs magic")
-	}
-	_, err = f.Seek(1024+86, io.SeekStart)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to seek bootstrap")
-	}
-	_, err = f.Read(byte4)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read devt_slotoff")
-	}
-	nrDevices := binary.LittleEndian.Uint16(byte4[0:2])
-	pos := int64(binary.LittleEndian.Uint16(byte4[2:4])) * 128
-	for nrDevices > 0 {
-		tag := make([]byte, 64)
-		_, err = f.Seek(pos, io.SeekStart)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to seek bootstrap")
-		}
-		_, err = f.Read(tag)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read device tag")
-		}
-		devices = append(devices, string(tag))
-		nrDevices = nrDevices - 1
-		pos = pos + 128
-	}
-	return devices, nil
-}
-
 func Mount(bootstrapPath, fsID, mountPoint string) error {
-	devices, err := getDevices(bootstrapPath)
-	if err != nil {
-		return errors.Wrap(err, "get erofs devices from bootstrap")
-	}
-
 	mount := unix.Mount
 
-	opts := "fsid=" + fsID + ",device=" + strings.Join(devices, ",device=")
+	opts := "fsid=" + fsID
 	logrus.Infof("Mount erofs to %s with options %s", mountPoint, opts)
 	if err := mount("erofs", mountPoint, "erofs", 0, opts); err != nil {
 		return errors.Wrapf(err, "failed to mount erofs")


### PR DESCRIPTION
Since kernel commit ba73eadd23d1 ("erofs: scan devices from device
table"), we don't need "device=" options any more.

Signed-off-by: Gao Xiang \<hsiangkao@linux.alibaba.com\>