### PR TITLE
Convert: support nydus v6 fs version convert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NYDUS_VERSION: v2.0.0-rc.5
+  NYDUS_VERSION: v2.1.0-alpha.0
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,4 @@ cover:
 
 smoke:
 	$(SUDO) NYDUS_BUILDER=${NYDUS_BUILDER} NYDUS_NYDUSD=${NYDUS_NYDUSD} ${GO_EXECUTABLE_PATH} test -race -v ./tests
+	$(SUDO) NYDUS_BUILDER=${NYDUS_BUILDER} NYDUS_NYDUSD=${NYDUS_NYDUSD} ${GO_EXECUTABLE_PATH} test -race -v ./tests -args -fs-version=6

--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -57,10 +57,6 @@ func Convert(option ConvertOption) error {
 		option.RafsVersion,
 		"--inline-bootstrap",
 	}
-	if option.RafsVersion == "6" {
-		// FIXME: these options should be handled automatically in builder (nydus-image).
-		args = append(args, "--disable-check")
-	}
 	if option.ChunkDictPath != "" {
 		args = append(args, "--chunk-dict", fmt.Sprintf("bootstrap=%s", option.ChunkDictPath))
 	}

--- a/tests/nydusd.go
+++ b/tests/nydusd.go
@@ -32,6 +32,8 @@ type NydusdConfig struct {
 	BlobCacheDir   string
 	APISockPath    string
 	MountPath      string
+	Mode           string
+	DigestValidate bool
 }
 
 // Nydusd runs nydusd binary.
@@ -57,14 +59,14 @@ var configTpl = `
 			}
 		}
 	},
-	"mode": "cached",
+	"mode": "{{.Mode}}",
 	"iostats_files": false,
 	"fs_prefetch": {
 		"enable": {{.EnablePrefetch}},
 		"threads_count": 10,
 		"merging_size": 131072
 	},
-	"digest_validate": true,
+	"digest_validate": {{.DigestValidate}},
 	"enable_xattr": true
 }
 `


### PR DESCRIPTION
1. add nydus v6 fs version support
2. add nydus v6 tests

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba.com>