### PR TITLE
args: change async-remove to sync-remove

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -42,7 +42,7 @@ type Args struct {
 	SharedDaemon         bool
 	DaemonMode           string
 	DaemonBackend        string
-	AsyncRemove          bool
+	SyncRemove           bool
 	EnableMetrics        bool
 	MetricsFile          string
 	EnableStargz         bool
@@ -147,10 +147,9 @@ func buildFlags(args *Args) []cli.Flag {
 			Destination: &args.DaemonBackend,
 		},
 		&cli.BoolFlag{
-			Name:        "async-remove",
-			Value:       true,
-			Usage:       "whether to cleanup snapshots asynchronously",
-			Destination: &args.AsyncRemove,
+			Name:        "sync-remove",
+			Usage:       "whether to cleanup snapshots synchronously, default is asynchronous",
+			Destination: &args.SyncRemove,
 		},
 		&cli.BoolFlag{
 			Name:        "enable-metrics",
@@ -240,7 +239,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	if args.SharedDaemon {
 		cfg.DaemonMode = config.DaemonModeShared
 	}
-	cfg.AsyncRemove = args.AsyncRemove
+	cfg.SyncRemove = args.SyncRemove
 	cfg.EnableMetrics = args.EnableMetrics
 	cfg.MetricsFile = args.MetricsFile
 	cfg.EnableStargz = args.EnableStargz

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	NydusImageBinaryPath string        `toml:"nydus_image_binary"`
 	DaemonMode           string        `toml:"daemon_mode"`
 	DaemonBackend        string        `toml:"daemon_backend"`
-	AsyncRemove          bool          `toml:"async_remove"`
+	SyncRemove           bool          `toml:"sync_remove"`
 	EnableMetrics        bool          `toml:"enable_metrics"`
 	MetricsFile          string        `toml:"metrics_file"`
 	EnableStargz         bool          `toml:"enable_stargz"`

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -56,7 +56,7 @@ type snapshotter struct {
 	root                 string
 	nydusdPath           string
 	ms                   *storage.MetaStore
-	asyncRemove          bool
+	syncRemove           bool
 	fs                   fspkg.FileSystem
 	stargzFs             fspkg.FileSystem
 	manager              *process.Manager
@@ -211,7 +211,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		root:                 cfg.RootDir,
 		nydusdPath:           cfg.NydusdBinaryPath,
 		ms:                   ms,
-		asyncRemove:          cfg.AsyncRemove,
+		syncRemove:           cfg.SyncRemove,
 		fs:                   nydusFs,
 		stargzFs:             stargzFs,
 		manager:              pm,
@@ -443,7 +443,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		return errors.Wrap(err, "failed to remove")
 	}
 
-	if !o.asyncRemove {
+	if o.syncRemove {
 		var removals []string
 		removals, err = o.getCleanupDirectories(ctx)
 		if err != nil {


### PR DESCRIPTION
According to the usage of boolflag, the default value should
be false. While async-remove is enabled by default, so we modify args
to sync-remove.

Signed-off-by: zhaoshang <zhaoshangsjtu@linux.alibaba.com>