### PR TITLE
config: Fix workdir json key not consist with nydusd fscache daemon

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -42,7 +42,7 @@ type FscacheDaemonConfig struct {
 		BackendConfig BackendConfig `json:"backend_config"`
 		CacheType     string        `json:"cache_type"`
 		CacheConfig   struct {
-			WorkDir string `json:"workdir"`
+			WorkDir string `json:"work_dir"`
 		} `json:"cache_config"`
 		MetadataPath string `json:"metadata_path"`
 	} `json:"config"`

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -164,6 +164,10 @@ func (d *Daemon) sharedErofsMount() error {
 		return err
 	}
 
+	if err := os.MkdirAll(d.FscacheWorkDir(), 0755); err != nil {
+		return errors.Wrapf(err, "failed to create fscache work dir %s", d.FscacheWorkDir())
+	}
+
 	if err := d.Client.FscacheBindBlob(d.ConfigFile()); err != nil {
 		return errors.Wrapf(err, "request to bind fscache blob")
 	}


### PR DESCRIPTION
Use work_dir for json key as what nydusd needed, and create fscache work
dir before call add blob cmd to nydusd.

Signed-off-by: Xin Yin <yinxin.x@bytedance.com>
Reported-by: Yongqing Li <liyongqing@bytedance.com>