### PR TITLE
Filesytem: support estargz for rafs v6

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -109,9 +109,9 @@ jobs:
           echo "stop containerd"
           sudo pkill -f /usr/local/bin/containerd
           echo "delete containerd dir"
-          # After the snapshotter container is stopped, it seems that Nydud doesn't umount it
+          # After the snapshotter container is stopped, it seems that Nydusd doesn't umount it
           # so we need to umount it here, otherwise you cannot delete this directory. 
-          # Frankly, I don't know why Nydud didn't clean up these resources.
+          # Frankly, I don't know why Nydusd didn't clean up these resources.
           sudo umount -f /var/lib/containerd-test/io.containerd.snapshotter.v1.nydus/mnt
           sudo rm -rf /var/lib/containerd-test/*
       - name: Test nydus-snapshotter image in localfs mode
@@ -125,6 +125,39 @@ jobs:
           sleep 10
           echo "Pull nydus-latest image"
           sudo crictl pull ghcr.io/dragonflyoss/image-service/ubuntu:nydus-latest
+          docker logs `docker ps |grep  "nydus-snapshotter"|cut -d ' ' -f1`
+          echo "create new pod with nydus snapshotter"
+          sudo crictl run misc/example/container.yaml misc/example/pod.yaml
+          container=$(sudo crictl ps -q)
+          echo "check container liveness"
+          sudo crictl exec $container ls
+          echo "delete pod"
+          sudo crictl rmp -fa
+      - name: Cleanup containerd and snapshotter
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "stop snapshotter"
+          docker stop snapshotter
+          docker rm snapshotter
+          echo "stop containerd"
+          sudo pkill -f /usr/local/bin/containerd
+          echo "delete containerd dir"
+          # After the snapshotter container is stopped, it seems that Nydusd doesn't umount it
+          # so we need to umount it here, otherwise you cannot delete this directory. 
+          # Frankly, I don't know why Nydusd didn't clean up these resources.
+          sudo umount -f /var/lib/containerd-test/io.containerd.snapshotter.v1.nydus/mnt
+          sudo rm -rf /var/lib/containerd-test/*
+      - name: Test nydus-snapshotter with estargz image
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          # start nydus-snapshotter
+          docker run -d --name snapshotter --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CONTAINERD_ROOT=/var/lib/containerd-test -v /var/lib/containerd-test:/var/lib/containerd-test:shared -v ~/.docker/config.json:/root/.docker/config.json:shared ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:local
+          # start containerd
+          sudo /usr/local/bin/containerd --config /etc/containerd/containerd-test-config.toml -l debug &
+          # wait for containerd to start up
+          sleep 10
+          echo "pull estargz image"
+          sudo crictl pull ghcr.io/stargz-containers/wordpress:5.9.2-esgz
           docker logs `docker ps |grep  "nydus-snapshotter"|cut -d ' ' -f1`
           echo "create new pod with nydus snapshotter"
           sudo crictl run misc/example/container.yaml misc/example/pod.yaml

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -163,7 +163,7 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "enable-stargz",
-			Usage:       "whether to support stargz image",
+			Usage:       "whether to support stargz image (experimental)",
 			Destination: &args.EnableStargz,
 		},
 		&cli.BoolFlag{

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -13,6 +13,7 @@ if [ "$#" -eq 0 ]; then
 	    --address ${CONTAINERD_ROOT}/io.containerd.snapshotter.v1.nydus/containerd-nydus-grpc.sock \
 	    --enable-nydus-overlayfs \
 	    --daemon-mode shared \
+			--enable-stargz \
 	    --log-to-stdout
 fi
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -97,7 +97,7 @@ func (d *Daemon) GetAPISock() string {
 }
 
 func (d *Daemon) FscacheWorkDir() string {
-	return filepath.Join(d.SnapshotDir, d.SnapshotID, "fscache_workdir")
+	return filepath.Join(d.SnapshotDir, "fscache_workdir")
 }
 
 func (d *Daemon) LogFile() string {

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -225,13 +226,6 @@ func (fs *Filesystem) newSharedDaemon() (*daemon.Daemon, error) {
 	return d, nil
 }
 
-func getParentSnapshotID(s storage.Snapshot) string {
-	if len(s.ParentIDs) == 0 {
-		return ""
-	}
-	return s.ParentIDs[0]
-}
-
 func (fs *Filesystem) SupportStargz(ctx context.Context, labels map[string]string) bool {
 	if fs.stargzResolver == nil {
 		return false
@@ -261,6 +255,50 @@ func (fs *Filesystem) SupportStargz(ctx context.Context, labels map[string]strin
 		return false
 	}
 	return true
+}
+
+func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapshot) error {
+	mergedBootstrap := filepath.Join(fs.UpperPath(s.ParentIDs[0]), "image.boot")
+	if _, err := os.Stat(mergedBootstrap); err == nil {
+		return nil
+	}
+
+	bootstraps := []string{}
+	for _, snapshotID := range s.ParentIDs {
+		files, err := ioutil.ReadDir(fs.UpperPath(snapshotID))
+		if err != nil {
+			if err != nil {
+				return errors.Wrap(err, "read snapshot dir")
+			}
+		}
+
+		bootstrapName := ""
+		for _, file := range files {
+			if digest.Digest(fmt.Sprintf("sha256:%s", file.Name())).Validate() == nil {
+				bootstrapName = file.Name()
+				break
+			}
+		}
+		if bootstrapName == "" {
+			return fmt.Errorf("can't find bootstrap for snapshot %s", snapshotID)
+		}
+
+		bootstrapPath := filepath.Join(fs.UpperPath(snapshotID), bootstrapName)
+		bootstraps = append([]string{bootstrapPath}, bootstraps...)
+	}
+
+	options := []string{
+		"merge",
+		"--bootstrap", filepath.Join(fs.UpperPath(s.ParentIDs[0]), "image.boot"),
+	}
+	options = append(options, bootstraps...)
+	log.G(ctx).Infof("nydus image command %v", options)
+
+	cmd := exec.Command(fs.nydusImageBinaryPath, options...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	return cmd.Run()
 }
 
 func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, s storage.Snapshot, labels map[string]string) error {
@@ -297,21 +335,14 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, s storage.Snap
 	if err != nil {
 		return errors.Wrap(err, "failed to save stargz index")
 	}
+	blobID := digest.Digest(layerDigest).Hex()
 	options := []string{
 		"create",
 		"--source-type", "stargz_index",
-		"--bootstrap", filepath.Join(fs.UpperPath(s.ID), "image.boot"),
-		"--blob-id", digest.Digest(layerDigest).Hex(),
+		"--bootstrap", filepath.Join(fs.UpperPath(s.ID), blobID),
+		"--blob-id", blobID,
 		"--repeatable",
 		"--disable-check",
-	}
-	if getParentSnapshotID(s) != "" {
-		parentBootstrap := filepath.Join(fs.UpperPath(getParentSnapshotID(s)), "image.boot")
-		if _, err := os.Stat(parentBootstrap); err != nil {
-			return fmt.Errorf("failed to find parentBootstrap from %s", parentBootstrap)
-		}
-		options = append(options,
-			"--parent-bootstrap", parentBootstrap)
 	}
 	options = append(options, filepath.Join(fs.UpperPath(s.ID), stargz.TocFileName))
 	log.G(ctx).Infof("nydus image command %v", options)
@@ -324,6 +355,10 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, s storage.Snap
 func (fs *Filesystem) Support(ctx context.Context, labels map[string]string) bool {
 	_, dataOk := labels[label.NydusDataLayer]
 	return dataOk
+}
+
+func (fs *Filesystem) StargzLayer(labels map[string]string) bool {
+	return labels[label.StargzLayer] != ""
 }
 
 func isRafsV6(buf []byte) bool {
@@ -789,7 +824,7 @@ func (fs *Filesystem) getBlobIDs(labels map[string]string) ([]string, error) {
 	if !ok {
 		// FIXME: for stargz layer, just return empty blobs here, we
 		// need to rethink how to implement blob cache GC for stargz.
-		if labels[label.StargzLayer] != "" {
+		if fs.StargzLayer(labels) {
 			return nil, nil
 		}
 		return nil, errors.New("no blob ids found")

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -336,6 +336,8 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, s storage.Snap
 		return errors.Wrap(err, "failed to save stargz index")
 	}
 	blobID := digest.Digest(layerDigest).Hex()
+	blobMetaPath := filepath.Join(fs.cacheMgr.CacheDir(), fmt.Sprintf("%s.blob.meta", blobID))
+
 	options := []string{
 		"create",
 		"--source-type", "stargz_index",
@@ -343,12 +345,19 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, s storage.Snap
 		"--blob-id", blobID,
 		"--repeatable",
 		"--disable-check",
+		// FIXME: allow user to specify fs version and automatically detect
+		// chunk size and compressor from estargz TOC file.
+		"--fs-version", "6",
+		"--chunk-size", "0x400000",
+		"--blob-meta", blobMetaPath,
 	}
 	options = append(options, filepath.Join(fs.UpperPath(s.ID), stargz.TocFileName))
 	log.G(ctx).Infof("nydus image command %v", options)
+
 	cmd := exec.Command(fs.nydusImageBinaryPath, options...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+
 	return cmd.Run()
 }
 

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -338,6 +338,14 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, s storage.Snap
 	blobID := digest.Digest(layerDigest).Hex()
 	blobMetaPath := filepath.Join(fs.cacheMgr.CacheDir(), fmt.Sprintf("%s.blob.meta", blobID))
 
+	if fs.daemonBackend == config.DaemonBackendFscache {
+		fscacheWorkdir := fs.FscacheWorkDir()
+		if err := os.MkdirAll(fscacheWorkdir, 0755); err != nil {
+			return errors.Wrapf(err, "failed to create fscache work dir %s", fscacheWorkdir)
+		}
+		blobMetaPath = filepath.Join(fscacheWorkdir, fmt.Sprintf("%s.blob.meta", blobID))
+	}
+
 	options := []string{
 		"create",
 		"--source-type", "stargz_index",

--- a/pkg/filesystem/fs/stargz/resolver.go
+++ b/pkg/filesystem/fs/stargz/resolver.go
@@ -31,6 +31,8 @@ import (
 	"github.com/containerd/stargz-snapshotter/estargz"
 )
 
+const httpTimeout = 15 * time.Second
+
 const (
 	FooterSize  = 47
 	TocFileName = "stargz.index.json"
@@ -171,7 +173,7 @@ func (r *Resolver) resolve(ref, digest string, keychain authn.Keychain) (*io.Sec
 
 	sr := io.NewSectionReader(readerAtFunc(func(b []byte, offset int64) (int, error) {
 		length := len(b)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
@@ -225,7 +227,7 @@ func (r *Resolver) resolveReference(ref name.Reference, digest string, keychain 
 }
 
 func redirect(endpointURL string, tr http.RoundTripper) (url string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "GET", endpointURL, nil)
 	if err != nil {
@@ -253,7 +255,7 @@ func redirect(endpointURL string, tr http.RoundTripper) (url string, err error) 
 }
 
 func getSize(url string, tr http.RoundTripper) (int64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/pkg/filesystem/meta/meta.go
+++ b/pkg/filesystem/meta/meta.go
@@ -31,3 +31,7 @@ func (m FileSystemMeta) ConfigRoot() string {
 func (m FileSystemMeta) UpperPath(id string) string {
 	return filepath.Join(m.RootDir, "snapshots", id, "fs")
 }
+
+func (m FileSystemMeta) FscacheWorkDir() string {
+	return filepath.Join(m.RootDir, "snapshots", "fscache_workdir")
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -307,6 +307,12 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 	if prepareForContainer(base) {
 		logCtx.Infof("prepare for container layer %s", key)
 		if id, info, err := o.findMetaLayer(ctx, key); err == nil {
+			// For stargz layer, we need to merge all bootstraps into one.
+			if o.fs.StargzLayer(info.Labels) {
+				if err := o.fs.MergeStargzMetaLayer(ctx, s); err != nil {
+					return nil, errors.Wrap(err, "merge stargz meta layer")
+				}
+			}
 			logCtx.Infof("found nydus meta layer id %s, parpare remote snapshot", id)
 			if o.manager.IsPrefetchDaemon() {
 				// Prepare prefetch mount in background, so we could return Mounts


### PR DESCRIPTION
This is an earlier, experimental version of nydus snapshotter that
implements the ability to run estargz images directly in nydusd
(in user space) or erofs with fscache (in kernel space).

In snapshot prepare stage, we need to convert estargz TOC file
to nydus bootstrap, and in snapshot mount stage, need to merge
all bootstraps into final bootstrap, nydusd will use this it to
mount filesystem.