### PR TITLE
feat: NYDUS files are convertible to OCI tar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NYDUS_VERSION: v2.1.0-alpha.0
+  NYDUS_VERSION: v2.1.0-alpha.3
 
 jobs:
   build:

--- a/pkg/converter/convert_windows.go
+++ b/pkg/converter/convert_windows.go
@@ -13,12 +13,18 @@ import (
 	"context"
 	"fmt"
 	"io"
+
+	"github.com/containerd/containerd/content"
 )
 
-func Convert(ctx context.Context, dest io.Writer, opt ConvertOption) (io.WriteCloser, error) {
+func Pack(ctx context.Context, dest io.Writer, opt PackOption) (io.WriteCloser, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
 func Merge(ctx context.Context, layers []Layer, dest io.Writer, opt MergeOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func Unpack(ctx context.Context, ia content.ReaderAt, dest io.Writer, opt UnpackOption) error {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/converter/types.go
+++ b/pkg/converter/types.go
@@ -18,7 +18,7 @@ type Layer struct {
 	ReaderAt content.ReaderAt
 }
 
-type ConvertOption struct {
+type PackOption struct {
 	// RafsVersion specifies nydus format version, possible values:
 	// `5`, `6` (EROFS-compatible), default is `5`.
 	RafsVersion string
@@ -36,3 +36,5 @@ type MergeOption struct {
 	// WithTar puts bootstrap into a tar stream (no gzip).
 	WithTar bool
 }
+
+type UnpackOption struct{}


### PR DESCRIPTION
BACKGROUND
OCI layer is convertible into bootstrap and blob of NYDUS. However there is no way to convert bootstrap and blob to OCI layer.

REQUIREMENT
BuildKit already provides ability to convert OCI layer to NYDUS files. It seeks for the ability to convert back.

FEATURE
Excluding hard link, the hash digests of result and original OCI tar are same .
Including hard link, the unpack result of result and original OCI tar are same.