### PR TITLE
fscache: fix possible conflict fscache id

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -132,7 +132,7 @@ func SaveConfig(c interface{}, configFile string) error {
 	return ioutil.WriteFile(configFile, b, 0755)
 }
 
-func NewDaemonConfig(daemonBackend string, cfg DaemonConfig, imageID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
+func NewDaemonConfig(daemonBackend string, cfg DaemonConfig, imageID, snapshotID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
 	image, err := registry.ParseImage(imageID)
 	if err != nil {
 		return DaemonConfig{}, errors.Wrapf(err, "failed to parse image %s", imageID)
@@ -159,7 +159,7 @@ func NewDaemonConfig(daemonBackend string, cfg DaemonConfig, imageID string, vpc
 		backendConfig := &cfg.Device.Backend.Config
 		if daemonBackend == DaemonBackendFscache {
 			backendConfig = &cfg.Config.BackendConfig
-			fscacheID := erofs.FscacheID(imageID)
+			fscacheID := erofs.FscacheID(snapshotID)
 			cfg.ID = fscacheID
 			cfg.DomainID = fscacheID
 			cfg.Config.ID = fscacheID

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -181,7 +181,7 @@ func (d *Daemon) sharedErofsMount() error {
 	if err != nil {
 		return err
 	}
-	fscacheID := erofs.FscacheID(d.ImageID)
+	fscacheID := erofs.FscacheID(d.SnapshotID)
 
 	if err := erofs.Mount(bootstrapPath, fscacheID, mountPoint); err != nil {
 		return errors.Wrapf(err, "mount erofs")

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -624,13 +624,13 @@ func (fs *Filesystem) BootstrapFile(id string) (string, error) {
 	return daemon.GetBootstrapFile(fs.SnapshotRoot(), id)
 }
 
-func (fs *Filesystem) NewDaemonConfig(labels map[string]string) (config.DaemonConfig, error) {
+func (fs *Filesystem) NewDaemonConfig(labels map[string]string, snapshotID string) (config.DaemonConfig, error) {
 	imageID, ok := labels[label.CRIImageRef]
 	if !ok {
 		return config.DaemonConfig{}, fmt.Errorf("no image ID found in label")
 	}
 
-	cfg, err := config.NewDaemonConfig(fs.daemonBackend, fs.daemonCfg, imageID, fs.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(fs.daemonBackend, fs.daemonCfg, imageID, snapshotID, fs.vpcRegistry, labels)
 	if err != nil {
 		return config.DaemonConfig{}, err
 	}
@@ -808,7 +808,7 @@ func (fs *Filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 
 // generateDaemonConfig generate Daemon configuration
 func (fs *Filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]string) error {
-	cfg, err := config.NewDaemonConfig(d.DaemonBackend, fs.daemonCfg, d.ImageID, fs.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(d.DaemonBackend, fs.daemonCfg, d.ImageID, d.SnapshotID, fs.vpcRegistry, labels)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
 	}

--- a/pkg/utils/erofs/erofs_linux.go
+++ b/pkg/utils/erofs/erofs_linux.go
@@ -4,6 +4,8 @@
 package erofs
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -26,6 +28,6 @@ func Umount(mountPoint string) error {
 	return unix.Unmount(mountPoint, 0)
 }
 
-func FscacheID(imageID string) string {
-	return digest.FromString(imageID).Hex()
+func FscacheID(snapshotID string) string {
+	return digest.FromString(fmt.Sprintf("nydus-snapshot-%s", snapshotID)).Hex()
 }

--- a/pkg/utils/erofs/erofs_other.go
+++ b/pkg/utils/erofs/erofs_other.go
@@ -13,6 +13,6 @@ func Umount(mountPoint string) error {
 	return fmt.Errorf("not implemented")
 }
 
-func FscacheID(imageID string) string {
+func FscacheID(snapshotID string) string {
 	panic("not implemented")
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -615,7 +615,7 @@ func (o *snapshotter) remoteMounts(ctx context.Context, s storage.Snapshot, id s
 		return nil, err
 	}
 
-	cfg, err := o.fs.NewDaemonConfig(labels)
+	cfg, err := o.fs.NewDaemonConfig(labels, id)
 	if err != nil {
 		return nil, errors.Wrapf(err, fmt.Sprintf("remoteMounts: failed to generate nydus config for snapshot %s, label: %v", id, labels))
 	}


### PR DESCRIPTION
Maybe image ref causes fscache id conflict when user updates
image content using same image ref. So it's more safe to use
snapshot id instead of image ref as the fscache id.

Signed-off-by: Yan Song <yansong.ys@antfin.com>