### PR TITLE
fscache: fix fscache workdir path for estargz

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -97,7 +97,7 @@ func (d *Daemon) GetAPISock() string {
 }
 
 func (d *Daemon) FscacheWorkDir() string {
-	return filepath.Join(d.SnapshotDir, "fscache_workdir")
+	return filepath.Join(d.SnapshotDir, d.SnapshotID, "fs")
 }
 
 func (d *Daemon) LogFile() string {

--- a/pkg/filesystem/meta/meta.go
+++ b/pkg/filesystem/meta/meta.go
@@ -31,7 +31,3 @@ func (m FileSystemMeta) ConfigRoot() string {
 func (m FileSystemMeta) UpperPath(id string) string {
 	return filepath.Join(m.RootDir, "snapshots", id, "fs")
 }
-
-func (m FileSystemMeta) FscacheWorkDir() string {
-	return filepath.Join(m.RootDir, "snapshots", "fscache_workdir")
-}


### PR DESCRIPTION
Before this patch, we share the same fscache workdir for all estargz
images, this workdir stores all blob meta files for each estargz image.

The fatal problem is that once an estargz image is removed by user, the
all blob meta files will be cleaned by containerd GC, this behavior affects
all existing estargz images.

This patch stores the blob meta files into each snapshot dir, and then
copy them into topmost snapshot dir if user wants to run a container.

Signed-off-by: Yan Song <yansong.ys@antfin.com>