### PR TITLE
fscache: simple fixup for busy mountpoint

### DIFF
--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -7,7 +7,9 @@
 package errdefs
 
 import (
+	stderrors "errors"
 	"net"
+	"syscall"
 
 	"github.com/pkg/errors"
 )
@@ -30,4 +32,8 @@ func IsConnectionClosed(err error) bool {
 	default:
 		return false
 	}
+}
+
+func IsErofsMounted(err error) bool {
+	return stderrors.Is(err, syscall.EBUSY)
 }


### PR DESCRIPTION
When snapshotter exits (either normally or abnormally), it will not have a
chance to umount erofs mountpoint, so if snapshotter resumes running and mount
again (by a new request to create container), it will need to ignore the mount
error `device or resource busy`.

Signed-off-by: Yan Song <yansong.ys@antfin.com>