### PR TITLE
converter: enhance pack/merge/unpack options

### DIFF
--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -21,10 +21,11 @@ type PackOption struct {
 
 	BootstrapPath    string
 	BlobPath         string
-	RafsVersion      string
+	FsVersion        string
 	SourcePath       string
 	ChunkDictPath    string
 	PrefetchPatterns string
+	Compressor       string
 }
 
 type MergeOption struct {
@@ -44,8 +45,8 @@ type UnpackOption struct {
 }
 
 func Pack(option PackOption) error {
-	if option.RafsVersion == "" {
-		option.RafsVersion = "5"
+	if option.FsVersion == "" {
+		option.FsVersion = "5"
 	}
 
 	args := []string{
@@ -61,7 +62,7 @@ func Pack(option PackOption) error {
 		"--whiteout-spec",
 		"none",
 		"--fs-version",
-		option.RafsVersion,
+		option.FsVersion,
 		"--inline-bootstrap",
 	}
 	if option.ChunkDictPath != "" {
@@ -69,6 +70,9 @@ func Pack(option PackOption) error {
 	}
 	if option.PrefetchPatterns == "" {
 		option.PrefetchPatterns = "/"
+	}
+	if option.Compressor != "" {
+		args = append(args, "--compressor", option.Compressor)
 	}
 	args = append(args, option.SourcePath)
 

--- a/pkg/converter/types.go
+++ b/pkg/converter/types.go
@@ -19,16 +19,26 @@ type Layer struct {
 }
 
 type PackOption struct {
-	// RafsVersion specifies nydus format version, possible values:
-	// `5`, `6` (EROFS-compatible), default is `5`.
-	RafsVersion string
+	// WorkDir is used as the work directory during layer pack.
+	WorkDir string
+	// BuilderPath holds the path of `nydus-image` binary tool.
+	BuilderPath string
+	// FsVersion specifies nydus RAFS format version, possible
+	// values: `5`, `6` (EROFS-compatible), default is `5`.
+	FsVersion string
 	// ChunkDictPath holds the bootstrap path of chunk dict image.
 	ChunkDictPath string
 	// PrefetchPatterns holds file path pattern list want to prefetch.
 	PrefetchPatterns string
+	// Compressor specifies nydus blob compression algorithm.
+	Compressor string
 }
 
 type MergeOption struct {
+	// WorkDir is used as the work directory during layer merge.
+	WorkDir string
+	// BuilderPath holds the path of `nydus-image` binary tool.
+	BuilderPath string
 	// ChunkDictPath holds the bootstrap path of chunk dict image.
 	ChunkDictPath string
 	// PrefetchPatterns holds file path pattern list want to prefetch.
@@ -37,4 +47,9 @@ type MergeOption struct {
 	WithTar bool
 }
 
-type UnpackOption struct{}
+type UnpackOption struct {
+	// WorkDir is used as the work directory during layer unpack.
+	WorkDir string
+	// BuilderPath holds the path of `nydus-image` binary tool.
+	BuilderPath string
+}

--- a/tests/converter_test.go
+++ b/tests/converter_test.go
@@ -187,7 +187,7 @@ func convertLayer(t *testing.T, source io.ReadCloser, chunkDict, workDir string,
 
 	twc, err := converter.Pack(context.TODO(), writer, converter.PackOption{
 		ChunkDictPath: chunkDict,
-		RafsVersion:   fsVersion,
+		FsVersion:     fsVersion,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Allow caller to specify the `WorkDir`, `BuilderPath` options,
instead of getting only from environment variable.

Change option name `RafsVersion` to `FsVersion`, make it consistent
with `nydus-image create --fs-version` command.

Add a new `Compressor` option to support more compression algorithms
for pack command.

Signed-off-by: Yan Song <yansong.ys@antfin.com>