### PR TITLE
feat: Only retain serious log while unpacking

### DIFF
--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -127,6 +127,8 @@ func Merge(option MergeOption) error {
 func Unpack(option UnpackOption) error {
 	args := []string{
 		"unpack",
+		"--log-level",
+		"warn",
 		"--bootstrap",
 		option.BootstrapPath,
 		"--output",


### PR DESCRIPTION
### DESCRIPTION:
Working with multiple layers, snapshotter produces trivial logs.