### PR TITLE
common: add flag --fs-driver to replace --daemon-backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,8 +30,8 @@ const (
 )
 
 const (
-	DaemonBackendFusedev string = "fusedev"
-	DaemonBackendFscache string = "fscache"
+	FsDriverFusedev string = "fusedev"
+	FsDriverFscache string = "fscache"
 )
 
 type Config struct {
@@ -47,7 +47,7 @@ type Config struct {
 	NydusdBinaryPath     string        `toml:"nydusd_binary_path"`
 	NydusImageBinaryPath string        `toml:"nydus_image_binary"`
 	DaemonMode           string        `toml:"daemon_mode"`
-	DaemonBackend        string        `toml:"daemon_backend"`
+	FsDriver             string        `toml:"daemon_backend"`
 	SyncRemove           bool          `toml:"sync_remove"`
 	EnableMetrics        bool          `toml:"enable_metrics"`
 	MetricsFile          string        `toml:"metrics_file"`

--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -132,14 +132,14 @@ func SaveConfig(c interface{}, configFile string) error {
 	return ioutil.WriteFile(configFile, b, 0755)
 }
 
-func NewDaemonConfig(daemonBackend string, cfg DaemonConfig, imageID, snapshotID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
+func NewDaemonConfig(fsDriver string, cfg DaemonConfig, imageID, snapshotID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
 	image, err := registry.ParseImage(imageID)
 	if err != nil {
 		return DaemonConfig{}, errors.Wrapf(err, "failed to parse image %s", imageID)
 	}
 
 	backend := cfg.Device.Backend.BackendType
-	if daemonBackend == DaemonBackendFscache {
+	if fsDriver == FsDriverFscache {
 		backend = cfg.Config.BackendType
 	}
 
@@ -157,7 +157,7 @@ func NewDaemonConfig(daemonBackend string, cfg DaemonConfig, imageID, snapshotID
 		// We don't validate the original nydusd auth from configuration file since it can be empty
 		// when repository is public.
 		backendConfig := &cfg.Device.Backend.Config
-		if daemonBackend == DaemonBackendFscache {
+		if fsDriver == FsDriverFscache {
 			backendConfig = &cfg.Config.BackendConfig
 			fscacheID := erofs.FscacheID(snapshotID)
 			cfg.ID = fscacheID

--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -11,19 +11,19 @@ import (
 )
 
 type Manager struct {
-	db            DB
-	store         *Store
-	cacheDir      string
-	period        time.Duration
-	eventCh       chan struct{}
-	daemonBackend string
+	db       DB
+	store    *Store
+	cacheDir string
+	period   time.Duration
+	eventCh  chan struct{}
+	fsDriver string
 }
 
 type Opt struct {
-	CacheDir      string
-	Period        time.Duration
-	Database      *store.Database
-	DaemonBackend string
+	CacheDir string
+	Period   time.Duration
+	Database *store.Database
+	FsDriver string
 }
 
 func NewManager(opt Opt) (*Manager, error) {
@@ -40,18 +40,18 @@ func NewManager(opt Opt) (*Manager, error) {
 
 	eventCh := make(chan struct{})
 	m := &Manager{
-		db:            db,
-		store:         s,
-		cacheDir:      opt.CacheDir,
-		period:        opt.Period,
-		eventCh:       eventCh,
-		daemonBackend: opt.DaemonBackend,
+		db:       db,
+		store:    s,
+		cacheDir: opt.CacheDir,
+		period:   opt.Period,
+		eventCh:  eventCh,
+		fsDriver: opt.FsDriver,
 	}
 
 	// For fscache backend, the cache is maintained by the kernel fscache module,
 	// so here we ignore gc for now, and in the future we need another design
 	// to remove the cache.
-	if opt.DaemonBackend == config.DaemonBackendFscache {
+	if opt.FsDriver == config.FsDriverFscache {
 		return m, nil
 	}
 
@@ -66,7 +66,7 @@ func (m *Manager) CacheDir() string {
 }
 
 func (m *Manager) SchedGC() {
-	if m.daemonBackend == config.DaemonBackendFscache {
+	if m.fsDriver == config.FsDriverFscache {
 		return
 	}
 	m.eventCh <- struct{}{}

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -139,9 +139,9 @@ func WithNydusdThreadNum(nydusdThreadNum int) NewDaemonOpt {
 	}
 }
 
-func WithDaemonBackend(daemonBackend string) NewDaemonOpt {
+func WithFsDriver(fsDriver string) NewDaemonOpt {
 	return func(d *Daemon) error {
-		d.DaemonBackend = daemonBackend
+		d.FsDriver = fsDriver
 		return nil
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -43,7 +43,7 @@ type Daemon struct {
 	Pid              int
 	ImageID          string
 	DaemonMode       string
-	DaemonBackend    string
+	FsDriver         string
 	APISock          *string
 	RootMountPoint   *string
 	CustomMountPoint *string
@@ -135,7 +135,7 @@ func (d *Daemon) SharedMount() error {
 	if err := d.ensureClient("share mount"); err != nil {
 		return err
 	}
-	if d.DaemonBackend == config.DaemonBackendFscache {
+	if d.FsDriver == config.FsDriverFscache {
 		if err := d.sharedErofsMount(); err != nil {
 			return errors.Wrapf(err, "failed to erofs mount")
 		}
@@ -152,7 +152,7 @@ func (d *Daemon) SharedUmount() error {
 	if err := d.ensureClient("share umount"); err != nil {
 		return err
 	}
-	if d.DaemonBackend == config.DaemonBackendFscache {
+	if d.FsDriver == config.FsDriverFscache {
 		if err := d.sharedErofsUmount(); err != nil {
 			return errors.Wrapf(err, "failed to erofs mount")
 		}

--- a/pkg/filesystem/fs/config.go
+++ b/pkg/filesystem/fs/config.go
@@ -115,13 +115,13 @@ func WithDaemonMode(daemonMode string) NewFSOpt {
 	}
 }
 
-func WithDaemonBackend(daemonBackend string) NewFSOpt {
+func WithFsDriver(fsDriver string) NewFSOpt {
 	return func(d *Filesystem) error {
-		switch daemonBackend {
-		case config.DaemonBackendFscache:
-			d.daemonBackend = config.DaemonBackendFscache
+		switch fsDriver {
+		case config.FsDriverFscache:
+			d.fsDriver = config.FsDriverFscache
 		default:
-			d.daemonBackend = config.DaemonBackendFusedev
+			d.fsDriver = config.FsDriverFusedev
 		}
 		return nil
 	}

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -137,7 +137,7 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 
 func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 	var args []string
-	if d.DaemonBackend == config.DaemonBackendFscache {
+	if d.FsDriver == config.FsDriverFscache {
 		args = []string{
 			"daemon",
 			"--apisock", d.GetAPISock(),

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -114,7 +114,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		fspkg.WithVPCRegistry(cfg.ConvertVpcRegistry),
 		fspkg.WithVerifier(verifier),
 		fspkg.WithDaemonMode(cfg.DaemonMode),
-		fspkg.WithDaemonBackend(cfg.DaemonBackend),
+		fspkg.WithFsDriver(cfg.FsDriver),
 		fspkg.WithLogLevel(cfg.LogLevel),
 		fspkg.WithLogDir(cfg.LogDir),
 		fspkg.WithLogToStdout(cfg.LogToStdout),
@@ -125,10 +125,10 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 
 	if !cfg.DisableCacheManager {
 		cacheMgr, err := cache.NewManager(cache.Opt{
-			Database:      db,
-			Period:        cfg.GCPeriod,
-			CacheDir:      cfg.CacheDir,
-			DaemonBackend: cfg.DaemonBackend,
+			Database: db,
+			Period:   cfg.GCPeriod,
+			CacheDir: cfg.CacheDir,
+			FsDriver: cfg.FsDriver,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to new cache manager")


### PR DESCRIPTION
fs-driver is a more descriptive name since fusedev and
fscache/cachefiles is a file system driver. In fact, fusedev
is nydusd's front-end. This patch also marks --daemon-backend
as deprecated.
