### PR TITLE
Optimize snapshotter to reduce container startup time

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -275,14 +275,14 @@ func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 }
 
 func GetBootstrapFile(dir, id string) (string, error) {
-	// the meta file is stored to <snapshotid>/image/image.boot
+	// meta files are stored at <snapshotid>/image/image.boot
 	bootstrap := filepath.Join(dir, id, "fs", "image", "image.boot")
 	_, err := os.Stat(bootstrap)
 	if err == nil {
 		return bootstrap, nil
 	}
 	if os.IsNotExist(err) {
-		// for backward compatibility check meta file from legacy location
+		// check legacy location for backward compatibility
 		bootstrap = filepath.Join(dir, id, "fs", "image.boot")
 		_, err = os.Stat(bootstrap)
 		if err == nil {

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -240,7 +240,7 @@ func (fs *Filesystem) StargzEnabled() bool {
 	return fs.stargzResolver != nil
 }
 
-func (fs *Filesystem) SupportStargz(ctx context.Context, labels map[string]string) (bool, string, string, *stargz.Blob) {
+func (fs *Filesystem) IsStargzDataLayer(ctx context.Context, labels map[string]string) (bool, string, string, *stargz.Blob) {
 	if !fs.StargzEnabled() {
 		return false, "", "", nil
 	}
@@ -458,8 +458,13 @@ func (fs *Filesystem) StargzLayer(labels map[string]string) bool {
 	return labels[label.StargzLayer] != ""
 }
 
-func (fs *Filesystem) Support(ctx context.Context, labels map[string]string) bool {
+func (fs *Filesystem) IsNydusDataLayer(ctx context.Context, labels map[string]string) bool {
 	_, dataOk := labels[label.NydusDataLayer]
+	return dataOk
+}
+
+func (fs *Filesystem) IsNydusMetaLayer(ctx context.Context, labels map[string]string) bool {
+	_, dataOk := labels[label.NydusMetaLayer]
 	return dataOk
 }
 

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -133,6 +133,13 @@ func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (*Filesystem, error) {
 	if err := fs.manager.Reconnect(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to reconnect daemons")
 	}
+	// Try to bring up the shared daemon early.
+	if fs.mode == SharedInstance {
+		if _, e := fs.getSharedDaemon(); e != nil {
+			log.G(ctx).Warnf("initialize the shared nydus daemon")
+			fs.initSharedDaemon(ctx)
+		}
+	}
 	return &fs, nil
 }
 


### PR DESCRIPTION
Optimize snapshotter to reduce container startup time by
1) avoid probing stargz layer for nydus metadata layer.
2) start shared nydusd daemon early, so it doesn't penalize the first container.