### PR TITLE
Remove blob.meta files when GC nydus blob files

### DIFF
--- a/pkg/cache/store.go
+++ b/pkg/cache/store.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	chunkMapFileSuffix = ".chunk_map"
+	metaFileSuffix     = ".blob.meta"
 )
 
 type Store struct {
@@ -35,6 +36,11 @@ func (cs *Store) DelBlob(blob string) error {
 	// Then remove the blob file named $blob_id.
 	if err := os.Remove(blobPath); err != nil {
 		return errors.Wrapf(err, "remove blob %v err", blobPath)
+	}
+
+	metaPath := blobPath + metaFileSuffix
+	if err := os.Remove(metaPath); err != nil {
+		return errors.Wrapf(err, "remove blob meta file %v err", metaPath)
 	}
 
 	return nil


### PR DESCRIPTION
Remove blob.meta files when deleting nydus blob files.

Fixes: https://github.com/containerd/nydus-snapshotter/issues/110

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>