### PR TITLE
change systemd KillMode to process

### DIFF
--- a/misc/snapshotter/nydus-snapshotter.fscache.service
+++ b/misc/snapshotter/nydus-snapshotter.fscache.service
@@ -9,6 +9,8 @@ Environment=HOME=/root
 ExecStart=/usr/local/bin/containerd-nydus-grpc --fs-driver fscache --daemon-mode shared --config-path /etc/nydus/config.json
 Restart=always
 RestartSec=1
+KillMode=process
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target

--- a/misc/snapshotter/nydus-snapshotter.fusedev.service
+++ b/misc/snapshotter/nydus-snapshotter.fusedev.service
@@ -9,6 +9,8 @@ Environment=HOME=/root
 ExecStart=/usr/local/bin/containerd-nydus-grpc --config-path /etc/nydus/config.json
 Restart=always
 RestartSec=1
+KillMode=process
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Otherwise, systemd will send SIGTERM to nydusd forked by
nydus-snapshotter ending up with nydusd exit and fuse session
disconnected.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>