### PR TITLE
Optimize handling of stargz images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 )
 
 require (
+	github.com/KarpelesLab/reflink v0.0.2 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/Microsoft/hcsshim v0.9.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/KarpelesLab/reflink v0.0.2 h1:PK0nDUsk2eEdIvMOUzh2TI35GY5KYmTdqdCCwd3BIz0=
+github.com/KarpelesLab/reflink v0.0.2/go.mod h1:mB+2afhyn+eZTMFSH1gXunrgArTsiUBzfoAy0X2fatA=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -292,9 +292,7 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 	for idx, snapshotID := range s.ParentIDs {
 		files, err := ioutil.ReadDir(fs.UpperPath(snapshotID))
 		if err != nil {
-			if err != nil {
-				return errors.Wrap(err, "read snapshot dir")
-			}
+			return errors.Wrap(err, "read snapshot dir")
 		}
 
 		bootstrapName := ""
@@ -310,6 +308,7 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 		if bootstrapName == "" {
 			return fmt.Errorf("can't find bootstrap for snapshot %s", snapshotID)
 		}
+
 		// The blob meta file is generated in corresponding snapshot dir for each layer,
 		// but we need copy them to fscache work dir for nydusd use. This is not an
 		// efficient method, but currently nydusd only supports reading blob meta files
@@ -321,7 +320,7 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 			// This path is same with `d.FscacheWorkDir()`, it's for fscache work dir.
 			targetPath := filepath.Join(fs.UpperPath(s.ParentIDs[0]), blobMetaName)
 			if err := reflink.Auto(sourcePath, targetPath); err != nil {
-				return errors.Wrap(err, "copy source blob meta to target")
+				return errors.Wrap(err, "copy source blob.meta to target")
 			}
 		}
 
@@ -329,36 +328,42 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 		bootstraps = append([]string{bootstrapPath}, bootstraps...)
 	}
 
-	tf, err := ioutil.TempFile(mergedDir, "merging-stargz")
-	if err != nil {
-		return errors.Wrap(err, "create temp file for merging stargz layers")
-	}
-	defer func() {
-		if err != nil {
-			os.Remove(tf.Name())
+	if len(bootstraps) == 1 {
+		if err := reflink.Auto(bootstraps[0], mergedBootstrap); err != nil {
+			return errors.Wrap(err, "copy source meta blob to target")
 		}
-		tf.Close()
-	}()
+	} else {
+		tf, err := ioutil.TempFile(mergedDir, "merging-stargz")
+		if err != nil {
+			return errors.Wrap(err, "create temp file for merging stargz layers")
+		}
+		defer func() {
+			if err != nil {
+				os.Remove(tf.Name())
+			}
+			tf.Close()
+		}()
 
-	options := []string{
-		"merge",
-		"--bootstrap", tf.Name(),
-	}
-	options = append(options, bootstraps...)
-	cmd := exec.Command(fs.nydusImageBinaryPath, options...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	log.G(ctx).Infof("nydus image command %v", options)
-	err = cmd.Run()
-	if err != nil {
-		return errors.Wrap(err, "merging stargz layers")
-	}
+		options := []string{
+			"merge",
+			"--bootstrap", tf.Name(),
+		}
+		options = append(options, bootstraps...)
+		cmd := exec.Command(fs.nydusImageBinaryPath, options...)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		log.G(ctx).Infof("nydus image command %v", options)
+		err = cmd.Run()
+		if err != nil {
+			return errors.Wrap(err, "merging stargz layers")
+		}
 
-	err = os.Rename(tf.Name(), mergedBootstrap)
-	if err != nil {
-		return errors.Wrap(err, "rename merged stargz layers")
+		err = os.Rename(tf.Name(), mergedBootstrap)
+		if err != nil {
+			return errors.Wrap(err, "rename merged stargz layers")
+		}
+		os.Chmod(mergedBootstrap, 0440)
 	}
-	os.Chmod(mergedBootstrap, 0440)
 
 	return nil
 }


### PR DESCRIPTION
Optimize handling of stargz images by:
1) use reflink copy when possible to copy blob.meta files.
2) avoid merging stargz layers when there's only one layer.