### PR TITLE
enhance how nydusd's log are logged and redirected

### DIFF
--- a/misc/snapshotter/nydus-snapshotter.fscache.service
+++ b/misc/snapshotter/nydus-snapshotter.fscache.service
@@ -11,6 +11,8 @@ Restart=always
 RestartSec=1
 KillMode=process
 OOMScoreAdjust=-999
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/misc/snapshotter/nydus-snapshotter.fusedev.service
+++ b/misc/snapshotter/nydus-snapshotter.fusedev.service
@@ -11,6 +11,8 @@ Restart=always
 RestartSec=1
 KillMode=process
 OOMScoreAdjust=-999
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -184,10 +184,11 @@ func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 	log.L.Infof("start nydus daemon: %s %s", m.nydusdBinaryPath, strings.Join(args, " "))
 
 	cmd := exec.Command(m.nydusdBinaryPath, args...)
-	if d.LogToStdout {
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stdout
-	}
+	// nydusd standard output and standard error rather than its logs are
+	// always redirected to snapshotter's respectively
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
 	return cmd, nil
 }
 


### PR DESCRIPTION
If nydusd does not make to reach logging setup when starting, it can not log any errors to its logger.
At present, nydusd's stderr is only redirected to snapshotter with `--log-to-stdout` enabled. But the option 
should only control nydusd's logs rather than its stderr and stdout.

This helps us with analyzing  failed started container