### PR TITLE
remove nydusd daemon mode fuse when starting

### DIFF
--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -147,7 +147,7 @@ func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 			args = append(args, "--fscache-threads", nydusdThreadNum)
 		}
 	} else {
-		args = []string{"fuse"}
+		args = []string{}
 		nydusdThreadNum := d.NydusdThreadNum()
 		if nydusdThreadNum != "" {
 			args = append(args, "--thread-num", nydusdThreadNum)


### PR DESCRIPTION
`fuse` subcommand is not compatible with old nydusd.
So remove it and new nydusd can use fuse as default mode.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>