### PR TITLE
Fix BlobMgr Remove

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           # start nydus-snapshotter
           docker run -d --name snapshotter --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e BACKEND_TYPE=localfs -e CONTAINERD_ROOT=/var/lib/containerd-test -v /var/lib/containerd-test:/var/lib/containerd-test:shared -v ~/.docker/config.json:/root/.docker/config.json:shared ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-snapshotter:local
+          docker_snapshotter=$(docker ps -q)
           # start containerd
           sudo /usr/local/bin/containerd --config /etc/containerd/containerd-test-config.toml -l debug &
           # wait for containerd to start up
@@ -133,6 +134,10 @@ jobs:
           sudo crictl exec $container ls
           echo "delete pod"
           sudo crictl rmp -fa
+          echo "delete nydus-latest image"
+          sudo crictl rmi ghcr.io/dragonflyoss/image-service/ubuntu:nydus-latest
+          echo "check whether the blobs of nydus-latest image has been deleted"
+          docker exec -i $docker_snapshotter sh -c 'if [ "`ls -A /tmp/blobs/`" != "" ]; then exit 1; fi'
       - name: Cleanup containerd and snapshotter
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -9,7 +9,7 @@ RUN mv nydus-static/* /; mv nydusd-fusedev nydusd
 FROM ubuntu:20.04
 
 WORKDIR /root/
-RUN mkdir -p /usr/local/bin/ /etc/nydus/ /var/lib/nydus/cache/
+RUN mkdir -p /usr/local/bin/ /etc/nydus/ /var/lib/nydus/cache/ /tmp/blobs/
 COPY --from=sourcer /nydusd /nydus-image /usr/local/bin/
 COPY containerd-nydus-grpc /usr/local/bin/
 COPY nydusd-config.fusedev.json /etc/nydus/config.json

--- a/misc/snapshotter/nydusd-config-localfs.json
+++ b/misc/snapshotter/nydusd-config-localfs.json
@@ -3,7 +3,7 @@
       "backend": {
         "type": "localfs",
         "config": {
-            "dir": "/tmp/"
+            "dir": "/tmp/blobs/"
         }
       },
       "cache": {

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -144,11 +144,11 @@ func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (*Filesystem, error) {
 	return &fs, nil
 }
 
-func (fs *Filesystem) CleanupBlobLayer(ctx context.Context, key string, async bool) error {
+func (fs *Filesystem) CleanupBlobLayer(ctx context.Context, blobDigest string, async bool) error {
 	if fs.blobMgr == nil {
 		return nil
 	}
-	return fs.blobMgr.Remove(key, async)
+	return fs.blobMgr.Remove(blobDigest, async)
 }
 
 func (fs *Filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error {


### PR DESCRIPTION
Previously in the localfs backend mode, when blobMgr delete the blob
corresponding to the snapshot, it mistakenly used the key (chainID)
issued by containerd as the blob digest, resulting in only the first
layer of blob being deleted.
Now
1. For the scenario of converting OCI to Nydus image, get the blob
digest, in fact the snapshot key by label NydusDataLayer, the kv pair
(NydusDataLayer --> snapshot key) has been set after the convert.
2. For the scenario of full download of nydus image, get the correct
blob digest by label CRILayerDigest.

Signed-off-by: zhaoshang <zhaoshangsjtu@linux.alibaba.com>