### PR TITLE
typical nydusd/rafs configuration file

### DIFF
--- a/misc/snapshotter/nydusd-config.fusedev.json
+++ b/misc/snapshotter/nydusd-config.fusedev.json
@@ -22,7 +22,8 @@
   "enable_xattr": true,
   "fs_prefetch": {
     "enable": true,
-    "threads_count": 2,
+    "threads_count": 8,
+    "merging_size": 1048576,
     "prefetch_all": true
   }
 }


### PR DESCRIPTION
Change typical prefetch threads to 8 and merging size to 1048576

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>