### PR TITLE
Revert "remove nydusd daemon mode fuse when starting"

### DIFF
--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -147,7 +147,7 @@ func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 			args = append(args, "--fscache-threads", nydusdThreadNum)
 		}
 	} else {
-		args = []string{}
+		args = []string{"fuse"}
 		nydusdThreadNum := d.NydusdThreadNum()
 		if nydusdThreadNum != "" {
 			args = append(args, "--thread-num", nydusdThreadNum)


### PR DESCRIPTION
Reverts containerd/nydus-snapshotter#119

`fuse' shouldn't be the default mode. It makes no sense to submit such commit.