### PR TITLE
tests: fix panic for unpack test

### DIFF
--- a/tests/converter_test.go
+++ b/tests/converter_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -73,12 +74,19 @@ func ensureNoFile(t *testing.T, name string) {
 }
 
 func writeFileToTar(t *testing.T, tw *tar.Writer, name string, data string) {
+	u, err := user.Current()
+	require.NoError(t, err)
+	g, err := user.LookupGroupId(u.Uid)
+	require.NoError(t, err)
+
 	hdr := &tar.Header{
-		Name: name,
-		Mode: 0444,
-		Size: int64(len(data)),
+		Name:  name,
+		Mode:  0444,
+		Size:  int64(len(data)),
+		Uname: u.Name,
+		Gname: g.Name,
 	}
-	err := tw.WriteHeader(hdr)
+	err = tw.WriteHeader(hdr)
 	require.NoError(t, err)
 
 	io.Copy(tw, bytes.NewReader([]byte(data)))
@@ -86,12 +94,19 @@ func writeFileToTar(t *testing.T, tw *tar.Writer, name string, data string) {
 }
 
 func writeDirToTar(t *testing.T, tw *tar.Writer, name string) {
+	u, err := user.Current()
+	require.NoError(t, err)
+	g, err := user.LookupGroupId(u.Uid)
+	require.NoError(t, err)
+
 	hdr := &tar.Header{
 		Name:     name,
 		Mode:     0444,
 		Typeflag: tar.TypeDir,
+		Uname:    u.Name,
+		Gname:    g.Name,
 	}
-	err := tw.WriteHeader(hdr)
+	err = tw.WriteHeader(hdr)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Throws a panic like below when run TestUnpack test case:

```
converter_test.go:415:
Error Trace:	converter_test.go:415
Error:      	Not equal:
              expected: "sha256:b4679f7afa21a5513d84ba7d9a6faf2621f101421c830648512cd63475118fa1"
              actual  : "sha256:92ad2fb1075eabd299daa2dbb5e822031c198551fa9cebf29046ed79efa27ce3"

              Diff:
              --- Expected
              +++ Actual
              @@ -1,2 +1,2 @@
              -(digest.Digest) (len=71) "sha256:b4679f7afa21a5513d84ba7d9a6faf2621f101421c830648512cd63475118fa1"
              +(digest.Digest) (len=71) "sha256:92ad2fb1075eabd299daa2dbb5e822031c198551fa9cebf29046ed79efa27ce3"

Test:       	TestUnpack
```

Related: https://github.com/dragonflyoss/image-service/pull/630

To make the unpacked tar consistent with the OCI-formatted tar before the pack,
we need to backfill the username and groupname in the tar header, which may
break the repeatable build when unpacking in different hosts, but actually has
little effect.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>