### PR TITLE
add a flag to control whether enable kubeconfig keychain

### DIFF
--- a/cmd/containerd-nydus-grpc/app/snapshotter/main.go
+++ b/cmd/containerd-nydus-grpc/app/snapshotter/main.go
@@ -29,6 +29,10 @@ func Start(ctx context.Context, cfg config.Config) error {
 	opt := ServeOptions{
 		ListeningSocketPath: cfg.Address,
 	}
-	auth.InitKubeSecretListener(ctx, cfg.KubeconfigPath)
+
+	if cfg.EnableKubeconfigKeychain {
+		auth.InitKubeSecretListener(ctx, cfg.KubeconfigPath)
+	}
+
 	return Serve(ctx, rs, opt, stopSignal)
 }

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -27,31 +27,32 @@ const (
 )
 
 type Args struct {
-	Address              string
-	LogLevel             string
-	LogDir               string
-	ConfigPath           string
-	RootDir              string
-	CacheDir             string
-	GCPeriod             string
-	ValidateSignature    bool
-	PublicKeyFile        string
-	ConvertVpcRegistry   bool
-	NydusdBinaryPath     string
-	NydusImageBinaryPath string
-	SharedDaemon         bool
-	DaemonMode           string
-	FsDriver             string
-	SyncRemove           bool
-	EnableMetrics        bool
-	MetricsFile          string
-	EnableStargz         bool
-	DisableCacheManager  bool
-	LogToStdout          bool
-	EnableNydusOverlayFS bool
-	NydusdThreadNum      int
-	CleanupOnClose       bool
-	KubeconfigPath       string
+	Address                  string
+	LogLevel                 string
+	LogDir                   string
+	ConfigPath               string
+	RootDir                  string
+	CacheDir                 string
+	GCPeriod                 string
+	ValidateSignature        bool
+	PublicKeyFile            string
+	ConvertVpcRegistry       bool
+	NydusdBinaryPath         string
+	NydusImageBinaryPath     string
+	SharedDaemon             bool
+	DaemonMode               string
+	FsDriver                 string
+	SyncRemove               bool
+	EnableMetrics            bool
+	MetricsFile              string
+	EnableStargz             bool
+	DisableCacheManager      bool
+	LogToStdout              bool
+	EnableNydusOverlayFS     bool
+	NydusdThreadNum          int
+	CleanupOnClose           bool
+	KubeconfigPath           string
+	EnableKubeconfigKeychain bool
 }
 
 type Flags struct {
@@ -209,6 +210,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "path to the kubeconfig file",
 			Destination: &args.KubeconfigPath,
 		},
+		&cli.BoolFlag{
+			Name:        "enable-kubeconfig-keychain",
+			Value:       false,
+			Usage:       "synchronize `kubernetes.io/dockerconfigjson` secret from kubernetes API server with provided `--kubeconfig-path` (default `$KUBECONFIG` or `~/.kube/config`)",
+			Destination: &args.EnableKubeconfigKeychain,
+		},
 	}
 }
 
@@ -284,5 +291,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.NydusdThreadNum = args.NydusdThreadNum
 	cfg.SyncRemove = args.SyncRemove
 	cfg.KubeconfigPath = args.KubeconfigPath
+	cfg.EnableKubeconfigKeychain = args.EnableKubeconfigKeychain
+
 	return cfg.SetupNydusBinaryPaths()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -35,31 +35,32 @@ const (
 )
 
 type Config struct {
-	Address              string        `toml:"-"`
-	ConvertVpcRegistry   bool          `toml:"-"`
-	DaemonCfgPath        string        `toml:"daemon_cfg_path"`
-	DaemonCfg            DaemonConfig  `toml:"-"`
-	PublicKeyFile        string        `toml:"-"`
-	RootDir              string        `toml:"-"`
-	CacheDir             string        `toml:"cache_dir"`
-	GCPeriod             time.Duration `toml:"gc_period"`
-	ValidateSignature    bool          `toml:"validate_signature"`
-	NydusdBinaryPath     string        `toml:"nydusd_binary_path"`
-	NydusImageBinaryPath string        `toml:"nydus_image_binary"`
-	DaemonMode           string        `toml:"daemon_mode"`
-	FsDriver             string        `toml:"daemon_backend"`
-	SyncRemove           bool          `toml:"sync_remove"`
-	EnableMetrics        bool          `toml:"enable_metrics"`
-	MetricsFile          string        `toml:"metrics_file"`
-	EnableStargz         bool          `toml:"enable_stargz"`
-	LogLevel             string        `toml:"-"`
-	LogDir               string        `toml:"log_dir"`
-	LogToStdout          bool          `toml:"log_to_stdout"`
-	DisableCacheManager  bool          `toml:"disable_cache_manager"`
-	EnableNydusOverlayFS bool          `toml:"enable_nydus_overlayfs"`
-	NydusdThreadNum      int           `toml:"nydusd_thread_num"`
-	CleanupOnClose       bool          `toml:"cleanup_on_close"`
-	KubeconfigPath       string        `toml:"kubeconfig_path"`
+	Address                  string        `toml:"-"`
+	ConvertVpcRegistry       bool          `toml:"-"`
+	DaemonCfgPath            string        `toml:"daemon_cfg_path"`
+	DaemonCfg                DaemonConfig  `toml:"-"`
+	PublicKeyFile            string        `toml:"-"`
+	RootDir                  string        `toml:"-"`
+	CacheDir                 string        `toml:"cache_dir"`
+	GCPeriod                 time.Duration `toml:"gc_period"`
+	ValidateSignature        bool          `toml:"validate_signature"`
+	NydusdBinaryPath         string        `toml:"nydusd_binary_path"`
+	NydusImageBinaryPath     string        `toml:"nydus_image_binary"`
+	DaemonMode               string        `toml:"daemon_mode"`
+	FsDriver                 string        `toml:"daemon_backend"`
+	SyncRemove               bool          `toml:"sync_remove"`
+	EnableMetrics            bool          `toml:"enable_metrics"`
+	MetricsFile              string        `toml:"metrics_file"`
+	EnableStargz             bool          `toml:"enable_stargz"`
+	LogLevel                 string        `toml:"-"`
+	LogDir                   string        `toml:"log_dir"`
+	LogToStdout              bool          `toml:"log_to_stdout"`
+	DisableCacheManager      bool          `toml:"disable_cache_manager"`
+	EnableNydusOverlayFS     bool          `toml:"enable_nydus_overlayfs"`
+	NydusdThreadNum          int           `toml:"nydusd_thread_num"`
+	CleanupOnClose           bool          `toml:"cleanup_on_close"`
+	KubeconfigPath           string        `toml:"kubeconfig_path"`
+	EnableKubeconfigKeychain bool          `toml:"enable_kubeconfig_keychain"`
 }
 
 func (c *Config) FillupWithDefaults() error {

--- a/pkg/auth/keychain.go
+++ b/pkg/auth/keychain.go
@@ -61,7 +61,7 @@ func (kc PassKeyChain) TokenBase() bool {
 }
 
 // FromLabels finds image pull username and secret from snapshot labels.
-// Returned `nil` means no validated username and secrect are passed, it should
+// Returned `nil` means no valid username and secret is passed, it should
 // not override input nydusd configuration.
 func FromLabels(labels map[string]string) *PassKeyChain {
 	u, found := labels[label.NydusImagePullUsername]


### PR DESCRIPTION
If node has no kubelet deployed, listener will report warning forver:

E0815 10:37:46.330502 1446182 reflector.go:138] pkg/mod/k8s.io/client-go@v0.22.5/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: Get "https://127.0.0.1:27949/api/v1/secrets?fieldSelector=type%3Dkubernetes.io%2Fdockerconfigjson&limit=500&resourceVersion=0": dial tcp 127.0.0.1:27949: connect: connection refused
E0815 10:38:30.398522 1446182 reflector.go:138] pkg/mod/k8s.io/client-go@v0.22.5/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: Get "https://127.0.0.1:27949/api/v1/secrets?fieldSelector=type%3Dkubernetes.io%2Fdockerconfigjson&limit=500&resourceVersion=0": dial tcp 127.0.0.1:27949: connect: connection refused
E0815 10:39:08.890713 1446182 reflector.go:138] pkg/mod/k8s.io/client-go@v0.22.5/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: Get "https://127.0.0.1:27949/api/v1/secrets?fieldSelector=type%3Dkubernetes.io%2Fdockerconfigjson&limit=500&resourceVersion=0": dial tcp 127.0.0.1:27949: connect: connection refused

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>