### PR TITLE
clean up and fix how nydus-snapshotter prepares mountpoints for nydusd

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -77,6 +77,8 @@ func WithLogLevel(logLevel string) NewDaemonOpt {
 	}
 }
 
+// In Shared mode, it is the mountpoint where single nydusd mounts fusedev. It has nothing
+// with fscache driver.
 func WithRootMountPoint(rootMountPoint string) NewDaemonOpt {
 	return func(d *Daemon) error {
 		if err := os.MkdirAll(rootMountPoint, 0755); err != nil {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -77,8 +77,7 @@ func WithLogLevel(logLevel string) NewDaemonOpt {
 	}
 }
 
-// In Shared mode, it is the mountpoint where single nydusd mounts fusedev. It has nothing
-// with fscache driver.
+// In Shared mode, it is the mountpoint where single nydusd mounts
 func WithRootMountPoint(rootMountPoint string) NewDaemonOpt {
 	return func(d *Daemon) error {
 		if err := os.MkdirAll(rootMountPoint, 0755); err != nil {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -67,16 +67,17 @@ func (d *Daemon) SharedAbsMountPoint() string {
 	return filepath.Join(*d.RootMountPoint, d.SharedMountPoint())
 }
 
+// Mountpoint of per-image nydusd/rafs. It is a kernel mountpoint for each
+// nydus meta layer. Each meta layer is associated with a nydusd.
 func (d *Daemon) MountPoint() string {
-	if d.RootMountPoint != nil {
-		return filepath.Join("/", d.SnapshotID, "fs")
-	}
 	if d.CustomMountPoint != nil {
 		return *d.CustomMountPoint
 	}
-	return filepath.Join(d.SnapshotDir, d.SnapshotID, "fs")
+
+	return filepath.Join(d.SnapshotDir, d.SnapshotID, "mnt")
 }
 
+// Keep this for backwards compatibility
 func (d *Daemon) OldMountPoint() string {
 	return filepath.Join(d.SnapshotDir, d.SnapshotID, "fs")
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -187,7 +187,7 @@ func (d *Daemon) sharedErofsMount() error {
 		return errors.Wrapf(err, "request to bind fscache blob")
 	}
 
-	mountPoint := d.SharedMountPoint()
+	mountPoint := d.MountPoint()
 	if err := os.MkdirAll(mountPoint, 0755); err != nil {
 		return errors.Wrapf(err, "failed to create mount dir %s", mountPoint)
 	}
@@ -221,7 +221,7 @@ func (d *Daemon) sharedErofsUmount() error {
 		return errors.Wrapf(err, "request to unbind fscache blob")
 	}
 
-	mountPoint := d.SharedMountPoint()
+	mountPoint := d.MountPoint()
 	if err := erofs.Umount(mountPoint); err != nil {
 		return errors.Wrapf(err, "umount erofs")
 	}

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -587,6 +587,12 @@ func (fs *Filesystem) MountPoint(snapshotID string) (string, error) {
 	}
 
 	if d, err := fs.manager.GetBySnapshotID(snapshotID); err == nil {
+		// Working for fscache driver, only one nydusd with multiple mountpoints.
+		// So it is not ordinary SharedMode.
+		if d.FsDriver == config.FsDriverFscache {
+			return d.MountPoint(), nil
+		}
+
 		if fs.mode == SharedInstance {
 			return d.SharedMountPoint(), nil
 		}

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -594,8 +594,9 @@ func (fs *Filesystem) MountPoint(snapshotID string) (string, error) {
 		}
 
 		if fs.mode == SharedInstance {
-			return d.SharedMountPoint(), nil
+			return d.SharedAbsMountPoint(), nil
 		}
+
 		return d.MountPoint(), nil
 	}
 	return "", fmt.Errorf("failed to find nydus mountpoint of snapshot %s", snapshotID)

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -62,9 +62,15 @@ var nativeEndian binary.ByteOrder
 type Mode int
 
 const (
+	// A single nydusd serves all container images
 	SharedInstance Mode = iota
+	// One container image one nydusd topology
 	MultiInstance
+	// Nydusd is not needed to work as FUSE server (fusedev) or other fs drivers,
+	// just provide the mount slices to containerd, and do real mount by other components
 	NoneInstance
+	// Nydusd does not fulfill any lazy-load (on-daemon) ability but only
+	// prefetches image data into local blob cache for other components
 	PrefetchInstance
 )
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -479,11 +479,15 @@ func (o *snapshotter) Close() error {
 }
 
 func (o *snapshotter) upperPath(id string) string {
+	return filepath.Join(o.root, "snapshots", id, "fs")
+}
+
+func (o *snapshotter) lowerPath(id string) string {
 	if mnt, err := o.fs.MountPoint(id); err == nil {
 		return mnt
 	}
 
-	return filepath.Join(o.root, "snapshots", id, "fs")
+	return ""
 }
 
 func (o *snapshotter) workPath(id string) string {
@@ -604,7 +608,7 @@ func (o *snapshotter) remoteMounts(ctx context.Context, s storage.Snapshot, id s
 		return bindMount(o.upperPath(s.ParentIDs[0])), nil
 	}
 
-	lowerDirOption := fmt.Sprintf("lowerdir=%s", o.upperPath(id))
+	lowerDirOption := fmt.Sprintf("lowerdir=%s", o.lowerPath(id))
 	overlayOptions = append(overlayOptions, lowerDirOption)
 
 	// when hasDaemon and not enableNydusOverlayFS, return overlayfs mount slice

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -299,7 +299,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 				}
 			}
 
-			logCtx.Infof("found nydus meta layer id %s, parpare remote snapshot", id)
+			logCtx.Infof("found nydus meta layer id %s, prepare remote snapshot", id)
 
 			if err := o.fs.AddSnapshot(info.Labels); err != nil {
 				return nil, errors.Wrap(err, "cache manager failed to add snapshot")


### PR DESCRIPTION
1. Erofs/fscache can't work in ordinary SharedMount mode since each erofs has a seperated mountpoint while shareMode means one nydusd one mountpoint.
2. rafs as lowerdir and read-only underlying FS should be mounted at `/mnt`. `fs` is used to store bootstrap for meta layer and writeable for Active snapshot
3. `fs` has permission 0700, which causes other user in the container can't read /bin dir