### PR TITLE
Change upperPath permission from 0750 to 0755

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -747,7 +747,7 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}
 
-	if err := os.Mkdir(filepath.Join(td, "fs"), 0750); err != nil {
+	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
 		return td, err
 	}
 


### PR DESCRIPTION
The user of ctr/nerdctl may be different from the user of nydus snapshotter.
In order to allow users of ctr and nerdctl to access rootfs, other group permissions need to be given here,
and the default permission of overlayfs is also 0755

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba-inc.com>