### PR TITLE
Make current machine's arch as defaulted GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_EXECUTABLE_PATH ?= $(shell which go)
 NYDUS_BUILDER ?= /usr/bin/nydus-image
 NYDUS_NYDUSD ?= /usr/bin/nydusd-fusedev
 GOOS ?= linux
-GOARCH ?= amd64
+GOARCH ?= $(shell go env GOARCH)
 #GOPROXY ?= https://goproxy.io
 
 ifdef GOPROXY


### PR DESCRIPTION
When building on arm64 machine, don't build amd64 as default GOARCH.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>