### PR TITLE
clean up nydus vestige when starting

### DIFF
--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -42,7 +42,7 @@ func main() {
 				RotateLogCompress:   cfg.RotateLogCompress,
 			}
 			if err := logging.SetUp(flags.Args.LogLevel, flags.Args.LogToStdout, flags.Args.LogDir, flags.Args.RootDir, logRotateArgs); err != nil {
-				return errors.Wrap(err, "failed to prepare logger")
+				return errors.Wrap(err, "failed to set up logger")
 			}
 
 			return snapshotter.Start(ctx, cfg)
@@ -50,9 +50,9 @@ func main() {
 	}
 	if err := app.Run(os.Args); err != nil {
 		if errdefs.IsConnectionClosed(err) {
-			log.L.Info("nydus snapshotter exited")
+			log.L.Info("nydus-snapshotter exited")
 		} else {
-			log.L.WithError(err).Fatal("failed to start nydus snapshotter:\n\r")
+			log.L.WithError(err).Fatal("failed to start nydus-snapshotter")
 		}
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -288,7 +288,7 @@ func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 }
 
 func GetBootstrapFile(dir, id string) (string, error) {
-	// meta files are stored at <snapshotid>/image/image.boot
+	// meta files are stored at <snapshot_id>/fs/image/image.boot
 	bootstrap := filepath.Join(dir, id, "fs", "image", "image.boot")
 	_, err := os.Stat(bootstrap)
 	if err == nil {


### PR DESCRIPTION
Nydusd judges if it should enter failover phrase by
checking residual disconnected unix socket file and mounted
mountpoint. But if snapshotter is restarting, nydusd can't fetch
back its states. So just start a fresh nydusd


Addressing #142 

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>