### PR TITLE
converter: fix incorrect blob list from merge

### DIFF
--- a/tests/converter_test.go
+++ b/tests/converter_test.go
@@ -324,8 +324,9 @@ func buildChunkDict(t *testing.T, workDir string) (string, string) {
 	require.NoError(t, err)
 	defer file.Close()
 
-	err = converter.Merge(context.TODO(), layers, file, converter.MergeOption{})
+	blobDigests, err := converter.Merge(context.TODO(), layers, file, converter.MergeOption{})
 	require.NoError(t, err)
+	require.Equal(t, []digest.Digest{lowerNydusBlobDigest}, blobDigests)
 
 	dictBlobPath := ""
 	err = filepath.WalkDir(blobDir, func(path string, entry fs.DirEntry, err error) error {
@@ -391,10 +392,12 @@ func TestConverter(t *testing.T) {
 	require.NoError(t, err)
 	defer file.Close()
 
-	err = converter.Merge(context.TODO(), layers, file, converter.MergeOption{
+	blobDigests, err := converter.Merge(context.TODO(), layers, file, converter.MergeOption{
 		ChunkDictPath: chunkDictBootstrapPath,
 	})
 	require.NoError(t, err)
+	expectedBlobDigests := []digest.Digest{digest.NewDigestFromHex(string(digest.SHA256), chunkDictBlobHash), upperNydusBlobDigest}
+	require.Equal(t, expectedBlobDigests, blobDigests)
 
 	verify(t, workDir)
 	dropCache(t)


### PR DESCRIPTION
Affected by chunk dict, the blob list referenced by final bootstrap
are from different layers, part of them are from original layers,
part from chunk dict bootstrap.

So we need to rewrite manifest's layers using the real blob list
referenced by final bootstrap.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>