### PR TITLE
Enhance daemon states management to improve usability and stability

### DIFF
--- a/integration/entrypoint.sh
+++ b/integration/entrypoint.sh
@@ -207,6 +207,9 @@ function pull_reomve_multiple_images {
     nerdctl --snapshotter nydus image rm "${TOMCAT_IMAGE}"
     nerdctl --snapshotter nydus image rm "${JAVA_IMAGE}"
     nerdctl --snapshotter nydus image rm "${WORDPRESS_IMAGE}"
+
+    # TODO: Validate running nydusd number
+
 }
 
 function start_multiple_containers_shared_daemon_erofs {

--- a/integration/entrypoint.sh
+++ b/integration/entrypoint.sh
@@ -176,6 +176,12 @@ function start_multiple_containers_multiple_daemons {
     nerdctl --snapshotter nydus run -d --net none "${JAVA_IMAGE}"
     nerdctl --snapshotter nydus run -d --net none "${WORDPRESS_IMAGE}"
     nerdctl --snapshotter nydus run -d --net none "${TOMCAT_IMAGE}"
+
+    nerdctl_prune_images
+
+    nerdctl --snapshotter nydus run -d --net none "${TOMCAT_IMAGE}"
+    nerdctl --snapshotter nydus run -d --net none "${JAVA_IMAGE}"
+    nerdctl --snapshotter nydus run -d --net none "${WORDPRESS_IMAGE}"
 }
 
 function start_multiple_containers_shared_daemon {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -53,6 +53,8 @@ type Daemon struct {
 	// Client will be rebuilt on Reconnect, skip marshal/unmarshal
 	Client nydussdk.Interface `json:"-"`
 	Once   *sync.Once         `json:"-"`
+	// It should only be used to distinguish daemons that needs to be startedwhen restarting nydus-snapshotter
+	Connected bool `json:"-"`
 }
 
 // Mountpoint for nydusd within single kernel mountpoint(FUSE mount). Each mountpoint

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -31,6 +31,7 @@ const (
 
 type NewDaemonOpt func(d *Daemon) error
 
+// TODO: Record queried nydusd state
 type Daemon struct {
 	ID               string
 	SnapshotID       string

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -53,7 +53,7 @@ type Daemon struct {
 	// Client will be rebuilt on Reconnect, skip marshal/unmarshal
 	Client nydussdk.Interface `json:"-"`
 	Once   *sync.Once         `json:"-"`
-	// It should only be used to distinguish daemons that needs to be startedwhen restarting nydus-snapshotter
+	// It should only be used to distinguish daemons that needs to be started when restarting nydus-snapshotter
 	Connected bool `json:"-"`
 }
 

--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -19,11 +19,17 @@ const signalKilled = "signal: killed"
 
 var (
 	ErrAlreadyExists = errors.New("already exists")
+	ErrNotFound      = errors.New("not found")
 )
 
 // IsAlreadyExists returns true if the error is due to already exists
 func IsAlreadyExists(err error) bool {
 	return errors.Is(err, ErrAlreadyExists)
+}
+
+// IsNotFound returns true if the error is due to a missing object
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound)
 }
 
 // IsSignalKilled returns true if the error is signal killed

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -165,6 +165,8 @@ func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (*Filesystem, error) {
 						return nil, errors.Errorf("failed to mount rafs when recovering, %v", err)
 					}
 				}
+			} else {
+				fs.manager.StartDaemon(d)
 			}
 		}
 	}

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -109,7 +109,7 @@ func (s *DaemonStates) RecoverDaemonState(d *daemon.Daemon) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.L.Errorf("Recovering snapshot ID %s daemon ID %s", d.SnapshotID, d.ID)
+	log.L.Infof("Recovering snapshot ID %s daemon ID %s", d.SnapshotID, d.ID)
 
 	s.daemons = append(s.daemons, d)
 	s.idxBySnapshotID[d.SnapshotID] = d

--- a/pkg/process/store.go
+++ b/pkg/process/store.go
@@ -13,14 +13,13 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/store"
 )
 
+// Nydus daemons and snapshots persistence storage.
 type Store interface {
-	Get(id string) (*daemon.Daemon, error)
-	GetBySnapshot(snapshotID string) (*daemon.Daemon, error)
+	GetByDaemonID(id string) (*daemon.Daemon, error)
+	GetBySnapshotID(snapshotID string) (*daemon.Daemon, error)
 	Add(*daemon.Daemon) error
 	Update(d *daemon.Daemon) error
 	Delete(*daemon.Daemon) error
-	List() []*daemon.Daemon
-	Size() int
 	WalkDaemons(ctx context.Context, cb func(*daemon.Daemon) error) error
 	CleanupDaemons(ctx context.Context) error
 }

--- a/pkg/store/daemonstore.go
+++ b/pkg/store/daemonstore.go
@@ -8,114 +8,44 @@ package store
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"sync"
 
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 )
 
 type DaemonStore struct {
-	sync.Mutex
-	idxBySnapshotID map[string]*daemon.Daemon // index by snapshot ID per image
-	idxByID         map[string]*daemon.Daemon // index by ID per daemon include upgraded daemon
-	daemons         []*daemon.Daemon          // all daemon
-	db              *Database                 // save daemons in database
+	db *Database // save daemons in database
 }
 
 func NewDaemonStore(db *Database) (*DaemonStore, error) {
 	return &DaemonStore{
-		idxBySnapshotID: make(map[string]*daemon.Daemon),
-		idxByID:         make(map[string]*daemon.Daemon),
-		db:              db,
+		db: db,
 	}, nil
 }
 
-func (s *DaemonStore) Get(id string) (*daemon.Daemon, error) {
-	s.Lock()
-	defer s.Unlock()
-	if d, ok := s.idxByID[id]; ok {
-		return d, nil
-	}
-	return nil, os.ErrNotExist
+// Generally, we should directly fetch daemon from upper cache layer.
+// Let's plant a stub here.
+func (s *DaemonStore) GetByDaemonID(id string) (*daemon.Daemon, error) {
+	return nil, nil
 }
 
-func (s *DaemonStore) GetBySnapshot(snapshotID string) (*daemon.Daemon, error) {
-	s.Lock()
-	defer s.Unlock()
-	if d, ok := s.idxBySnapshotID[snapshotID]; ok {
-		return d, nil
-	}
-
-	return nil, os.ErrNotExist
-}
-
-func (s *DaemonStore) List() []*daemon.Daemon {
-	s.Lock()
-	defer s.Unlock()
-	if s.daemons == nil {
-		return nil
-	}
-	res := make([]*daemon.Daemon, len(s.daemons))
-	copy(res, s.daemons)
-	return res
-}
-
-func (s *DaemonStore) Size() int {
-	s.Lock()
-	defer s.Unlock()
-	return len(s.daemons)
+// Generally, we should directly fetch daemon from upper cache layer.
+// Let's plant a stub here.
+func (s *DaemonStore) GetBySnapshotID(snapshotID string) (*daemon.Daemon, error) {
+	return nil, nil
 }
 
 func (s *DaemonStore) Add(d *daemon.Daemon) error {
-	s.Lock()
-	defer s.Unlock()
-
-	if _, ok := s.idxBySnapshotID[d.SnapshotID]; ok {
-		return fmt.Errorf("daemon of snapshotID %s already exists", d.SnapshotID)
-	}
-
-	s.daemons = append(s.daemons, d)
-	s.idxBySnapshotID[d.SnapshotID] = d
-	s.idxByID[d.ID] = d
-
-	// save daemon info in case snapshotter restarts so that we can restore the
-	// daemon structs and reconnect the daemons.
+	// Save daemon info in case snapshotter restarts so that we can restore the
+	// daemon states and reconnect the daemons.
 	return s.db.SaveDaemon(context.TODO(), d)
 }
 
 func (s *DaemonStore) Update(d *daemon.Daemon) error {
-	s.Lock()
-	defer s.Unlock()
-
-	if _, ok := s.idxBySnapshotID[d.SnapshotID]; !ok {
-		return fmt.Errorf("daemon of snapshotID %s not found", d.SnapshotID)
-	}
-
-	// update daemon info in case snapshotter restarts so that we can restore the
-	// daemon structs and reconnect the daemons.
 	return s.db.UpdateDaemon(context.TODO(), d)
 }
 
 func (s *DaemonStore) Delete(d *daemon.Daemon) error {
-	s.Lock()
-	defer s.Unlock()
-	delete(s.idxBySnapshotID, d.SnapshotID)
-	delete(s.idxByID, d.ID)
-	s.daemons = s.filterOutDeletedDaemon(d)
-
 	return s.db.DeleteDaemon(context.TODO(), d.ID)
-}
-
-func (s *DaemonStore) filterOutDeletedDaemon(d *daemon.Daemon) []*daemon.Daemon {
-	res := s.daemons[:0]
-	for _, md := range s.daemons {
-		if md == d {
-			continue
-		}
-		res = append(res, md)
-	}
-	return res
 }
 
 func (s *DaemonStore) WalkDaemons(ctx context.Context, cb func(d *daemon.Daemon) error) error {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -805,7 +805,7 @@ func (o *snapshotter) cleanupDirectories(ctx context.Context) ([]string, error) 
 }
 
 func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) error {
-	// On a remote snapshot, the layer is mounted on the "fs" directory.
+	// On a remote snapshot, the layer is mounted on the "mnt" directory.
 	// We use Filesystem's Unmount API so that it can do necessary finalization
 	// before/after the unmount.
 	log.G(ctx).WithField("dir", dir).Infof("cleanupSnapshotDirectory %s", dir)


### PR DESCRIPTION
Several community users and nydus contributors have complained about nydus-snapshotter's usability and stability.
1. nydusd is not ready so the container image can't be accessed
2. nydus image can't be accessed after rebooting the host

To solve the issues once and for all, this PR refactors nydusd daemons states management. It decouples in-memory states cache from DB persistence storage. Snapshotter never empties the DB when restarting but to rebuild the in-memory daemon states cache to get consistent with DB persistent storage. In addition, it will request API to restarted nydusd daemon to recover the API mounts.

Several E2E cases are accompanied.

Address: https://github.com/containerd/nydus-snapshotter/issues/142 https://github.com/containerd/nydus-snapshotter/issues/125