### PR TITLE
configure prefetch in example fscache nydusd config file

### DIFF
--- a/misc/snapshotter/nydusd-config.fscache.json
+++ b/misc/snapshotter/nydusd-config.fscache.json
@@ -5,6 +5,11 @@
         "backend_config": {
             "scheme": "https"
         },
-        "cache_type": "fscache"
+        "cache_type": "fscache",
+        "prefetch_config": {
+            "enable": true,
+            "threads_count": 8,
+            "merging_size": 1048576
+        }
     }
 }


### PR DESCRIPTION
So nydusd in fscache mode can have a better porformance.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>