### PR TITLE
tidy golangci lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,11 +13,19 @@ linters:
     - vet
     - unused
     - misspell
-  disable:
     - errcheck
+    - bodyclose
+    - cyclop
+    - dogsled
+    - nilnil
+    - unparam
+    - unused
+    - nilerr
+    - goerr113
+  disable:
+    - godox
 
 run:
   deadline: 4m
   skip-dirs:
     - misc
-


### PR DESCRIPTION
As two linters are already deprecated, remove them two In addition, add more useful linters.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>