### PR TITLE
replace deprecated ioutil package

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -8,7 +8,7 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -114,7 +114,7 @@ type DeviceConfig struct {
 }
 
 func LoadConfig(configFile string, cfg *DaemonConfig) error {
-	b, err := ioutil.ReadFile(configFile)
+	b, err := os.ReadFile(configFile)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func SaveConfig(c interface{}, configFile string) error {
 	if err != nil {
 		return nil
 	}
-	return ioutil.WriteFile(configFile, b, 0755)
+	return os.WriteFile(configFile, b, 0755)
 }
 
 func NewDaemonConfig(fsDriver string, cfg DaemonConfig, imageID, snapshotID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {

--- a/pkg/auth/docker_test.go
+++ b/pkg/auth/docker_test.go
@@ -9,7 +9,6 @@ package auth
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,13 +41,13 @@ const (
 var oldDockerConfig = os.Getenv("DOCKER_CONFIG")
 
 func setupDockerConfig() (string, error) {
-	dir, err := ioutil.TempDir("", "testdocker-")
+	dir, err := os.MkdirTemp("", "testdocker-")
 	if err != nil {
 		return "", err
 	}
 	os.Setenv("DOCKER_CONFIG", dir)
 
-	err = ioutil.WriteFile(filepath.Join(dir, configFile),
+	err = os.WriteFile(filepath.Join(dir, configFile),
 		[]byte(fmt.Sprintf(testConfigFmt, dockerHost, base64.StdEncoding.EncodeToString([]byte(dockerUser+":"+dockerPass)),
 			extraHost, base64.StdEncoding.EncodeToString([]byte(extraUser+":"+extraPass)))),
 		0600)

--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -75,7 +74,7 @@ func ensureWorkDir(specifiedBasePath string) (string, error) {
 		return "", errors.Wrapf(err, "create base directory %s", baseWorkDir)
 	}
 
-	workDirPath, err := ioutil.TempDir(baseWorkDir, "nydus-converter-")
+	workDirPath, err := os.MkdirTemp(baseWorkDir, "nydus-converter-")
 	if err != nil {
 		return "", errors.Wrap(err, "create work directory")
 	}

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -194,7 +193,7 @@ func (fs *Filesystem) PrepareBlobLayer(ctx context.Context, snapshot storage.Sna
 	}
 	defer readerCloser.Close()
 
-	blobFile, err := ioutil.TempFile(fs.blobMgr.GetBlobDir(), "downloading-")
+	blobFile, err := os.CreateTemp(fs.blobMgr.GetBlobDir(), "downloading-")
 	if err != nil {
 		return errors.Wrap(err, "create temp file for downloading blob")
 	}
@@ -300,7 +299,7 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 
 	bootstraps := []string{}
 	for idx, snapshotID := range s.ParentIDs {
-		files, err := ioutil.ReadDir(fs.UpperPath(snapshotID))
+		files, err := os.ReadDir(fs.UpperPath(snapshotID))
 		if err != nil {
 			return errors.Wrap(err, "read snapshot dir")
 		}
@@ -343,7 +342,7 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 			return errors.Wrap(err, "copy source meta blob to target")
 		}
 	} else {
-		tf, err := ioutil.TempFile(mergedDir, "merging-stargz")
+		tf, err := os.CreateTemp(mergedDir, "merging-stargz")
 		if err != nil {
 			return errors.Wrap(err, "create temp file for merging stargz layers")
 		}
@@ -421,7 +420,7 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, blob *stargz.B
 		blobMetaPath = filepath.Join(upperPath, fmt.Sprintf("%s.blob.meta", blobID))
 	}
 
-	tf, err := ioutil.TempFile(upperPath, "converting-stargz")
+	tf, err := os.CreateTemp(upperPath, "converting-stargz")
 	if err != nil {
 		return errors.Wrap(err, "create temp file for merging stargz layers")
 	}

--- a/pkg/filesystem/fs/stargz/resolver.go
+++ b/pkg/filesystem/fs/stargz/resolver.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -182,7 +181,7 @@ func (r *Resolver) resolve(ref, digest string, keychain authn.Keychain) (*io.Sec
 			return 0, err
 		}
 		defer func() {
-			io.Copy(ioutil.Discard, res.Body)
+			io.Copy(io.Discard, res.Body)
 			res.Body.Close()
 		}()
 		if res.StatusCode/100 != 2 {
@@ -208,7 +207,7 @@ func getSize(url string, tr http.RoundTripper) (int64, error) {
 		return 0, err
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, res.Body)
+		io.Copy(io.Discard, res.Body)
 		res.Body.Close()
 	}()
 	if res.StatusCode/100 != 2 {

--- a/pkg/filesystem/fs/stargz/resolver_test.go
+++ b/pkg/filesystem/fs/stargz/resolver_test.go
@@ -11,8 +11,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -66,7 +67,7 @@ func (tr *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	if url == "https://example.com/v2/" {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}, nil
 	}
 	if url == "https://example.com/v2/test/myserver/blobs/sha256:mock" {
@@ -75,7 +76,7 @@ func (tr *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		return &http.Response{
 			StatusCode: http.StatusMovedPermanently,
 			Header:     header,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}, nil
 	}
 	if url == "http://oss.com/v2/test/myserver/blobs/sha256:mock" {
@@ -87,22 +88,22 @@ func (tr *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 			return &http.Response{
 				StatusCode: http.StatusPartialContent,
 				Header:     header,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 			}, nil
 		}
 		// get footer
 		if rangeHeader == "bytes=24613139-24613185" {
-			footer, _ := ioutil.ReadFile("testdata/stargzfooter.bin")
+			footer, _ := os.ReadFile("testdata/stargzfooter.bin")
 			return &http.Response{
 				StatusCode: http.StatusPartialContent,
-				Body:       ioutil.NopCloser(bytes.NewReader(footer[:])),
+				Body:       io.NopCloser(bytes.NewReader(footer[:])),
 			}, nil
 		}
 		if rangeHeader == "bytes=24442675-24613138" {
-			toc, _ := ioutil.ReadFile("testdata/stargztoc.bin")
+			toc, _ := os.ReadFile("testdata/stargztoc.bin")
 			return &http.Response{
 				StatusCode: http.StatusPartialContent,
-				Body:       ioutil.NopCloser(bytes.NewReader(toc[:])),
+				Body:       io.NopCloser(bytes.NewReader(toc[:])),
 			}, nil
 		}
 	}

--- a/pkg/nydussdk/client.go
+++ b/pkg/nydussdk/client.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -68,7 +67,7 @@ func (c *NydusClient) CheckStatus() (*model.DaemonInfo, error) {
 		return nil, errors.Wrapf(err, "failed to do HTTP GET from %s", addr)
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read status response")
 	}
@@ -127,7 +126,7 @@ func (c *NydusClient) GetFsMetric(sharedDaemon bool, sid string) (*model.FsMetri
 
 func (c *NydusClient) SharedMount(sharedMountPoint, bootstrap, daemonConfig string) error {
 	requestURL := fmt.Sprintf("http://unix%s?mountpoint=%s", mountEndpoint, sharedMountPoint)
-	content, err := ioutil.ReadFile(daemonConfig)
+	content, err := os.ReadFile(daemonConfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get content of daemon config %s", daemonConfig)
 	}
@@ -149,7 +148,7 @@ func (c *NydusClient) SharedMount(sharedMountPoint, bootstrap, daemonConfig stri
 func (c NydusClient) FscacheBindBlob(daemonConfig string) error {
 	log.L.Infof("requesting daemon to bind fscache blob with config %s", daemonConfig)
 
-	body, err := ioutil.ReadFile(daemonConfig)
+	body, err := os.ReadFile(daemonConfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get content of daemon config %s", daemonConfig)
 	}
@@ -174,7 +173,7 @@ func (c NydusClient) FscacheBindBlob(daemonConfig string) error {
 }
 
 func (c NydusClient) FscacheUnbindBlob(daemonConfig string) error {
-	body, err := ioutil.ReadFile(daemonConfig)
+	body, err := os.ReadFile(daemonConfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get content of daemon config %s", daemonConfig)
 	}
@@ -234,7 +233,7 @@ func buildTransport(sock string) (http.RoundTripper, error) {
 
 func handleMountError(resp *http.Response) error {
 	var r io.Reader = resp.Body
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return errors.Wrap(err, "failed to read from reader")
 	}

--- a/pkg/signature/signature.go
+++ b/pkg/signature/signature.go
@@ -9,7 +9,6 @@ package signature
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -36,7 +35,7 @@ func NewVerifier(publicKeyFile string, validateSignature bool) (*Verifier, error
 	if _, err := os.Stat(publicKeyFile); err != nil {
 		return nil, fmt.Errorf("failed to find publicKeyFile %q", publicKeyFile)
 	}
-	publicKeyByte, err := ioutil.ReadFile(publicKeyFile)
+	publicKeyByte, err := os.ReadFile(publicKeyFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read from publicKeyFile %q", publicKeyFile)
 	}

--- a/pkg/utils/transport/pool.go
+++ b/pkg/utils/transport/pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
@@ -82,7 +81,7 @@ func redirect(endpointURL string, tr http.RoundTripper) (url string, err error) 
 		return "", errors.Wrapf(err, "failed to request to %q", endpointURL)
 	}
 	defer func() {
-		_, err := io.Copy(ioutil.Discard, res.Body)
+		_, err := io.Copy(io.Discard, res.Body)
 		log.L.Warnf("Discard body failed %s", err)
 		res.Body.Close()
 	}()

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -747,7 +746,7 @@ func (o *snapshotter) mounts(ctx context.Context, info *snapshots.Info, s storag
 }
 
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
-	td, err := ioutil.TempDir(snapshotDir, "new-")
+	td, err := os.MkdirTemp(snapshotDir, "new-")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}

--- a/tests/converter_test.go
+++ b/tests/converter_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -292,7 +291,7 @@ func verify(t *testing.T, workDir string) {
 			file, err := os.Open(path)
 			require.NoError(t, err)
 			defer file.Close()
-			_data, err := ioutil.ReadAll(file)
+			_data, err := io.ReadAll(file)
 			require.NoError(t, err)
 			data = string(_data)
 		}
@@ -345,7 +344,7 @@ func buildChunkDict(t *testing.T, workDir string) (string, string) {
 
 // sudo go test -v -count=1 -run TestConverter ./pkg/nydusify
 func TestConverter(t *testing.T) {
-	workDir, err := ioutil.TempDir("", "nydus-converter-test-")
+	workDir, err := os.MkdirTemp("", "nydus-converter-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 
@@ -408,7 +407,7 @@ func TestConverter(t *testing.T) {
 }
 
 func TestUnpack(t *testing.T) {
-	workDir, err := ioutil.TempDir("", "nydus-converter-test-")
+	workDir, err := os.MkdirTemp("", "nydus-converter-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 

--- a/tests/nydusd.go
+++ b/tests/nydusd.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -86,7 +86,7 @@ func makeConfig(conf NydusdConfig) error {
 		return errors.New("prepare config template for Nydusd")
 	}
 
-	if err := ioutil.WriteFile(conf.ConfigPath, ret.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(conf.ConfigPath, ret.Bytes(), 0644); err != nil {
 		return errors.New("write config file for Nydusd")
 	}
 
@@ -129,7 +129,7 @@ func checkReady(ctx context.Context, sock string) (<-chan bool, error) {
 			}
 			defer resp.Body.Close()
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
golangci-lint run
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. pkg/signature/signature.go:12:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
pkg/filesystem/fs/fs.go:15:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
pkg/converter/convert_unix.go:19:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
make: *** [Makefile:52: check] Error 1

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>