### PR TITLE
Introduce daemons liveness monitor

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -60,6 +60,7 @@ type Args struct {
 	CleanupOnClose           bool
 	KubeconfigPath           string
 	EnableKubeconfigKeychain bool
+	RecoverPolicy            string
 }
 
 type Flags struct {
@@ -201,6 +202,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "Deprecated, equivalent to \"--daemon-mode shared\"",
 			Destination: &args.SharedDaemon,
 		},
+		&cli.StringFlag{
+			Name:        "recover-policy",
+			Usage:       "Policy on recovering nydus filesystem service [none, restart, failover], default to none",
+			Destination: &args.RecoverPolicy,
+			Value:       "restart",
+		},
 		&cli.BoolFlag{
 			Name:        "sync-remove",
 			Usage:       "whether to clean up snapshots in synchronous mode, default to asynchronous mode",
@@ -312,6 +319,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.SyncRemove = args.SyncRemove
 	cfg.KubeconfigPath = args.KubeconfigPath
 	cfg.EnableKubeconfigKeychain = args.EnableKubeconfigKeychain
+	cfg.RecoverPolicy = args.RecoverPolicy
 
 	return cfg.SetupNydusBinaryPaths()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	RotateLogMaxAge          int           `toml:"log_rotate_max_age"`
 	RotateLogLocalTime       bool          `toml:"log_rotate_local_time"`
 	RotateLogCompress        bool          `toml:"log_rotate_compress"`
+	RecoverPolicy            string        `toml:"recover_policy"`
 }
 
 func (c *Config) FillupWithDefaults() error {

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -42,7 +42,8 @@ install -D -m 755 runc.amd64 /usr/local/bin/runc
 RUN  wget ${DOWNLOADS_MIRROR}/dragonflyoss/image-service/releases/download/v${NYDUS_VER}/nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
 tar xzf nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
 install -D -m 755 nydus-static/nydusd-fusedev /usr/local/bin/nydusd && \
-install -D -m 755 nydus-static/nydus-image /usr/local/bin/nydus-image
+install -D -m 755 nydus-static/nydus-image /usr/local/bin/nydus-image && \
+install -D -m 755 nydus-static/nydusctl /usr/local/bin/nydusctl
 
 # Install nerdctl
 RUN wget ${DOWNLOADS_MIRROR}/containerd/nerdctl/releases/download/v${NERDCTL_VER}/nerdctl-${NERDCTL_VER}-linux-amd64.tar.gz && \

--- a/misc/snapshotter/nydus-snapshotter.fusedev.service
+++ b/misc/snapshotter/nydus-snapshotter.fusedev.service
@@ -6,7 +6,7 @@ Before=containerd.service
 [Service]
 Type=simple
 Environment=HOME=/root
-ExecStart=/usr/local/bin/containerd-nydus-grpc --config-path /etc/nydus/config.json
+ExecStart=/usr/local/bin/containerd-nydus-grpc --recover-policy restart --config-path /etc/nydus/config.json
 Restart=always
 RestartSec=1
 KillMode=process

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -54,7 +54,16 @@ type Daemon struct {
 	Client nydussdk.Interface `json:"-"`
 	Once   *sync.Once         `json:"-"`
 	// It should only be used to distinguish daemons that needs to be started when restarting nydus-snapshotter
-	Connected bool `json:"-"`
+	Connected bool       `json:"-"`
+	mu        sync.Mutex `json:"-"`
+}
+
+func (d *Daemon) Lock() {
+	d.mu.Lock()
+}
+
+func (d *Daemon) Unlock() {
+	d.mu.Unlock()
 }
 
 // Mountpoint for nydusd within single kernel mountpoint(FUSE mount). Each mountpoint

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -80,6 +80,17 @@ func (d *Daemon) MountPoint() string {
 	return filepath.Join(d.SnapshotDir, d.SnapshotID, "mnt")
 }
 
+func (d *Daemon) HostMountPoint() (mnt string) {
+	// Identify a shared nydusd for multiple rafs instances.
+	if d.ID == SharedNydusDaemonID {
+		mnt = *d.RootMountPoint
+	} else {
+		mnt = d.MountPoint()
+	}
+
+	return
+}
+
 // Keep this for backwards compatibility
 func (d *Daemon) OldMountPoint() string {
 	return filepath.Join(d.SnapshotDir, d.SnapshotID, "fs")

--- a/pkg/nydussdk/client.go
+++ b/pkg/nydussdk/client.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -199,11 +200,17 @@ func (c NydusClient) FscacheUnbindBlob(daemonConfig string) error {
 	return handleMountError(resp)
 }
 
-func waitUntilSocketReady(sock string) error {
-	return retry.Do(func() error {
-		if _, err := os.Stat(sock); err != nil {
-			return err
+func WaitUntilSocketExisted(sock string) error {
+	return retry.Do(func() (err error) {
+		var st fs.FileInfo
+		if st, err = os.Stat(sock); err != nil {
+			return
 		}
+
+		if st.Mode()&os.ModeSocket == 0 {
+			return errors.Errorf("file %s is not socket file", sock)
+		}
+
 		return nil
 	},
 		retry.Attempts(3),
@@ -211,13 +218,13 @@ func waitUntilSocketReady(sock string) error {
 		retry.Delay(100*time.Millisecond))
 }
 
+// TODO: It's time-consuming. Make it execute only once by sync.Once
 func buildTransport(sock string) (http.RoundTripper, error) {
-	err := waitUntilSocketReady(sock)
+	err := WaitUntilSocketExisted(sock)
 	if err != nil {
 		return nil, err
 	}
 	return &http.Transport{
-		// DisableKeepAlives:     true,
 		MaxIdleConns:          10,
 		IdleConnTimeout:       10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/pkg/nydussdk/client.go
+++ b/pkg/nydussdk/client.go
@@ -213,7 +213,7 @@ func WaitUntilSocketExisted(sock string) error {
 
 		return nil
 	},
-		retry.Attempts(3),
+		retry.Attempts(5),
 		retry.LastErrorOnly(true),
 		retry.Delay(100*time.Millisecond))
 }

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -325,12 +325,15 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 		return err
 	}
 	d.Pid = cmd.Process.Pid
+
+	// Update both states cache and DB
+	// TODO: Is it right to commit daemon before nydusd successfully started?
+	m.daemonStates.Add(d)
 	err = m.store.Update(d)
 	if err != nil {
 		// Nothing we can do, just ignore it for now
-		log.L.Errorf("fail to update daemon info (%+v) to db: %v", d, err)
+		log.L.Errorf("fail to update daemon info (%+v) to DB: %v", d, err)
 	}
-	// process wait when destroy daemon and kill process
 
 	// If nydusd fails startup, manager can't subscribe its death event.
 	// So we can ignore the subscribing error.

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -50,7 +50,8 @@ func (s *DaemonStates) Add(daemon *daemon.Daemon) *daemon.Daemon {
 
 	old, ok := s.idxByDaemonID[daemon.ID]
 
-	// TODO: No need to retain all daemons in the slice, just use the map indexed by DaemonID
+	// TODO: No need to retain all daemons in the slice,
+	// just use the map indexed by DaemonID
 	if ok {
 		for i, d := range s.daemons {
 			if d.ID == daemon.ID {
@@ -59,6 +60,10 @@ func (s *DaemonStates) Add(daemon *daemon.Daemon) *daemon.Daemon {
 		}
 	} else {
 		s.daemons = append(s.daemons, daemon)
+	}
+
+	if ok && old.SnapshotID != daemon.SnapshotID {
+		log.L.Panicf("same daemon ID with different snapshot ID")
 	}
 
 	s.idxByDaemonID[daemon.ID] = daemon

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -202,6 +202,16 @@ func (m *Manager) handleDaemonDeathEvent() {
 	for event := range m.LivenessNotifier {
 		log.L.Warnf("Daemon %s died! socket path %s", event.daemonID, event.path)
 
+		// We can't restart nydusd for now fuse connection
+		d := m.GetByDaemonID(event.daemonID)
+		// TODO: Handle error
+		waitDaemon(d)
+		clearDaemonVestige(d)
+		// FIXME: handle shared mode recovery
+		m.StartDaemon(d)
+	}
+}
+
 func clearDaemonVestige(d *daemon.Daemon) {
 	mounter := mount.Mounter{}
 	// This is best effort. So no need to handle its error.

--- a/pkg/process/monitor_linux.go
+++ b/pkg/process/monitor_linux.go
@@ -1,0 +1,242 @@
+//go:build linux
+// +build linux
+
+/*
+   Copyright The nydus Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"net"
+	"sync"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+)
+
+// LivenessMonitor liveness of a nydusd daemon.
+type LivenessMonitor interface {
+	// Subscribe death event of a nydusd daemon.
+	// `path` is where the monitor is listening on.
+	Subscribe(id string, path string, notifier chan<- deathEvent) error
+	// Unsubscribe death event of a nydusd daemon.
+	Unsubscribe(id string) error
+	// Run the monitor, wait for nydusd death event.
+	Run()
+	// Stop the monitor and release all the resources.
+	Destroy()
+}
+
+type target struct {
+	// A connection to the nydusd. Should close it when stopping the liveness monitor!
+	uc *net.UnixConn
+	// Notify subscriber that the nydusd is dead via the channel
+	notifier chan<- deathEvent
+	// `id` is usually the daemon ID
+	id   string
+	path string
+}
+
+type FD = uintptr
+
+type livenessMonitor struct {
+	mu sync.Mutex
+	// Get a subscribing target by the target ID (usually is the daemon ID)
+	subscribers map[string]*target
+	// Get a subscribing target by the connection FD. Each liveness
+	// probe has a unique connection FD which is listened for epoll event.
+	set     map[FD]*target
+	epollFd int
+}
+
+type deathEvent struct {
+	daemonID string
+	path     string
+}
+
+func newMonitor() (_ *livenessMonitor, err error) {
+	var epollFd int
+	epollFd, err = unix.EpollCreate1(unix.EPOLL_CLOEXEC)
+	if err != nil {
+		return nil, errors.Wrap(err, "create daemons monitor")
+	}
+
+	m := &livenessMonitor{
+		epollFd:     epollFd,
+		subscribers: make(map[string]*target),
+		set:         make(map[uintptr]*target),
+	}
+
+	return m, nil
+}
+
+func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deathEvent) (err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if s, ok := m.subscribers[id]; ok && s.id == path {
+		log.L.Warnf("Daemon %s is already subscribed!", id)
+		return errdefs.ErrAlreadyExists
+	}
+
+	var (
+		c       net.Conn
+		rawConn syscall.RawConn
+	)
+
+	// Don't forget close me!
+	if c, err = net.Dial("unix", path); err != nil {
+		log.L.Errorf("Fails to connect to %s, %v", path, err)
+		return
+		q
+	}
+
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		return errors.Errorf("a unix socket connection is required")
+	}
+
+	if rawConn, err = uc.SyscallConn(); err != nil {
+		return
+	}
+
+	err = rawConn.Control(func(fd FD) {
+		err = unix.SetNonblock(int(fd), true)
+		if err != nil {
+			log.L.Errorf("Failed to set file. daemon id %s path %s. %v", id, path, err)
+			return
+		}
+
+		event := unix.EpollEvent{
+			Fd:     int32(fd),
+			Events: unix.EPOLLHUP | unix.EPOLLERR | unix.EPOLLET,
+		}
+
+		err = unix.EpollCtl(m.epollFd, unix.EPOLL_CTL_ADD, int(fd), &event)
+		if err != nil {
+			log.L.Errorf("Failed to control epoll. daemon id %s path %s. %v", id, path, err)
+			return
+		}
+		target := &target{uc: uc, id: id, path: path}
+
+		// Only add subscribed target when everything is OK.
+		m.set[fd] = target
+		m.subscribers[id] = target
+		target.notifier = notifier
+	})
+
+	log.L.Infof("Subscribe daemon %s liveness event, path=%s.", id, path)
+
+	return
+}
+
+func (m *livenessMonitor) Unsubscribe(id string) (err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.unsubscribe(id)
+}
+
+func (m *livenessMonitor) unsubscribe(id string) (err error) {
+	target, ok := m.subscribers[id]
+	if !ok {
+		return errdefs.ErrNotFound
+	}
+
+	delete(m.subscribers, id)
+
+	var rawConn syscall.RawConn
+	if rawConn, err = target.uc.SyscallConn(); err != nil {
+		log.L.Errorf("Fail to access underlying FD, id=%s", id)
+		return
+	}
+
+	// No longer wait for event, delete it from interest list.
+	if err = rawConn.Control(func(fd uintptr) {
+		unix.EpollCtl(m.epollFd, unix.EPOLL_CTL_DEL, int(fd), &unix.EpollEvent{})
+		delete(m.set, fd)
+	}); err != nil {
+		return errors.Wrapf(err, "remove target FD in the interested list, id=%s", id)
+	}
+
+	if err = target.uc.Close(); err != nil {
+		log.L.Errorf("Fails to close unix connection for daemon %s", id)
+		return
+	}
+
+	return nil
+}
+
+func (m *livenessMonitor) Run() {
+	var events [512]unix.EpollEvent
+	go func() {
+		defer log.L.Infof("Exiting liveness monitor")
+		log.L.Infof("Run daemons monitor...")
+		for {
+			n, err := unix.EpollWait(m.epollFd, events[:], -1)
+			if err != nil {
+				if err == unix.EINTR {
+					continue
+				}
+
+				// `Destroy` should close the epoll fd thus to exit the goroutine.
+				log.L.Errorf("Monitor fails to wait events, %v. Exiting!", err)
+				return
+			}
+
+			for i := 0; i < n; i++ {
+				ev := events[i]
+
+				m.mu.Lock()
+				target, ok := m.set[uintptr(ev.Fd)]
+				m.mu.Unlock()
+				// There is a race that it is waken before unsubscribing,
+				// so the target can't be found.
+				if !ok {
+					continue
+				}
+
+				if ev.Events&(unix.EPOLLHUP|unix.EPOLLERR) != 0 {
+					log.L.Warnf("Daemon %s died", target.id)
+					// Notify subscribers that death event happens
+					target.notifier <- deathEvent{daemonID: target.id, path: target.path}
+				}
+			}
+		}
+	}()
+}
+
+func (m *livenessMonitor) Destroy() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i := range m.subscribers {
+		if err := m.unsubscribe(i); err != nil {
+			log.L.Warnf("fail to unsubscribe %s", i)
+		}
+	}
+
+	if m.epollFd > 0 {
+		// Closing epoll fd does not waken `EpollWait`. So ending events loop can not be
+		// done via closing the file. But liveness monitor is running with nydus-snapshotter
+		// in the whole life. So we don't stop the loop now.
+		unix.Close(m.epollFd)
+	}
+}

--- a/pkg/process/monitor_other.go
+++ b/pkg/process/monitor_other.go
@@ -1,0 +1,55 @@
+//go:build !linux
+// +build !linux
+
+/*
+   Copyright The nydus Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+// LivenessMonitor liveness of a nydusd daemon.
+type LivenessMonitor interface {
+	// Subscribe death event of a nydusd daemon.
+	// `path` is where the monitor is listening on.
+	Subscribe(id string, path string, notifier chan<- deathEvent) error
+	// Unsubscribe death event of a nydusd daemon.
+	Unsubscribe(id string) error
+	// Run the monitor, wait for nydusd death event.
+	Run()
+	// Stop the monitor and release all the resources.
+	Destroy()
+}
+
+type livenessMonitor struct {
+}
+
+type deathEvent struct {
+	daemonID string
+	path     string
+}
+
+func newMonitor() (*livenessMonitor, error) {
+	return &livenessMonitor{}, nil
+}
+
+func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deathEvent) (err error) {
+	panic("unimplemented")
+}
+
+func (m *livenessMonitor) Unsubscribe(id string) (err error) { panic("unimplemented") }
+
+func (m *livenessMonitor) Run() { panic("unimplemented") }
+
+func (m *livenessMonitor) Destroy() { panic("unimplemented") }

--- a/pkg/process/monitor_test.go
+++ b/pkg/process/monitor_test.go
@@ -1,0 +1,115 @@
+//go:build linux
+// +build linux
+
+/*
+   Copyright The nydus Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"log"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func startUnixServer(ctx context.Context, sock string) {
+
+	os.RemoveAll(sock)
+
+	listener, err := net.Listen("unix", sock)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var conn net.Conn
+	conn, err = listener.Accept()
+	if err != nil {
+		log.Fatal()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+			return
+		default:
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+}
+
+func TestLivenessMonitor(t *testing.T) {
+	sockPattern := "liveness_monitor_sock"
+
+	s1, err1 := os.CreateTemp("", sockPattern)
+	assert.Nil(t, err1)
+	s1.Close()
+
+	s2, err2 := os.CreateTemp("", sockPattern)
+	assert.Nil(t, err2)
+	s2.Close()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+
+	go startUnixServer(ctx1, s1.Name())
+	go startUnixServer(ctx2, s2.Name())
+
+	monitor, _ := newMonitor()
+	assert.NotNil(t, monitor)
+
+	time.Sleep(time.Millisecond * 200)
+
+	notifier := make(chan deathEvent, 10)
+
+	e1 := monitor.Subscribe("daemon_1", s1.Name(), notifier)
+	assert.Nil(t, e1)
+	e2 := monitor.Subscribe("daemon_2", s2.Name(), notifier)
+	assert.Nil(t, e2)
+
+	t.Cleanup(func() {
+		os.Remove(s1.Name())
+		os.Remove(s2.Name())
+	})
+
+	monitor.Run()
+
+	time.Sleep(time.Millisecond * 200)
+
+	// Daemon 1 dies and unblock from channel `n1`
+	cancel1()
+	event := <-notifier
+	assert.Equal(t, event.daemonID, "daemon_1")
+
+	monitor.Unsubscribe("daemon_2")
+	cancel2()
+
+	// Should not block here.
+	assert.Equal(t, len(notifier), 0)
+
+	time.Sleep(time.Second * 1)
+
+	monitor.Destroy()
+
+	assert.Equal(t, len(monitor.set), 0)
+	assert.Equal(t, len(monitor.subscribers), 0)
+}

--- a/pkg/process/states_cache_test.go
+++ b/pkg/process/states_cache_test.go
@@ -1,0 +1,27 @@
+package process
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDaemonStatesCache(t *testing.T) {
+	states := newDaemonStates()
+
+	d1 := &daemon.Daemon{ID: "d1"}
+	d2 := &daemon.Daemon{ID: "d2"}
+
+	states.Add(d1)
+	states.Add(d2)
+
+	another_d1 := states.GetByDaemonID("d1", nil)
+	another_d2 := states.GetByDaemonID("d2", nil)
+
+	assert.Equal(t, another_d1, d1)
+	assert.Equal(t, another_d2, d2)
+
+	assert.True(t, reflect.DeepEqual(states.List(), []*daemon.Daemon{d1, d2}))
+}

--- a/pkg/process/states_cache_test.go
+++ b/pkg/process/states_cache_test.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The nydus Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package process
 
 import (
@@ -11,17 +27,34 @@ import (
 func TestDaemonStatesCache(t *testing.T) {
 	states := newDaemonStates()
 
-	d1 := &daemon.Daemon{ID: "d1"}
-	d2 := &daemon.Daemon{ID: "d2"}
+	d1 := &daemon.Daemon{ID: "d1", SnapshotID: "sn1"}
+	d2 := &daemon.Daemon{ID: "d2", SnapshotID: "sn2"}
 
 	states.Add(d1)
 	states.Add(d2)
 
-	another_d1 := states.GetByDaemonID("d1", nil)
-	another_d2 := states.GetByDaemonID("d2", nil)
+	anotherD1 := states.GetByDaemonID("d1", nil)
+	anotherD2 := states.GetByDaemonID("d2", nil)
 
-	assert.Equal(t, another_d1, d1)
-	assert.Equal(t, another_d2, d2)
+	assert.Equal(t, anotherD1, d1)
+	assert.Equal(t, anotherD2, d2)
 
 	assert.True(t, reflect.DeepEqual(states.List(), []*daemon.Daemon{d1, d2}))
+
+	assert.Equal(t, states.Size(), 2)
+
+	states.Remove(d1)
+
+	assert.Equal(t, states.Size(), 1)
+
+	states.RemoveBySnapshotID("sn2")
+
+	assert.Equal(t, states.Size(), 0)
+
+	states.RecoverDaemonState(d2)
+
+	assert.Equal(t, states.Size(), 1)
+
+	states.RemoveBySnapshotID("sn2")
+	assert.Equal(t, states.Size(), 0)
 }

--- a/pkg/process/store.go
+++ b/pkg/process/store.go
@@ -17,6 +17,7 @@ import (
 type Store interface {
 	GetByDaemonID(id string) (*daemon.Daemon, error)
 	GetBySnapshotID(snapshotID string) (*daemon.Daemon, error)
+	// If the daemon is inserted to DB before, return error ErrAlreadyExisted.
 	Add(*daemon.Daemon) error
 	Update(d *daemon.Daemon) error
 	Delete(*daemon.Daemon) error

--- a/pkg/store/daemonstore.go
+++ b/pkg/store/daemonstore.go
@@ -34,6 +34,7 @@ func (s *DaemonStore) GetBySnapshotID(snapshotID string) (*daemon.Daemon, error)
 	return nil, nil
 }
 
+// If the daemon is inserted to DB before, return error ErrAlreadyExisted.
 func (s *DaemonStore) Add(d *daemon.Daemon) error {
 	// Save daemon info in case snapshotter restarts so that we can restore the
 	// daemon states and reconnect the daemons.

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -440,7 +440,6 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		// Remove directories after the transaction is closed, failures must not
 		// return error since the transaction is committed with the removal
 		// key no longer available.
-		// FIXME: deferred snapshot directory cleanup could delete a newly created snapshot's dir since snapshot ID can be reused.
 		defer func() {
 			if err == nil {
 				for _, dir := range removals {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -255,7 +255,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 	if err != nil {
 		return nil, err
 	}
-	logCtx.Infof("prepare snapshot with labels %v", base.Labels)
+	logCtx.Debugf("prepare snapshot with labels %v", base.Labels)
 
 	// Handle nydus/stargz image data layers.
 	if target, ok := base.Labels[label.TargetSnapshotRef]; ok {
@@ -683,7 +683,7 @@ func (o *snapshotter) remoteMounts(ctx context.Context, s storage.Snapshot, id s
 		return nil, errors.Wrapf(err, "remoteMounts: failed to marshal NydusOption")
 	}
 	// XXX: Log options without extraoptions as it might contain secrets.
-	log.G(ctx).Infof("fuse.nydus-overlayfs mount options %v", overlayOptions)
+	log.G(ctx).Debugf("fuse.nydus-overlayfs mount options %v", overlayOptions)
 	// base64 to filter easily in `nydus-overlayfs`
 	opt := fmt.Sprintf("extraoption=%s", base64.StdEncoding.EncodeToString(no))
 	options := append(overlayOptions, opt)
@@ -744,7 +744,7 @@ func (o *snapshotter) mounts(ctx context.Context, info *snapshots.Info, s storag
 	}
 	options = append(options, fmt.Sprintf("lowerdir=%s", strings.Join(parentPaths, ":")))
 
-	log.G(ctx).Infof("overlayfs mount options %s", options)
+	log.G(ctx).Debugf("overlayfs mount options %s", options)
 	return []mount.Mount{
 		{
 			Type:    "overlay",

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -72,12 +72,17 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		return nil, errors.Wrap(err, "failed to new database")
 	}
 
+	rp, err := process.ParseRecoverPolicy(cfg.RecoverPolicy)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse recover policy")
+	}
+
 	pm, err := process.NewManager(process.Opt{
 		NydusdBinaryPath: cfg.NydusdBinaryPath,
 		Database:         db,
 		DaemonMode:       cfg.DaemonMode,
 		CacheDir:         cfg.CacheDir,
-		RecoverPolicy:    cfg.RecoverPolicy,
+		RecoverPolicy:    rp,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to new process manager")

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -77,6 +77,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		Database:         db,
 		DaemonMode:       cfg.DaemonMode,
 		CacheDir:         cfg.CacheDir,
+		RecoverPolicy:    cfg.RecoverPolicy,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to new process manager")


### PR DESCRIPTION
At present, nydus-snapshotter is not aware of the termination of nydusd. When a nydusd is dead somehow, snapshotter can't clean up its vestige and reclaim its resources. By introducing the daemon's liveness monitor, the snapshotter can restart nydusd when the old one dies.