### PR TITLE
manager: update nydusd commandline options

### DIFF
--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -315,7 +315,7 @@ func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 	var args []string
 	if d.FsDriver == config.FsDriverFscache {
 		args = []string{
-			"daemon",
+			"singleton",
 			"--fscache", m.cacheDir,
 		}
 		nydusdThreadNum := d.NydusdThreadNum()


### PR DESCRIPTION
We've renamed `daemon` subcommand to `singleton`.

Ref: https://github.com/dragonflyoss/image-service/pull/722

Please only merge this when upgrading nydusd dependency version.