### PR TITLE
support configure nydusd mirror registry

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -60,6 +60,11 @@ type DaemonConfig struct {
 	FscacheDaemonConfig
 }
 
+type MirrorConfig struct {
+	Scheme  string            `json:"scheme,omitempty"`
+	Host    string            `json:"host,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
 type BackendConfig struct {
 	// Localfs backend configs
 	BlobFile     string `json:"blob_file,omitempty"`
@@ -68,12 +73,13 @@ type BackendConfig struct {
 	ReadAheadSec int    `json:"readahead_sec,omitempty"`
 
 	// Registry backend configs
-	Host               string `json:"host,omitempty"`
-	Repo               string `json:"repo,omitempty"`
-	Auth               string `json:"auth,omitempty"`
-	RegistryToken      string `json:"registry_token,omitempty"`
-	BlobURLScheme      string `json:"blob_url_scheme,omitempty"`
-	BlobRedirectedHost string `json:"blob_redirected_host,omitempty"`
+	Host               string         `json:"host,omitempty"`
+	Repo               string         `json:"repo,omitempty"`
+	Auth               string         `json:"auth,omitempty"`
+	RegistryToken      string         `json:"registry_token,omitempty"`
+	BlobURLScheme      string         `json:"blob_url_scheme,omitempty"`
+	BlobRedirectedHost string         `json:"blob_redirected_host,omitempty"`
+	Mirrors            []MirrorConfig `json:"mirrors,omitempty"`
 
 	// OSS backend configs
 	EndPoint        string `json:"endpoint,omitempty"`

--- a/pkg/filesystem/fs/config.go
+++ b/pkg/filesystem/fs/config.go
@@ -81,9 +81,6 @@ func WithVerifier(verifier *signature.Verifier) NewFSOpt {
 
 func WithDaemonConfig(cfg config.DaemonConfig) NewFSOpt {
 	return func(d *Filesystem) error {
-		if (config.DaemonConfig{}) == cfg {
-			return errors.New("daemon config is empty")
-		}
 		d.daemonCfg = cfg
 		return nil
 	}


### PR DESCRIPTION
Nydusd is going to support adding multiple registry mirrors as a pull-through cache.
So snapshotter should also load mirror-related configuration items and provide them to nydusd.

relates to https://github.com/dragonflyoss/image-service/pull/736

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>