### PR TITLE
fix wrong description in help message

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -204,7 +204,7 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "recover-policy",
-			Usage:       "Policy on recovering nydus filesystem service [none, restart, failover], default to none",
+			Usage:       "Policy on recovering nydus filesystem service [none, restart, failover], default to restart",
 			Destination: &args.RecoverPolicy,
 			Value:       "restart",
 		},

--- a/misc/snapshotter/nydus-snapshotter.fusedev.service
+++ b/misc/snapshotter/nydus-snapshotter.fusedev.service
@@ -6,7 +6,7 @@ Before=containerd.service
 [Service]
 Type=simple
 Environment=HOME=/root
-ExecStart=/usr/local/bin/containerd-nydus-grpc --recover-policy restart --config-path /etc/nydus/config.json
+ExecStart=/usr/local/bin/containerd-nydus-grpc --config-path /etc/nydus/config.json
 Restart=always
 RestartSec=1
 KillMode=process


### PR DESCRIPTION
In addition remove --recover-plicy from systemd service file since restart is default one now.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>