### PR TITLE
turn delay policy from Backoff to Fixed

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -160,7 +160,7 @@ func (d *Daemon) WaitUntilReady() error {
 		}
 		return nil
 	},
-		retry.Attempts(3),
+		retry.Attempts(20), // totally wait for 2 seconds, should be enough
 		retry.LastErrorOnly(true),
 		retry.Delay(100*time.Millisecond),
 	)

--- a/pkg/nydussdk/client.go
+++ b/pkg/nydussdk/client.go
@@ -213,7 +213,7 @@ func WaitUntilSocketExisted(sock string) error {
 
 		return nil
 	},
-		retry.Attempts(5),
+		retry.Attempts(20), // totally wait for 2 seconds, should be enough
 		retry.LastErrorOnly(true),
 		retry.Delay(100*time.Millisecond))
 }

--- a/pkg/process/monitor_linux.go
+++ b/pkg/process/monitor_linux.go
@@ -112,7 +112,7 @@ func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deat
 
 		return nil
 	},
-		retry.Attempts(4),
+		retry.Attempts(20), // totally wait for 2 seconds, should be enough
 		retry.LastErrorOnly(true),
 		retry.Delay(100*time.Millisecond))
 

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -21,7 +21,7 @@ var (
 	DefaultMaxJitter     = 100 * time.Millisecond
 	DefaultOnRetry       = func(n uint, err error) {}
 	DefaultRetryIf       = IsRecoverable
-	DefaultDelayType     = CombineDelay(BackOffDelay, RandomDelay)
+	DefaultDelayType     = CombineDelay(FixedDelay, RandomDelay)
 	DefaultLastErrorOnly = false
 )
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -88,8 +88,6 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		return nil, errors.Wrap(err, "failed to new process manager")
 	}
 
-	// FIXME: How to get event goroutine has exited with error?
-
 	opts := []fspkg.NewFSOpt{
 		fspkg.WithProcessManager(pm),
 		fspkg.WithNydusdBinaryPath(cfg.NydusdBinaryPath, cfg.DaemonMode),


### PR DESCRIPTION
Backendoff delay policy brings longer and longer
delay when retrying. So it brings long latency to
set up images snapshots when creating containers.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>