### PR TITLE
remove scheme from mirro configuration

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -61,7 +61,6 @@ type DaemonConfig struct {
 }
 
 type MirrorConfig struct {
-	Scheme  string            `json:"scheme,omitempty"`
 	Host    string            `json:"host,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 }


### PR DESCRIPTION
Mirror host should be filled with URL rather than URI

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>