### PR TITLE
Fix daemon race

### DIFF
--- a/integration/entrypoint.sh
+++ b/integration/entrypoint.sh
@@ -239,7 +239,7 @@ function start_multiple_containers_shared_daemon {
 function start_single_container_on_stargz {
     echo "testing $FUNCNAME"
     nerdctl_prune_images
-    reboot_containerd shared
+    reboot_containerd multiple
 
     killall "containerd-nydus-grpc" || true
     sleep 0.5

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -353,6 +353,7 @@ func (d *Daemon) ClearVestige() {
 	mounter := mount.Mounter{}
 	// This is best effort. So no need to handle its error.
 	log.L.Infof("Umounting %s when clear vestige", d.HostMountPoint())
+
 	if err := mounter.Umount(d.HostMountPoint()); err != nil {
 		log.L.Warnf("Can't umount %s, %v", *d.RootMountPoint, err)
 	}
@@ -361,6 +362,9 @@ func (d *Daemon) ClearVestige() {
 	if err := os.Remove(d.GetAPISock()); err != nil {
 		log.L.Warnf("Can't delete residual unix socket %s, %v", d.GetAPISock(), err)
 	}
+
+	// Let't transport builder wait for nydusd startup again until it sees the created socket file.
+	d.ResetClient()
 }
 
 func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {


### PR DESCRIPTION
Nydusd daemon record can be wrongly deleted from DB when nydusd fails to start up. A reliable and stable way to fix is to refactor nydusd daemon and rafs instance relationship. So the workaround is just start a new daemon when it can't be found from states cache and DB.

In addition, we should reset client when clear daemons vestige since the API socket has to be re-created by the new nydusd