### PR TITLE
fix go race when resetting http client

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -283,12 +283,15 @@ func (d *Daemon) initClient() error {
 }
 
 func (d *Daemon) ResetClient() {
+	d.Lock()
 	d.client = nil
 	d.Once = &sync.Once{}
+	d.Unlock()
 }
 
-func (d *Daemon) ensureClient(situation string) error {
-	var err error
+func (d *Daemon) ensureClient(situation string) (err error) {
+	d.Lock()
+	defer d.Unlock()
 
 	d.Once.Do(func() {
 		if d.client == nil {
@@ -303,7 +306,7 @@ func (d *Daemon) ensureClient(situation string) error {
 		return errors.Errorf("failed to %s, client not initialized", situation)
 	}
 
-	return err
+	return
 }
 
 func (d *Daemon) Terminate() error {


### PR DESCRIPTION
otherwise, go race happens:

 go race detected
2022-09-28T03:58:01.2478136Z ==================
2022-09-28T03:58:01.2478813Z WARNING: DATA RACE
2022-09-28T03:58:01.2479296Z Write at 0x00c00017a8d0 by goroutine 40:
2022-09-28T03:58:01.2480254Z   github.com/containerd/nydus-snapshotter/pkg/daemon.(*Daemon).ResetClient()
2022-09-28T03:58:01.2618661Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/daemon/daemon.go:286 +0x4b9
2022-09-28T03:58:01.2619768Z   github.com/containerd/nydus-snapshotter/pkg/daemon.(*Daemon).ClearVestige()
2022-09-28T03:58:01.2620682Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/daemon/daemon.go:367 +0x4a5
2022-09-28T03:58:01.2621606Z   github.com/containerd/nydus-snapshotter/pkg/process.(*Manager).handleDaemonDeathEvent.func1()
2022-09-28T03:58:01.2622497Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/process/manager.go:267 +0x2b3
2022-09-28T03:58:01.2623343Z   github.com/containerd/nydus-snapshotter/pkg/process.(*Manager).handleDaemonDeathEvent·dwrap·7()
2022-09-28T03:58:01.2624258Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/process/manager.go:284 +0x74
2022-09-28T03:58:01.2624545Z
2022-09-28T03:58:01.2624739Z Previous read at 0x00c00017a8d0 by goroutine 41:
2022-09-28T03:58:01.2625338Z   github.com/containerd/nydus-snapshotter/pkg/daemon.(*Daemon).ensureClient()
2022-09-28T03:58:01.2626171Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/daemon/daemon.go:302 +0xee
2022-09-28T03:58:01.2626837Z   github.com/containerd/nydus-snapshotter/pkg/daemon.(*Daemon).CheckStatus()
2022-09-28T03:58:01.2627664Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/daemon/daemon.go:145 +0x3c
2022-09-28T03:58:01.2628365Z   github.com/containerd/nydus-snapshotter/pkg/daemon.(*Daemon).WaitUntilReady.func1()
2022-09-28T03:58:01.2629360Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/daemon/daemon.go:154 +0x34
2022-09-28T03:58:01.2629926Z   github.com/containerd/nydus-snapshotter/pkg/utils/retry.Do()
2022-09-28T03:58:01.2630675Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/utils/retry/retry.go:158 +0x455
2022-09-28T03:58:01.2631296Z   github.com/containerd/nydus-snapshotter/pkg/daemon.(*Daemon).WaitUntilReady()
2022-09-28T03:58:01.2632055Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/daemon/daemon.go:153 +0xf8
2022-09-28T03:58:01.2633167Z   github.com/containerd/nydus-snapshotter/pkg/filesystem/fs.(*Filesystem).WaitUntilReady()
2022-09-28T03:58:01.2633857Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/filesystem/fs/fs.go:585 +0xce
2022-09-28T03:58:01.2634536Z   github.com/containerd/nydus-snapshotter/snapshot.(*snapshotter).Mounts()
2022-09-28T03:58:01.2635214Z       /home/runner/work/nydus-snapshotter/nydus-snapshotter/snapshot/snapshot.go:233 +0x4b1
2022-09-28T03:58:01.2635668Z   github.com/containerd/containerd/contrib/snapshotservice.service.Mounts()
2022-09-28T03:58:01.2636316Z       /home/runner/go/pkg/mod/github.com/containerd/containerd@v1.6.6/contrib/snapshotservice/service.go:71 +0x97
2022-09-28T03:58:01.2636796Z   github.com/containerd/containerd/contrib/snapshotservice.(*service).Mounts()
2022-09-28T03:58:01.2637400Z       <autogenerated>:1 +0x7a
2022-09-28T03:58:01.2637803Z   github.com/containerd/containerd/api/services/snapshots/v1._Snapshots_Mounts_Handler()
2022-09-28T03:58:01.2638479Z       /home/runner/go/pkg/mod/github.com/containerd/containerd@v1.6.6/api/services/snapshots/v1/snapshots.pb.go:1162 +0x257
2022-09-28T03:58:01.2639004Z   google.golang.org/grpc.(*Server).processUnaryRPC()
2022-09-28T03:58:01.2639562Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1282 +0x1514
2022-09-28T03:58:01.2639941Z   google.golang.org/grpc.(*Server).handleStream()
2022-09-28T03:58:01.2640445Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1616 +0xfd3
2022-09-28T03:58:01.2640835Z   google.golang.org/grpc.(*Server).serveStreams.func1.2()
2022-09-28T03:58:01.2641352Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:921 +0xfd

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>