### PR TITLE
print which directories are being deleted

### DIFF
--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -275,6 +275,9 @@ func (m *Manager) handleDaemonDeathEvent() {
 					daemons := m.daemonStates.List()
 					for _, d := range daemons {
 						if d.ID != daemon.SharedNydusDaemonID {
+							// FIXME: Virtual daemon has a separated client, so it skips checking unix socket's existence.
+							// This is really hacky, but I don't have better solution until rafs object is decoupled from daemon.
+							d.ResetClient()
 							if err := d.SharedMount(); err != nil {
 								log.L.Warnf("fail to mount rafs instance, %v", err)
 							}

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -403,11 +403,14 @@ func (m *Manager) CleanUpDaemonResources(d *daemon.Daemon) {
 	if d.IsMultipleDaemon() {
 		resource = append(resource, d.SocketDir)
 	}
+
 	for _, dir := range resource {
 		if err := os.RemoveAll(dir); err != nil {
 			log.L.Errorf("failed to remove dir %s err %v", dir, err)
 		}
 	}
+
+	log.L.Infof("Deleting resources %v", resource)
 }
 
 func (m *Manager) StartDaemon(d *daemon.Daemon) error {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -825,6 +825,9 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 	if err := os.RemoveAll(dir); err != nil {
 		return errors.Wrapf(err, "failed to remove directory %q", dir)
 	}
+
+	log.L.Infof("Delete snapshot directory %s", dir)
+
 	return nil
 }
 


### PR DESCRIPTION
This is very helpful when debug and trace how
nydus-snapshotter is releasing resources.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>