### PR TITLE
support configuring nydusd with supervisor path

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -146,3 +146,10 @@ func WithFsDriver(fsDriver string) NewDaemonOpt {
 		return nil
 	}
 }
+
+func WithSupervisor(supervisor string) NewDaemonOpt {
+	return func(d *Daemon) error {
+		d.SupervisorPath = supervisor
+		return nil
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -51,6 +51,7 @@ type Daemon struct {
 	RootMountPoint   *string
 	CustomMountPoint *string
 	nydusdThreadNum  int
+	SupervisorPath   string
 
 	// client will be rebuilt on Reconnect, skip marshal/unmarshal
 	client nydussdk.Interface `json:"-"`

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -489,6 +489,11 @@ func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 		}
 	}
 
+	if d.SupervisorPath != "" {
+		args = append(args, "--supervisor", d.SupervisorPath)
+		args = append(args, "--id", d.ID)
+	}
+
 	args = append(args, "--apisock", d.GetAPISock())
 	args = append(args, "--log-level", d.LogLevel)
 	if !d.LogToStdout {


### PR DESCRIPTION
So supervisor can be communicated with nydusd and
help to store damone states.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>