### PR TITLE
Add nydusd daemon command line builder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
+	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
@@ -70,7 +71,6 @@ require (
 	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.1 // indirect
-	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect

--- a/pkg/daemon/command/command.go
+++ b/pkg/daemon/command/command.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2022. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package command
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+type Opt = func(cmd *DaemonCommand)
+
+// Define how to build a command line to start a nydusd daemon
+type DaemonCommand struct {
+	// "singleton" "fuse"
+	Mode string `type:"subcommand"`
+	// "blobcache" "fscache" "virtiofs"
+	FscacheDriver  string `type:"param" name:"fscache"`
+	FscacheThreads string `type:"param" name:"fscache-threads"`
+	Upgrade        bool   `type:"flag" name:"upgrade" default:""`
+	ThreadNum      string `type:"param" name:"thread-num"`
+	Config         string `type:"param" name:"config"`
+	Bootstrap      string `type:"param" name:"bootstrap"`
+	Mountpoint     string `type:"param" name:"mountpoint"`
+	APISock        string `type:"param" name:"apisock"`
+	LogLevel       string `type:"param" name:"log-level"`
+	Supervisor     string `type:"param" name:"supervisor"`
+	LogFile        string `type:"param" name:"log-file"`
+}
+
+// Build exec style command line
+func BuildCommand(opts []Opt) ([]string, error) {
+	var cmd DaemonCommand
+	var subcommand string
+
+	for _, o := range opts {
+		o(&cmd)
+	}
+
+	args := make([]string, 0, 32)
+	t := reflect.TypeOf(cmd)
+	v := reflect.ValueOf(cmd)
+
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag
+		argType := tag.Get("type")
+
+		switch argType {
+		case "param":
+			// Zero value will be skipped appending to command line
+			if v.Field(i).IsZero() {
+				continue
+			}
+
+			value := v.Field(i).Interface()
+
+			pair := []string{fmt.Sprintf("--%s", tag.Get("name")), fmt.Sprintf("%s", value)}
+			args = append(args, pair...)
+		case "subcommand":
+			// Zero value will be skipped appending to command line
+			if v.Field(i).IsZero() {
+				continue
+			}
+			subcommand = v.Field(i).String()
+		case "flag":
+			kind := v.Field(i).Kind()
+
+			if kind != reflect.Bool {
+				return nil, errors.Errorf("flag must be boolean")
+			}
+
+			v := v.Field(i).Bool()
+
+			if v {
+				flag := fmt.Sprintf("--%s", tag.Get("name"))
+				args = append(args, flag)
+			} else {
+				continue
+			}
+		default:
+			return nil, errors.Errorf("unknown tag type: %s ", argType)
+		}
+	}
+
+	if subcommand != "" {
+		// Ensure subcommand is at the first place.
+		args = append([]string{subcommand}, args...)
+	}
+
+	return args, nil
+}
+
+func WithMode(m string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.Mode = m
+	}
+}
+
+func WithFscacheDriver(w string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.FscacheDriver = w
+	}
+}
+
+func WithFscacheThreads(num int) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.FscacheThreads = strconv.Itoa(num)
+	}
+}
+
+func WithThreadNum(num int) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.ThreadNum = strconv.Itoa(num)
+	}
+}
+
+func WithConfig(config string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.Config = config
+	}
+}
+
+func WithBootstrap(b string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.Bootstrap = b
+	}
+}
+
+func WithMountpoint(m string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.Mountpoint = m
+	}
+}
+
+func WithAPISock(api string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.APISock = api
+	}
+}
+
+func WithLogLevel(l string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.LogLevel = l
+	}
+}
+
+func WithSupervisor(s string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.Supervisor = s
+	}
+}
+
+func WithUpgrade() Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.Upgrade = true
+	}
+}
+
+func WithLogFile(l string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.LogFile = l
+	}
+}

--- a/pkg/daemon/command/command_builder_test.go
+++ b/pkg/daemon/command/command_builder_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildCommand(t *testing.T) {
+
+	c := []Opt{WithMode("singleton"),
+		WithFscacheDriver("fs_cache_dir"),
+		WithFscacheThreads(4),
+		WithAPISock("/dummy/apisock"),
+		WithUpgrade()}
+
+	args, err := BuildCommand(c)
+	assert.Nil(t, err)
+	actual := strings.Join(args, " ")
+	assert.Equal(t, "singleton --fscache fs_cache_dir --fscache-threads 4 --upgrade --apisock /dummy/apisock", actual)
+
+	c1 := []Opt{WithMode("singleton"),
+		WithFscacheDriver("fs_cache_dir"),
+		WithFscacheThreads(4),
+		WithAPISock("/dummy/apisock")}
+
+	args1, err := BuildCommand(c1)
+	assert.Nil(t, err)
+	actual1 := strings.Join(args1, " ")
+	assert.Equal(t, "singleton --fscache fs_cache_dir --fscache-threads 4 --apisock /dummy/apisock", actual1)
+}
+
+// pkg: github.com/containerd/nydus-snapshotter/pkg/process
+// cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+// BenchmarkBuildCommand-8   	  394146	      3084 ns/op
+// BenchmarkXxx-8            	 3933902	       281.4 ns/op
+// PASS
+func BenchmarkBuildCommand(b *testing.B) {
+
+	c := []Opt{WithMode("singleton"),
+		WithFscacheDriver("fs_cache_dir"),
+		WithFscacheThreads(4),
+		WithAPISock("/dummy/apisock"),
+		WithUpgrade()}
+
+	for n := 0; n < b.N; n++ {
+		BuildCommand(c)
+	}
+}

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020. Ant Group. All rights reserved.
+ * Copyright (c) 2022. Nydus Developers. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,8 @@ import (
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/pkg/errors"
 )
+
+// Build runtime nydusd daemon object, which might be persisted later
 
 func WithSnapshotID(id string) NewDaemonOpt {
 	return func(d *Daemon) error {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020. Ant Group. All rights reserved.
+ * Copyright (c) 2022. Nydus Developers. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -111,19 +111,14 @@ func (d *Daemon) BootstrapFile() (string, error) {
 	return GetBootstrapFile(d.SnapshotDir, d.SnapshotID)
 }
 
+// Each nydusd daemon has a copy of configuration json file.
 func (d *Daemon) ConfigFile() string {
 	return filepath.Join(d.ConfigDir, "config.json")
 }
 
-// NydusdThreadNum returns `nydusd-thread-num` for nydusd if set,
-// otherwise will return the number of CPUs as default.
-func (d *Daemon) NydusdThreadNum() string {
-	if d.nydusdThreadNum > 0 {
-		return strconv.Itoa(d.nydusdThreadNum)
-	}
-	// if nydusd-thread-num is not set, return empty string
-	// to let manager don't set thread-num option.
-	return ""
+// NydusdThreadNum returns how many working threads are needed of a single nydusd
+func (d *Daemon) NydusdThreadNum() int {
+	return d.nydusdThreadNum
 }
 
 func (d *Daemon) GetAPISock() string {

--- a/pkg/process/daemon_adaptor.go
+++ b/pkg/process/daemon_adaptor.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon/command"
+	"github.com/containerd/nydus-snapshotter/pkg/nydussdk"
+	"github.com/pkg/errors"
+)
+
+// Fork the nydusd daemon with the process PID decided
+func (m *Manager) StartDaemon(d *daemon.Daemon) error {
+	cmd, err := m.buildDaemonCommand(d)
+	if err != nil {
+		return errors.Wrapf(err, "create command for daemon %s", d.ID)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	d.Lock()
+	defer d.Unlock()
+
+	d.Pid = cmd.Process.Pid
+
+	// Update both states cache and DB
+	// TODO: Is it right to commit daemon before nydusd successfully started?
+	// And it brings extra latency of accessing DB. Only write daemon record to
+	// DB when nydusd is started?
+	err = m.UpdateDaemon(d)
+	if err != nil {
+		// Nothing we can do, just ignore it for now
+		log.L.Errorf("Fail to update daemon info (%+v) to DB: %v", d, err)
+	}
+
+	// If nydusd fails startup, manager can't subscribe its death event.
+	// So we can ignore the subscribing error.
+	go func() {
+		if err := nydussdk.WaitUntilSocketExisted(d.GetAPISock()); err != nil {
+			log.L.Errorf("Nydusd %s probably not started", d.ID)
+			return
+		}
+
+		// TODO: It's better to subscribe death event when snapshotter
+		// has set daemon's state to RUNNING or READY.
+		if err := m.monitor.Subscribe(d.ID, d.GetAPISock(), m.LivenessNotifier); err != nil {
+			log.L.Errorf("Nydusd %s probably not started", d.ID)
+		}
+	}()
+
+	return nil
+}
+
+// Build a daemon command which will be started to fork a new nydusd process later
+// according to previously setup daemon object.
+func (m *Manager) buildDaemonCommand(d *daemon.Daemon) (*exec.Cmd, error) {
+	var cmdOpts []command.Opt
+
+	nydusdThreadNum := d.NydusdThreadNum()
+
+	if d.FsDriver == config.FsDriverFscache {
+		cmdOpts = append(cmdOpts,
+			command.WithMode("singleton"),
+			command.WithFscacheDriver(m.cacheDir))
+
+		if nydusdThreadNum != 0 {
+			cmdOpts = append(cmdOpts, command.WithFscacheThreads(nydusdThreadNum))
+		}
+
+	} else {
+		cmdOpts = append(cmdOpts, command.WithMode("fuse"))
+
+		if nydusdThreadNum != 0 {
+			cmdOpts = append(cmdOpts, command.WithThreadNum(nydusdThreadNum))
+		}
+
+		switch {
+		case d.IsMultipleDaemon():
+			bootstrap, err := d.BootstrapFile()
+			if err != nil {
+				return nil, errors.Wrapf(err, "locate bootstrap")
+			}
+			cmdOpts = append(cmdOpts,
+				command.WithConfig(d.ConfigFile()),
+				command.WithBootstrap(bootstrap),
+				command.WithMountpoint(d.MountPoint()))
+
+		case m.isOneDaemon():
+			cmdOpts = append(cmdOpts, command.WithMountpoint(d.HostMountPoint()))
+
+		default:
+			return nil, errors.Errorf("invalid daemon mode %s ", d.DaemonMode)
+		}
+	}
+
+	cmdOpts = append(cmdOpts,
+		command.WithAPISock(d.GetAPISock()),
+		command.WithLogLevel(d.LogLevel))
+
+	if !d.LogToStdout {
+		cmdOpts = append(cmdOpts, command.WithLogFile(d.LogFile()))
+	}
+
+	args, err := command.BuildCommand(cmdOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	log.L.Infof("Start nydusd daemon: %s %s", m.nydusdBinaryPath, strings.Join(args, " "))
+
+	cmd := exec.Command(m.nydusdBinaryPath, args...)
+
+	// nydusd standard output and standard error rather than its logs are
+	// always redirected to snapshotter's respectively
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd, nil
+}


### PR DESCRIPTION
Generate nydusd exec style command line via a daemonCommand object. It provides the flexibility to start nydusd as a library API. 
Move nydusd daemon startup logics to a new file `daemon_adapter.go`