### PR TITLE
Move nydusd http client code to daemon package

### DIFF
--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package nydussdk
+package daemon
 
 import (
 	"bytes"

--- a/pkg/daemon/client_test.go
+++ b/pkg/daemon/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,9 @@ var BTI = types.BuildTimeInfo{
 }
 
 func prepareNydusServer(t *testing.T) (string, func()) {
-	mockSocket := "testdata/nydus.sock"
+	dir, _ := os.MkdirTemp("", "nydus-snapshotter-test")
+	mockSocket := filepath.Join(dir, "nydusd.sock")
+
 	_, err := os.Stat(mockSocket)
 	if err == nil {
 		_ = os.Remove(mockSocket)

--- a/pkg/daemon/client_test.go
+++ b/pkg/daemon/client_test.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package nydussdk
+package daemon
 
 import (
 	"encoding/json"

--- a/pkg/daemon/command/command_builder_test.go
+++ b/pkg/daemon/command/command_builder_test.go
@@ -37,7 +37,6 @@ func TestBuildCommand(t *testing.T) {
 	assert.Equal(t, "singleton --fscache fs_cache_dir --fscache-threads 4 --apisock /dummy/apisock", actual1)
 }
 
-// pkg: github.com/containerd/nydus-snapshotter/pkg/process
 // cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
 // BenchmarkBuildCommand-8   	  394146	      3084 ns/op
 // BenchmarkXxx-8            	 3933902	       281.4 ns/op

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
-	"github.com/containerd/nydus-snapshotter/pkg/nydussdk"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/erofs"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/mount"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/retry"
@@ -53,8 +52,8 @@ type Daemon struct {
 	nydusdThreadNum  int
 
 	// client will be rebuilt on Reconnect, skip marshal/unmarshal
-	client nydussdk.NydusdClient `json:"-"`
-	Once   *sync.Once            `json:"-"`
+	client NydusdClient `json:"-"`
+	Once   *sync.Once   `json:"-"`
 	// It should only be used to distinguish daemons that needs to be started when restarting nydus-snapshotter
 	Connected bool       `json:"-"`
 	mu        sync.Mutex `json:"-"`
@@ -286,7 +285,7 @@ func (d *Daemon) IsPrefetchDaemon() bool {
 }
 
 func (d *Daemon) initClient() error {
-	client, err := nydussdk.NewNydusClient(d.GetAPISock())
+	client, err := NewNydusClient(d.GetAPISock())
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nydus client")
 	}

--- a/pkg/filesystem/fs/config.go
+++ b/pkg/filesystem/fs/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
 	"github.com/containerd/nydus-snapshotter/pkg/filesystem/fs/stargz"
 	"github.com/containerd/nydus-snapshotter/pkg/filesystem/meta"
-	"github.com/containerd/nydus-snapshotter/pkg/process"
+	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
 	"github.com/pkg/errors"
 )
@@ -50,7 +50,7 @@ func WithNydusImageBinaryPath(p string) NewFSOpt {
 	}
 }
 
-func WithProcessManager(pm *process.Manager) NewFSOpt {
+func WithManager(pm *manager.Manager) NewFSOpt {
 	return func(d *Filesystem) error {
 		if pm == nil {
 			return errors.New("process manager cannot be nil")

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -35,7 +35,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/filesystem/fs/stargz"
 	"github.com/containerd/nydus-snapshotter/pkg/filesystem/meta"
 	"github.com/containerd/nydus-snapshotter/pkg/label"
-	"github.com/containerd/nydus-snapshotter/pkg/process"
+	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/registry"
 )
@@ -100,7 +100,7 @@ func init() {
 type Filesystem struct {
 	meta.FileSystemMeta
 	blobMgr              *BlobManager
-	manager              *process.Manager
+	manager              *manager.Manager
 	cacheMgr             *cache.Manager
 	sharedDaemon         *daemon.Daemon
 	daemonCfg            config.DaemonConfig

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package process
+package manager
 
 import (
 	"os"

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package process
+package manager
 
 import (
 	"context"

--- a/pkg/manager/monitor_linux.go
+++ b/pkg/manager/monitor_linux.go
@@ -17,7 +17,7 @@
    limitations under the License.
 */
 
-package process
+package manager
 
 import (
 	"net"

--- a/pkg/manager/monitor_other.go
+++ b/pkg/manager/monitor_other.go
@@ -17,7 +17,7 @@
    limitations under the License.
 */
 
-package process
+package manager
 
 // LivenessMonitor liveness of a nydusd daemon.
 type LivenessMonitor interface {

--- a/pkg/manager/monitor_test.go
+++ b/pkg/manager/monitor_test.go
@@ -17,7 +17,7 @@
    limitations under the License.
 */
 
-package process
+package manager
 
 import (
 	"context"

--- a/pkg/manager/states_cache_test.go
+++ b/pkg/manager/states_cache_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package process
+package manager
 
 import (
 	"reflect"

--- a/pkg/manager/store.go
+++ b/pkg/manager/store.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package process
+package manager
 
 import (
 	"context"

--- a/pkg/metric/serve.go
+++ b/pkg/metric/serve.go
@@ -14,11 +14,13 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/metric/exporter"
-	"github.com/containerd/nydus-snapshotter/pkg/process"
-	"github.com/pkg/errors"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -30,7 +32,7 @@ type Server struct {
 	listener    net.Listener
 	rootDir     string
 	metricsFile string
-	pm          *process.Manager
+	pm          *manager.Manager
 	exp         *exporter.Exporter
 }
 
@@ -56,7 +58,7 @@ func WithMetricsFile(metricsFile string) ServerOpt {
 	}
 }
 
-func WithProcessManager(pm *process.Manager) ServerOpt {
+func WithProcessManager(pm *manager.Manager) ServerOpt {
 	return func(s *Server) error {
 		s.pm = pm
 		return nil

--- a/pkg/process/daemon_adaptor.go
+++ b/pkg/process/daemon_adaptor.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/command"
-	"github.com/containerd/nydus-snapshotter/pkg/nydussdk"
 	"github.com/pkg/errors"
 )
 
@@ -48,7 +47,7 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 	// If nydusd fails startup, manager can't subscribe its death event.
 	// So we can ignore the subscribing error.
 	go func() {
-		if err := nydussdk.WaitUntilSocketExisted(d.GetAPISock()); err != nil {
+		if err := daemon.WaitUntilSocketExisted(d.GetAPISock()); err != nil {
 			log.L.Errorf("Nydusd %s probably not started", d.ID)
 			return
 		}

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
-	"github.com/containerd/nydus-snapshotter/pkg/nydussdk"
 	"github.com/containerd/nydus-snapshotter/pkg/store"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/mount"
 )
@@ -558,7 +557,7 @@ func (m *Manager) Reconnect(ctx context.Context) ([]*daemon.Daemon, error) {
 		log.L.WithField("daemon", d.ID).Infof("found alive daemon")
 
 		go func() {
-			if err := nydussdk.WaitUntilSocketExisted(d.GetAPISock()); err != nil {
+			if err := daemon.WaitUntilSocketExisted(d.GetAPISock()); err != nil {
 				log.L.Errorf("Nydusd %s probably not started", d.ID)
 				return
 			}


### PR DESCRIPTION
We aim to put all logic that starts nydusd, queries nydusd, and controls nydusd to the daemon package.
So the daemons manager as well as other projects like KataContainers can easily call daemon functions to operate nydusd daemons/

This RR contains no logical changes.