### PR TITLE
support configure authorization through mirror

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -61,8 +61,9 @@ type DaemonConfig struct {
 }
 
 type MirrorConfig struct {
-	Host    string            `json:"host,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
+	Host        string            `json:"host,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	AuthThrough bool              `json:"auth_through,omitempty"`
 }
 type BackendConfig struct {
 	// Localfs backend configs


### PR DESCRIPTION
Nydusd needs a parameters to determine if it is authorized through mirror. 
So snapshotter should also load auth_through item and provide it to nydusd.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>