### PR TITLE
support shared domain

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,9 @@ func SetStartupParameter(startupFlag *command.Args, cfg *Config) error {
 	}
 	cfg.PublicKeyFile = startupFlag.PublicKeyFile
 	cfg.ValidateSignature = startupFlag.ValidateSignature
+	if len(cfg.DaemonCfg.DomainID) != 0 {
+		log.L.Warnf("Linux Kernel Shared Domain feature in use. make sure your kernel version >= 6.1")
+	}
 
 	daemonMode, err := parseDaemonMode(startupFlag.DaemonMode)
 	if err != nil {

--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -168,7 +168,9 @@ func NewDaemonConfig(fsDriver string, cfg DaemonConfig, imageID, snapshotID stri
 			backendConfig = &cfg.Config.BackendConfig
 			fscacheID := erofs.FscacheID(snapshotID)
 			cfg.ID = fscacheID
-			cfg.DomainID = fscacheID
+			if len(cfg.DomainID) == 0 {
+				cfg.DomainID = fscacheID
+			}
 			cfg.Config.ID = fscacheID
 		}
 		if keyChain != nil {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -149,3 +149,10 @@ func WithFsDriver(fsDriver string) NewDaemonOpt {
 		return nil
 	}
 }
+
+func WithDomainID(domainID string) NewDaemonOpt {
+	return func(d *Daemon) error {
+		d.domainID = domainID
+		return nil
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -57,6 +57,7 @@ type Daemon struct {
 	// It should only be used to distinguish daemons that needs to be started when restarting nydus-snapshotter
 	Connected bool       `json:"-"`
 	mu        sync.Mutex `json:"-"`
+	domainID  string     `json:"-"`
 }
 
 func (d *Daemon) Lock() {
@@ -250,7 +251,7 @@ func (d *Daemon) sharedErofsMount() error {
 	}
 	fscacheID := erofs.FscacheID(d.SnapshotID)
 
-	if err := erofs.Mount(bootstrapPath, fscacheID, mountPoint); err != nil {
+	if err := erofs.Mount(bootstrapPath, d.domainID, fscacheID, mountPoint); err != nil {
 		if !errdefs.IsErofsMounted(err) {
 			return errors.Wrapf(err, "mount erofs to %s", mountPoint)
 		}

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -267,6 +267,7 @@ func (fs *Filesystem) newSharedDaemon() (*daemon.Daemon, error) {
 		daemon.WithLogToStdout(fs.logToStdout),
 		daemon.WithNydusdThreadNum(fs.nydusdThreadNum),
 		daemon.WithFsDriver(fs.fsDriver),
+		daemon.WithDomainID(fs.daemonCfg.DomainID),
 		modeOpt,
 	)
 	if err != nil {
@@ -793,6 +794,7 @@ func (fs *Filesystem) createDaemon(snapshotID string, imageID string) (*daemon.D
 		daemon.WithCustomMountPoint(customMountPoint),
 		daemon.WithNydusdThreadNum(fs.nydusdThreadNum),
 		daemon.WithFsDriver(fs.fsDriver),
+		daemon.WithDomainID(fs.daemonCfg.DomainID),
 	); err != nil {
 		return nil, err
 	}
@@ -836,6 +838,7 @@ func (fs *Filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 		daemon.WithLogToStdout(fs.logToStdout),
 		daemon.WithNydusdThreadNum(fs.nydusdThreadNum),
 		daemon.WithFsDriver(fs.fsDriver),
+		daemon.WithDomainID(fs.daemonCfg.DomainID),
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
User could configure the 'share_domain' field in config file to use this feature.

Be cautious! If you use this feature, make sure your kernel version is higher than 6.1.

Signed-off-by: Jia Zhu <zhujia.zj@bytedance.com>