### PR TITLE
support configure nydusd mirror health checking

### DIFF
--- a/config/daemonconfig.go
+++ b/config/daemonconfig.go
@@ -61,9 +61,12 @@ type DaemonConfig struct {
 }
 
 type MirrorConfig struct {
-	Host        string            `json:"host,omitempty"`
-	Headers     map[string]string `json:"headers,omitempty"`
-	AuthThrough bool              `json:"auth_through,omitempty"`
+	Host                string            `json:"host,omitempty"`
+	Headers             map[string]string `json:"headers,omitempty"`
+	AuthThrough         bool              `json:"auth_through,omitempty"`
+	HealthCheckInterval int               `json:"health_check_interval,omitempty"`
+	FailureLimit        uint8             `json:"failure_limit,omitempty"`
+	PingURL             string            `json:"ping_url,omitempty"`
 }
 type BackendConfig struct {
 	// Localfs backend configs


### PR DESCRIPTION
The failure_limit indicates the failed time at which the mirror is set to unavailable, and the health_check_interval indicates the time interval to recover the unavailable mirror.

This PR is related to https://github.com/dragonflyoss/image-service/pull/800

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>