### PR TITLE
Fix the annotation error of the converted bootstrap layer

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -660,6 +660,7 @@ func convertManifest(ctx context.Context, cs content.Store, newDesc *ocispec.Des
 		BuilderPath:   opt.BuilderPath,
 		WorkDir:       opt.WorkDir,
 		ChunkDictPath: opt.ChunkDictPath,
+		FsVersion:     opt.FsVersion,
 		WithTar:       true,
 	})
 	if err != nil {


### PR DESCRIPTION
This pr fixes the fs-version annotation error of the converted Nydus bootstrap layer.

By now, the "containerd.io/snapshot/nydus-fs-version" annotation of the converted bootstrap layer is always `5` which is the default value. The reason for this error is that the value of `MergeOption.FsVersion` is not assigned correctly in the `convertManifest` function of `convert_unix.go` when call the `MergeLayers` function and the `MergeLayers` always uses the empty string as the value of `MergeOption.FsVersion`.

Signed-off-by: Nan Li <loheagn@icloud.com>