### PR TITLE
fix broken release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,6 @@ jobs:
         with:
           name: "Nydus Snapshotter ${{ env.tag }} Release"
           generate_release_notes: true
-          files: ${{ env.tarball }}
+          files: |
+            ${{ env.tarball }}
             ${{ env.tarball_shasum }}


### PR DESCRIPTION
The release action can't upload artifacts when it told the error:

🤔 Pattern 'nydus-snapshotter-v0.11.2-x86_64.tgz nydus-snapshotter-v0.11.2-x86_64.tgz.sha256sum' does not match any files. 👩‍🏭 Creating new GitHub release for tag v0.11.2... 🤔 nydus-snapshotter-v0.11.2-x86_64.tgz nydus-snapshotter-v0.11.2-x86_64.tgz.sha256sum not include valid file. 🎉 Release ready at https://github.com/containerd/nydus-snapshotter/releases/tag/v0.11.2

So we shoud use literal style yaml block to keep the newline untouched

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>