### PR TITLE
fix broken release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: "1.17"
       - name: cache go mod
         uses: actions/cache@v2
         with:
@@ -67,6 +67,6 @@ jobs:
         with:
           name: "Nydus Snapshotter ${{ env.tag }} Release"
           generate_release_notes: true
-          files:
+          files: |
             ${{ env.tarball }}
             ${{ env.tarball_shasum }}


### PR DESCRIPTION
The release action can't upload artifacts when it told the error:

🤔 Pattern 'nydus-snapshotter-v0.11.2-x86_64.tgz nydus-snapshotter-v0.11.2-x86_64.tgz.sha256sum' does not match any files. 👩‍🏭 Creating new GitHub release for tag v0.11.2... 🤔 nydus-snapshotter-v0.11.2-x86_64.tgz nydus-snapshotter-v0.11.2-x86_64.tgz.sha256sum not include valid file. 🎉 Release ready at https://github.com/containerd/nydus-snapshotter/releases/tag/v0.11.2

So we shoud use literal style yaml block to keep the newline untouched

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>