### PR TITLE
Report nydus real blob cache disk usage

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -334,6 +334,18 @@ func (d *Daemon) GetFsMetrics(sharedDaemon bool, sid string) (*types.FsMetrics, 
 	return d.client.GetFsMetrics(sharedDaemon, sid)
 }
 
+func (d *Daemon) GetCacheMetrics(sharedDaemon bool, sid string) (*types.CacheMetrics, error) {
+	if err := d.ensureClient("get cache metrics"); err != nil {
+		return nil, err
+	}
+
+	// Protect daemon client when it's being reset.
+	d.Lock()
+	defer d.Unlock()
+
+	return d.client.GetCacheMetrics(sharedDaemon, sid)
+}
+
 func (d *Daemon) IsMultipleDaemon() bool {
 	return d.DaemonMode == config.DaemonModeMultiple
 }

--- a/pkg/daemon/types/types.go
+++ b/pkg/daemon/types/types.go
@@ -68,3 +68,13 @@ type FsMetrics struct {
 	NrMaxOpens                uint64   `json:"nr_max_opens"`
 	LastFopTp                 uint64   `json:"last_fop_tp"`
 }
+
+type CacheMetrics struct {
+	ID              string   `json:"id"`
+	UnderlyingFiles []string `json:"underlying_files"`
+	StorePath       string   `json:"store_path"`
+	PartialHits     uint64   `json:"partial_hits"`
+	WholeHits       uint64   `json:"whole_hits"`
+	Total           uint64   `json:"total"`
+	EntriesCount    uint32   `json:"entries_count"`
+}

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/KarpelesLab/reflink"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -553,6 +554,17 @@ func (fs *Filesystem) Mount(snapshotID string, labels map[string]string) (err er
 	}
 
 	return nil
+}
+
+// How much space the layer/blob cache filesystem is occupying
+// The blob digest mush have `sha256:` prefixed, otherwise, throw errors.
+func (fs *Filesystem) CacheUsage(ctx context.Context, blobDigest string) (snapshots.Usage, error) {
+	digest := digest.Digest(blobDigest)
+	if err := digest.Validate(); err != nil {
+		return snapshots.Usage{}, errors.Wrapf(err, "invalid blob digest from label %s", label.CRILayerDigest)
+	}
+	blobID := digest.Hex()
+	return fs.cacheMgr.CacheUsage(ctx, blobID)
 }
 
 // WaitUntilReady wait until daemon ready by snapshotID, it will wait until nydus domain socket established

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -212,7 +212,9 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, e
 	if err != nil {
 		return snapshots.Usage{}, err
 	}
+
 	upperPath := o.upperPath(id)
+
 	if info.Kind == snapshots.KindActive {
 		du, err := fs.DiskUsage(ctx, upperPath)
 		if err != nil {
@@ -220,6 +222,18 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, e
 		}
 		usage = snapshots.Usage(du)
 	}
+
+	// Blob layers are all committed snapshots
+	if info.Kind == snapshots.KindCommitted {
+		blobDigest := info.Labels[label.CRILayerDigest]
+		// Try to get nydus meta layer/snapshot disk usage
+		cacheUsage, err := o.fs.CacheUsage(ctx, blobDigest)
+		if err != nil {
+			return snapshots.Usage{}, errors.Wrapf(err, "try to get snapshot %s nydus disk usage", id)
+		}
+		usage.Add(cacheUsage)
+	}
+
 	return usage, nil
 }
 


### PR DESCRIPTION
Report nydusd blob cache real disk usage. We can find blob layer digest from labels thus to locate the blob cache file rather than use the fake usage in DB. This can benefit Kubelet imagefs based Pod eviction.

```
# ctr snapshot --snapshotter nydus usage
KEY                                                                     SIZE      INODES
109b7d58b01ebec145bb9442e4ccc689924cc0ff58a1cfec4e9c2e4dd8b42406        1.2 GiB   83
1ec71efdd3b1e343aadba2cb99799cd449f6265c586b676d187ebd6fa5da365a        1.2 GiB   87
connectiontest-dummy-MWJlMjQwOT                                         1.2 GiB   83
sha256:02b8d8942291bd3719dc67b9a13c546b35dcbd997abbdc8895f46a04b1e955b0 4.0 KiB   1
sha256:14378bfef64c87c460841af12e60e2322a37242bda61d315dc5042eb2cc4d9cc 4.0 KiB   1
sha256:2b9b33469ea282b43c5a86ee628ba968f6ada2f1979e1863077ec209f63fb469 4.0 KiB   1
sha256:2e8b536212e956b07542e85569d0d7efa09f01024de78bd86c03a33e9857aa95 4.0 KiB   1
sha256:4fbde15ddd9c87e9740ba02a601bc306c500cf95d508227831dd02907f36aea1 3.8 MiB   3
sha256:5719bce6612f41a4e92930ee71796201f85fa1bc693afcd9de7e4a3805f56bc0 24.0 KiB  4
sha256:5d6434a58230148a9bf8aefd8e4bd6a75bc92bb21b908cb7433fd298efcfa3d8 4.0 KiB   1
sha256:5eccfed8da2b943d2dfd8ac925e97d1bc700fa4ecdc89ff683f6511da02daf5c 16.0 KiB  4
sha256:61f536f56b676cd1628cb461f025476c6dfd0d9fbd782146fbe6d4ca77d8c34e 4.0 KiB   1
sha256:705a1539a7151dba137b5e4ec81e2e0ae21ac4f2c363bae82cc8e1c267fe1c75 36.0 KiB  4
sha256:789e8785856068b4d715aadd22bbc20c31518bd9f9699eeb162ea88e6776d466 4.0 KiB   1
sha256:8190de964f7688b1d32b88835e62ed050b03848ec32b7c6f5ef9076f228b5b25 4.0 KiB   1
sha256:8c2ed532dce363da2d08489f385c432f7c0ee4509ab4e20eb2778803916adc93 3.2 MiB   3
sha256:8cf78d04c06d53f2e99ada3473da4221e59f18857f90e1f2d5710699d934cbf7 24.0 KiB  4
sha256:931045627ee1e0e44af51ec89dda09759f5c52ceffd8ae2db92405259d39e323 4.0 KiB   1
sha256:9654e96f4c04cb672d22bc09935147100246398a77923d62088e57e2c02ec8cf 24.0 KiB  4
sha256:9b143edfe7a0b6341370fcc0f09d5420c1f4b2904e4e8aa53cf50d8aa4ebfb9b 4.0 KiB   1
sha256:9deb5a38cd37dd10431f5f8c414f02638cd84c4449596a6cea8ae44f2d4c6a9d 28.0 KiB  4
sha256:a331eac0fc34b4a97d66213fcc458896fd0d43b6973f3494cfe013dabed3ad02 24.0 KiB  4
sha256:a63ecf415944e53401008c5786f7b30a34067567f373bd67034f30a718be45b8 4.0 KiB   1
sha256:ab9639681f582c8e81ba914b9448316cf2ded3e6a88764197e15e5d43c6374c2 4.0 KiB   1
sha256:ae92af8d12aaf8ac4c9bea9c7baf961e13e6e4f58decac40cb4c0711030fded8 266.4 MiB 4
sha256:b0a7b8145d4a658c505358d4d2c76028d7cd380867c2072e3a4722e24d8d71d9 41.6 MiB  4
sha256:c33c40022c8f333e7f199cd094bd56758bc479ceabf1e490bb75497bf47c2ebf 4.0 KiB   1
sha256:c76eea57d04f9607823d22d37a49d0a596e9c1af3d2d9b55d1f73ff6d84a74ad 50.9 MiB  4
sha256:c858413d9e5162c287028d630128ea4323d5029bf8a093af783480b38cf8d44e 128.6 MiB 4
sha256:d4e40dfbb1fd529fcad279dd882d9d4002cf21b6130ef0f384613cb8f7e097b3 4.0 KiB   1
sha256:e2824c891805a25a7a7e32cde05904bd6fbcc5393abb0505c419d50e75b1efb5 4.0 KiB   1
sha256:ef8095b843d412e088fd410f3d2729246457a3273e1feecee45814df03bc7856 1.3 MiB   4
sha256:fb7b6c8aaefef87be8adab437710822613b7f3a10ca28e72be4da91c55b0a7e9 10.0 MiB  4
sha256:fcb51e3c865d96542718beba0bb247376e4c78e039412c5d30c989872e66b6d5 4.0 KiB   1
```