### PR TITLE
[Bugfix] Use the correct label to distinguish the lower layer from th…

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -338,10 +338,8 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 				}
 			}
 		}
-	}
-
-	// Mount image for running container, which has a nydus/stargz image as parent.
-	if prepareForContainer(*base) {
+	} else {
+		// Mount image for running container, which has a nydus/stargz image as parent.
 		logCtx.Infof("prepare for container layer %s", key)
 		if id, info, err := o.findMetaLayer(ctx, key); err == nil {
 			// For stargz layer, we need to merge all bootstraps into one.
@@ -372,11 +370,6 @@ func (o *snapshotter) findMetaLayer(ctx context.Context, key string) (string, sn
 		}
 		return ok
 	})
-}
-
-func prepareForContainer(info snapshots.Info) bool {
-	_, ok := info.Labels[label.CRIImageLayers]
-	return !ok
 }
 
 func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {


### PR DESCRIPTION
…e upper layer

Previously, the unreliable (may not exist, such as when disable_snapshot_annotations = true) label added by cri was used as the basis for judging the upper layer, then when the OCI image without the label was started, it would mistakenly enter prepare for upper layer logic.

We noticed that "containerd.io/snapshot.ref" is a label added by containerd before calling sn.Prepare(), and only exists in the lower layer snapshot, not in the upper layer, so we can simply put the negative situation of lower layer as the upper layer.

Signed-off-by: zhaoshang <zhaoshangsjtu@linux.alibaba.com>