### PR TITLE
Update GitHub actions packages in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           go-version: "1.19.1"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: cache go mod
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
@@ -43,9 +43,9 @@ jobs:
         with:
           go-version: "1.18.6"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: cache go mod
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
@@ -81,9 +81,9 @@ jobs:
         with:
           go-version: "1.18.6"
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: cache go mod
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
@@ -104,9 +104,9 @@ jobs:
         with:
           go-version: "1.18.6"
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache go mod
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           go-version: "1.18.6"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache go mod
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18.6"
       - name: cache go mod
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
@@ -29,7 +29,7 @@ jobs:
           export PATH=$PATH:$(go env GOPATH)/bin
           make
       - name: upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: nydus-snapshotter_artifacts
           path: |
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install hub
         run: |
           HUB_VER=$(curl -s "https://api.github.com/repos/github/hub/releases/latest" | jq -r .tag_name | sed 's/^v//')
@@ -46,7 +46,7 @@ jobs:
           tar xz --strip-components=2 --wildcards '*/bin/hub'
           sudo mv hub /usr/local/bin/hub
       - name: download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: nydus-snapshotter_artifacts
           path: nydus-snapshotter


### PR DESCRIPTION
Update actions/checkout, actions/cache, and actions/upload-artifact to v3.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>