### PR TITLE
Update golangci-lint to v1.50.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-go
       - name: Build
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
           export PATH=$PATH:$(go env GOPATH)/bin
           make
           make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,6 @@ linters:
     - dogsled
     # - nilnil
     - unparam
-    - unused
     - nilerr
     # - goerr113
     - exportloopref


### PR DESCRIPTION
Updates golangci-lint to v1.50.1 and removes a duplicate linter setting.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>