### PR TITLE
Running state cache

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -135,7 +135,7 @@ func (d *Daemon) AddInstance(r *Rafs) {
 // 1. INIT
 // 2. READY: All needed resources are ready.
 // 3. RUNNING
-func (d *Daemon) State() (types.DaemonState, error) {
+func (d *Daemon) GetState() (types.DaemonState, error) {
 	c, err := d.GetClient()
 	if err != nil {
 		return types.DaemonStateUnknown, errors.Wrapf(err, "get daemon state")
@@ -155,7 +155,7 @@ func (d *Daemon) State() (types.DaemonState, error) {
 //  3. RUNNING
 func (d *Daemon) WaitUntilState(expected types.DaemonState) error {
 	return retry.Do(func() error {
-		state, err := d.State()
+		state, err := d.GetState()
 		if err != nil {
 			return errors.Wrapf(err, "wait until daemon is %s", expected)
 		}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/utils/mount"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/retry"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -70,6 +71,8 @@ type Daemon struct {
 	// Nil means this daemon object has no supervisor
 	Supervisor *supervisor.Supervisor
 	Config     daemonconfig.DaemonConfig
+
+	stateGetterGroup singleflight.Group
 
 	ref   int32
 	State types.DaemonState
@@ -137,11 +140,6 @@ func (d *Daemon) AddInstance(r *Rafs) {
 // 2. READY: All needed resources are ready.
 // 3. RUNNING
 func (d *Daemon) GetState() (types.DaemonState, error) {
-	// Daemon caches the RUNNING state if it ever be retrieved.
-	if d.State == types.DaemonStateRunning {
-		return d.State, nil
-	}
-
 	c, err := d.GetClient()
 	if err != nil {
 		return types.DaemonStateUnknown, errors.Wrapf(err, "get daemon state")
@@ -153,9 +151,7 @@ func (d *Daemon) GetState() (types.DaemonState, error) {
 
 	st := info.DaemonState()
 
-	if st == types.DaemonStateRunning {
-		d.State = types.DaemonStateRunning
-	}
+	d.State = st
 
 	return st, nil
 }
@@ -166,23 +162,36 @@ func (d *Daemon) GetState() (types.DaemonState, error) {
 //  2. READY
 //  3. RUNNING
 func (d *Daemon) WaitUntilState(expected types.DaemonState) error {
-	return retry.Do(func() error {
-		state, err := d.GetState()
-		if err != nil {
-			return errors.Wrapf(err, "wait until daemon is %s", expected)
-		}
+	stateGetter := func() (v any, err error) {
+		err = retry.Do(func() error {
+			if expected == d.State {
+				return nil
+			}
 
-		if state != expected {
-			return errors.Errorf("daemon %s is not %s yet, current state %s",
-				d.ID(), expected, state)
-		}
+			state, err := d.GetState()
+			if err != nil {
+				return errors.Wrapf(err, "wait until daemon is %s", expected)
+			}
 
-		return nil
-	},
-		retry.Attempts(20), // totally wait for 2 seconds, should be enough
-		retry.LastErrorOnly(true),
-		retry.Delay(100*time.Millisecond),
-	)
+			if state != expected {
+				return errors.Errorf("daemon %s is not %s yet, current state %s",
+					d.ID(), expected, state)
+			}
+
+			return nil
+		},
+			retry.Attempts(20), // totally wait for 2 seconds, should be enough
+			retry.LastErrorOnly(true),
+			retry.Delay(100*time.Millisecond),
+		)
+
+		return
+	}
+
+	_, err, shared := d.stateGetterGroup.Do(d.ID(), stateGetter)
+	log.L.Debugf("Get daemon %s with shared result: %v ", d.ID(), shared)
+
+	return err
 }
 
 func (d *Daemon) SharedMount(rafs *Rafs) error {

--- a/pkg/daemon/types/types.go
+++ b/pkg/daemon/types/types.go
@@ -15,13 +15,13 @@ type BuildTimeInfo struct {
 	Rustc      string `json:"rustc"`
 }
 
+type DaemonState string
+
 type DaemonInfo struct {
 	ID      string        `json:"id"`
 	Version BuildTimeInfo `json:"version"`
 	State   DaemonState   `json:"state"`
 }
-
-type DaemonState string
 
 const (
 	DaemonStateUnknown DaemonState = "UNKNOWN"

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -528,7 +528,7 @@ func (m *Manager) Recover(ctx context.Context) (map[string]*daemon.Daemon, map[s
 			d.Config = cfg
 		}
 
-		state, err := d.State()
+		state, err := d.GetState()
 		if err != nil {
 			log.L.Warnf("Daemon %s died somehow. Clean up its vestige!, %s", d.ID(), err)
 			recoveringDaemons[d.ID()] = d


### PR DESCRIPTION
At present, nydus-snapshotter queries daemon's state each
time when it gets daemon object's state. The query comes
from several positions which cause duplicated query.
We can use single-flight mechanism to query daemon'state
to reduce unnecessary comunications between processes.

This changeset will benefit container startup performance.