### PR TITLE
fails snapshotter startup if its fsdriver mismatches daemon's

### DIFF
--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -39,16 +39,16 @@ func main() {
 				fmt.Println("Build time: ", version.BuildTimestamp)
 				return nil
 			}
-			var (
-				cfg config.Config
-			)
+
+			var cfg config.Config
+
 			if snapshotterCfg, err := config.LoadSnapshotterConfig(flags.Args.ConfigPath); err == nil && snapshotterCfg != nil {
 				if err = config.SetStartupParameter(&snapshotterCfg.StartupFlag, &cfg); err != nil {
-					return errors.Wrap(err, "invalid configuration")
+					return errors.Wrap(err, "parse parameters")
 				}
 			} else {
 				if err := config.SetStartupParameter(flags.Args, &cfg); err != nil {
-					return errors.Wrap(err, "invalid argument")
+					return errors.Wrap(err, "parse parameters")
 				}
 			}
 
@@ -61,10 +61,11 @@ func main() {
 				RotateLogCompress:   cfg.RotateLogCompress,
 			}
 			if err := logging.SetUp(flags.Args.LogLevel, flags.Args.LogToStdout, flags.Args.LogDir, flags.Args.RootDir, logRotateArgs); err != nil {
-				return errors.Wrap(err, "failed to set up logger")
+				return errors.Wrap(err, "set up logger")
 			}
 
-			log.L.Infof("Start nydus-snapshotter. PID %d Version %s", os.Getpid(), version.Version)
+			log.L.Infof("Start nydus-snapshotter. PID %d Version %s FsDriver %s DaemonMode %s",
+				os.Getpid(), version.Version, cfg.FsDriver, cfg.DaemonMode)
 
 			return snapshotter.Start(ctx, cfg)
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,7 @@ type Config struct {
 	NydusdBinaryPath         string        `toml:"nydusd_binary_path"`
 	NydusImageBinaryPath     string        `toml:"nydus_image_binary"`
 	DaemonMode               DaemonMode    `toml:"daemon_mode"`
-	FsDriver                 string        `toml:"daemon_backend"`
+	FsDriver                 string        `toml:"fs_driver"`
 	SyncRemove               bool          `toml:"sync_remove"`
 	EnableMetrics            bool          `toml:"enable_metrics"`
 	MetricsFile              string        `toml:"metrics_file"`

--- a/pkg/filesystem/fs/config.go
+++ b/pkg/filesystem/fs/config.go
@@ -33,84 +33,84 @@ func WithMeta(root string) NewFSOpt {
 }
 
 func WithNydusImageBinaryPath(p string) NewFSOpt {
-	return func(d *Filesystem) error {
-		d.nydusImageBinaryPath = p
+	return func(fs *Filesystem) error {
+		fs.nydusImageBinaryPath = p
 		return nil
 	}
 }
 
 func WithManager(pm *manager.Manager) NewFSOpt {
-	return func(d *Filesystem) error {
+	return func(fs *Filesystem) error {
 		if pm == nil {
 			return errors.New("process manager cannot be nil")
 		}
 
-		d.Manager = pm
+		fs.Manager = pm
 		return nil
 	}
 }
 
 func WithCacheManager(cm *cache.Manager) NewFSOpt {
-	return func(d *Filesystem) error {
+	return func(fs *Filesystem) error {
 		if cm == nil {
 			return errors.New("cache manager cannot be nil")
 		}
 
-		d.cacheMgr = cm
+		fs.cacheMgr = cm
 		return nil
 	}
 }
 
 func WithVerifier(verifier *signature.Verifier) NewFSOpt {
-	return func(d *Filesystem) error {
-		d.verifier = verifier
+	return func(fs *Filesystem) error {
+		fs.verifier = verifier
 		return nil
 	}
 }
 
 func WithVPCRegistry(vpcRegistry bool) NewFSOpt {
-	return func(d *Filesystem) error {
-		d.vpcRegistry = vpcRegistry
+	return func(fs *Filesystem) error {
+		fs.vpcRegistry = vpcRegistry
 		return nil
 	}
 }
 
 func WithDaemonMode(daemonMode config.DaemonMode) NewFSOpt {
-	return func(d *Filesystem) error {
-		d.mode = daemonMode
+	return func(fs *Filesystem) error {
+		fs.mode = daemonMode
 		return nil
 	}
 }
 
 func WithFsDriver(fsDriver string) NewFSOpt {
-	return func(d *Filesystem) error {
+	return func(fs *Filesystem) error {
 		switch fsDriver {
 		case config.FsDriverFscache:
-			d.fsDriver = config.FsDriverFscache
+			fs.fsDriver = config.FsDriverFscache
 		default:
-			d.fsDriver = config.FsDriverFusedev
+			fs.fsDriver = config.FsDriverFusedev
 		}
 		return nil
 	}
 }
 
 func WithLogLevel(logLevel string) NewFSOpt {
-	return func(d *Filesystem) error {
+	return func(fs *Filesystem) error {
 		if logLevel == "" {
-			d.logLevel = config.DefaultLogLevel
+			fs.logLevel = config.DefaultLogLevel
 		} else {
-			d.logLevel = logLevel
+			fs.logLevel = logLevel
 		}
 		return nil
 	}
 }
 
 func WithLogDir(dir string) NewFSOpt {
-	return func(d *Filesystem) error {
+	return func(fs *Filesystem) error {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return errors.Errorf("failed to create logDir %s: %v", dir, err)
 		}
-		d.logDir = dir
+		fs.logDir = dir
 		return nil
 	}
 }
@@ -123,23 +123,23 @@ func WithLogToStdout(logToStdout bool) NewFSOpt {
 }
 
 func WithNydusdThreadNum(nydusdThreadNum int) NewFSOpt {
-	return func(d *Filesystem) error {
-		d.nydusdThreadNum = nydusdThreadNum
+	return func(fs *Filesystem) error {
+		fs.nydusdThreadNum = nydusdThreadNum
 		return nil
 	}
 }
 
 func WithRootMountpoint(mountpoint string) NewFSOpt {
-	return func(d *Filesystem) error {
-		d.rootMountpoint = mountpoint
+	return func(fs *Filesystem) error {
+		fs.rootMountpoint = mountpoint
 		return nil
 	}
 }
 
 func WithEnableStargz(enable bool) NewFSOpt {
-	return func(d *Filesystem) error {
+	return func(fs *Filesystem) error {
 		if enable {
-			d.stargzResolver = stargz.NewResolver()
+			fs.stargzResolver = stargz.NewResolver()
 		}
 		return nil
 	}

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -434,7 +434,6 @@ func (fs *Filesystem) initSharedDaemon() (err error) {
 // createDaemon create new nydus daemon by snapshotID and imageID
 // For fscache driver, no need to provide mountpoint to nydusd daemon.
 func (fs *Filesystem) createDaemon(mountpoint string, ref int32) (d *daemon.Daemon, err error) {
-
 	opts := []daemon.NewDaemonOpt{
 		daemon.WithRef(ref),
 		daemon.WithSocketDir(fs.SocketRoot()),

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -91,6 +91,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		CacheDir:         cfg.CacheDir,
 		RootDir:          cfg.RootDir,
 		RecoverPolicy:    rp,
+		FsDriver:         cfg.FsDriver,
 		DaemonConfig:     daemonConfig,
 	})
 	if err != nil {


### PR DESCRIPTION
I have observed that users misuses snapshotter's fsdirver parameter by changing it between two startups. As the daemon is
persisted to database, snapshotter can't at the same time serves two types of fsdrvier. So we should abort this startup

Otherwise, even snapshotter can restore and recover daemons during this startup, it can't provide correct rootfs.

