### PR TITLE
Optimize how nydus meta snapshot is prepared and enable errcheck linter

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags_test.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags_test.go
@@ -17,7 +17,8 @@ func TestNewFlags(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	flags := NewFlags()
 	for _, i := range flags.F {
-		i.Apply(set)
+		err := i.Apply(set)
+		assert.Nil(t, err)
 	}
 	err := set.Parse([]string{"--config-path", "/etc/testconfig", "--root", "/root"})
 	assert.Nil(t, err)

--- a/cmd/containerd-nydus-grpc/pkg/logging/setup_test.go
+++ b/cmd/containerd-nydus-grpc/pkg/logging/setup_test.go
@@ -25,12 +25,15 @@ const (
 
 func GetRotateLogFileNumbers(testLogDir string, suffix string) int {
 	i := 0
-	filepath.Walk(testLogDir, func(fname string, fi os.FileInfo, err error) error {
+	err := filepath.Walk(testLogDir, func(fname string, fi os.FileInfo, err error) error {
 		if !fi.IsDir() && strings.HasSuffix(fname, suffix) {
 			i++
 		}
 		return nil
 	})
+	if err != nil {
+		log.L.Fatal("walk path")
+	}
 	return i
 }
 

--- a/pkg/backend/oss.go
+++ b/pkg/backend/oss.go
@@ -141,7 +141,10 @@ func (b *OSSBackend) push(ra content.ReaderAt, blobDigest digest.Digest) error {
 		}
 
 		if err := g.Wait(); err != nil {
-			b.bucket.AbortMultipartUpload(imur)
+			if err := b.bucket.AbortMultipartUpload(imur); err != nil {
+				close(partsChan)
+				return errors.Wrap(err, "aborting upload")
+			}
 			close(partsChan)
 			return errors.Wrap(err, "upload parts")
 		}

--- a/pkg/blob/blob_manager.go
+++ b/pkg/blob/blob_manager.go
@@ -53,7 +53,7 @@ func (b *Manager) Run(ctx context.Context) error {
 		case id := <-b.eventChan:
 			err := b.cleanupBlob(id)
 			if err != nil {
-				log.G(ctx).Warnf("delete blob %s failed", id)
+				log.G(ctx).WithError(err).Warnf("delete blob %s failed", id)
 			} else {
 				log.G(ctx).Infof("delete blob %s success", id)
 			}

--- a/pkg/blob/blob_manager.go
+++ b/pkg/blob/blob_manager.go
@@ -146,7 +146,11 @@ func (b *Manager) PrepareBlobLayer(snapshot storage.Snapshot, labels map[string]
 	if err != nil {
 		return errors.Wrap(err, "rename temp file as blob file")
 	}
-	os.Chmod(blobFile.Name(), 0440)
+
+	err = os.Chmod(blobPath, 0440)
+	if err != nil {
+		return errors.Wrapf(err, "chmod blob %s", blobPath)
+	}
 
 	return nil
 }

--- a/pkg/blob/blob_manager_test.go
+++ b/pkg/blob/blob_manager_test.go
@@ -32,10 +32,10 @@ func Test_Remove(t *testing.T) {
 	defer cancel()
 	blobMgr := NewBlobManager(dir, resolve.NewResolver())
 	go func() {
-		err := blobMgr.Run(ctx)
-		assert.Nil(t, err)
+		// This goroutine can be canceled, so ignore error
+		_ = blobMgr.Run(ctx)
 	}()
-	err = blobMgr.Remove(id, true)
+	err = blobMgr.Remove("sha256:"+id, true)
 	assert.Nil(t, err)
 	// wait to deleted the file
 	time.Sleep(time.Millisecond * 100)

--- a/pkg/blob/blob_manager_test.go
+++ b/pkg/blob/blob_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containerd/nydus-snapshotter/pkg/resolve"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Remove(t *testing.T) {
@@ -31,9 +32,11 @@ func Test_Remove(t *testing.T) {
 	defer cancel()
 	blobMgr := NewBlobManager(dir, resolve.NewResolver())
 	go func() {
-		blobMgr.Run(ctx)
+		err := blobMgr.Run(ctx)
+		assert.Nil(t, err)
 	}()
-	blobMgr.Remove(id, true)
+	err = blobMgr.Remove(id, true)
+	assert.Nil(t, err)
 	// wait to deleted the file
 	time.Sleep(time.Millisecond * 100)
 	_, err = os.Stat(filepath.Join(dir, "sha256:"+id))

--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -217,9 +217,11 @@ func (c *nydusdClient) GetFsMetrics(sid string) (*types.FsMetrics, error) {
 
 	url := c.url(endpointMetrics, query)
 	var m types.FsMetrics
-	c.request(http.MethodGet, url, nil, func(resp *http.Response) error {
+	if err := c.request(http.MethodGet, url, nil, func(resp *http.Response) error {
 		return decode(resp, &m)
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	return &m, nil
 }
@@ -232,9 +234,11 @@ func (c *nydusdClient) GetCacheMetrics(sid string) (*types.CacheMetrics, error) 
 
 	url := c.url(endpointCacheMetrics, query)
 	var m types.CacheMetrics
-	c.request(http.MethodGet, url, nil, func(resp *http.Response) error {
+	if err := c.request(http.MethodGet, url, nil, func(resp *http.Response) error {
 		return decode(resp, &m)
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	return &m, nil
 }

--- a/pkg/daemon/client_test.go
+++ b/pkg/daemon/client_test.go
@@ -46,7 +46,8 @@ func prepareNydusServer(t *testing.T) (string, func()) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		j, _ := json.Marshal(info)
-		w.Write(j)
+		_, err := w.Write(j)
+		assert.Nil(t, err)
 	}))
 	unixListener, err := net.Listen("unix", mockSocket)
 	require.Nil(t, err)

--- a/pkg/daemon/command/command_builder_test.go
+++ b/pkg/daemon/command/command_builder_test.go
@@ -50,6 +50,7 @@ func BenchmarkBuildCommand(b *testing.B) {
 		WithUpgrade()}
 
 	for n := 0; n < b.N; n++ {
-		BuildCommand(c)
+		_, err := BuildCommand(c)
+		assert.Nil(b, err)
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -461,9 +461,10 @@ func (d *Daemon) Wait() error {
 		// nydus-snapshotter, p.Wait() will return err, so here should exclude this case
 		if _, err = p.Wait(); err != nil && !errors.Is(err, syscall.ECHILD) {
 			log.L.Errorf("failed to process wait, %v", err)
-
 		} else {
-			mount.WaitUntilUnmounted(d.HostMountpoint())
+			if err := mount.WaitUntilUnmounted(d.HostMountpoint()); err != nil {
+				log.L.WithError(err).Errorf("umount %s", d.HostMountpoint())
+			}
 		}
 	}
 

--- a/pkg/filesystem/fs/fs.go
+++ b/pkg/filesystem/fs/fs.go
@@ -152,6 +152,10 @@ func (fs *Filesystem) WaitUntilReady(snapshotID string) error {
 	}
 
 	instance := daemon.RafsSet.Get(snapshotID)
+	if instance == nil {
+		return errors.Wrapf(errdefs.ErrNotFound, "no instance %s", snapshotID)
+	}
+
 	d := fs.Manager.GetByDaemonID(instance.DaemonID)
 	if d == nil {
 		return errors.Wrapf(errdefs.ErrNotFound, "snapshot id %s daemon id %s", snapshotID, instance.DaemonID)

--- a/pkg/filesystem/fs/stargz_adaptor.go
+++ b/pkg/filesystem/fs/stargz_adaptor.go
@@ -146,7 +146,9 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 		if err != nil {
 			return errors.Wrap(err, "rename merged stargz layers")
 		}
-		os.Chmod(mergedBootstrap, 0440)
+		if err := os.Chmod(mergedBootstrap, 0440); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -186,7 +188,10 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, blob *stargz.B
 	if err != nil {
 		return errors.Wrap(err, "failed to save stargz index")
 	}
-	os.Chmod(stargzFile, 0440)
+	err = os.Chmod(stargzFile, 0440)
+	if err != nil {
+		return err
+	}
 
 	blobMetaPath := filepath.Join(fs.cacheMgr.CacheDir(), fmt.Sprintf("%s.blob.meta", blobID))
 	if fs.fsDriver == config.FsDriverFscache {
@@ -236,7 +241,10 @@ func (fs *Filesystem) PrepareStargzMetaLayer(ctx context.Context, blob *stargz.B
 	if err != nil {
 		return errors.Wrap(err, "rename converted stargz layer")
 	}
-	os.Chmod(convertedBootstrap, 0440)
+
+	if err := os.Chmod(convertedBootstrap, 0440); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/manager/monitor_test.go
+++ b/pkg/manager/monitor_test.go
@@ -87,7 +87,8 @@ func TestLivenessMonitor(t *testing.T) {
 	event := <-notifier
 	assert.Equal(t, event.daemonID, "daemon_1")
 
-	monitor.Unsubscribe("daemon_2")
+	err := monitor.Unsubscribe("daemon_2")
+	assert.Nil(t, err)
 	cancel2()
 
 	// Should not block here.

--- a/pkg/metrics/ttl/gauge_test.go
+++ b/pkg/metrics/ttl/gauge_test.go
@@ -37,7 +37,8 @@ func TestNewGaugeVecWithTTL(t *testing.T) {
 	go func() {
 		for m := range metricsCh {
 			var metrics dto.Metric
-			m.Write(&metrics)
+			err := m.Write(&metrics)
+			assert.Nil(t, err)
 			metricsSlice = append(metricsSlice, metrics)
 			wg.Done()
 		}
@@ -60,7 +61,8 @@ func TestNewGaugeVecWithTTL(t *testing.T) {
 	go func() {
 		for m := range metricsCh {
 			var metrics dto.Metric
-			m.Write(&metrics)
+			err := m.Write(&metrics)
+			assert.Nil(t, err)
 			mu.Lock()
 			metricsSlice = append(metricsSlice, metrics)
 			mu.Unlock()

--- a/pkg/stargz/resolver.go
+++ b/pkg/stargz/resolver.go
@@ -182,7 +182,9 @@ func (r *Resolver) resolve(ref, digest string, keychain authn.Keychain) (*io.Sec
 			return 0, err
 		}
 		defer func() {
-			io.Copy(io.Discard, res.Body)
+			if _, err := io.Copy(io.Discard, res.Body); err != nil {
+				log.L.Errorf("failed to copy %s", err)
+			}
 			res.Body.Close()
 		}()
 		if res.StatusCode/100 != 2 {
@@ -208,7 +210,9 @@ func getSize(url string, tr http.RoundTripper) (int64, error) {
 		return 0, err
 	}
 	defer func() {
-		io.Copy(io.Discard, res.Body)
+		if _, err := io.Copy(io.Discard, res.Body); err != nil {
+			log.L.Errorf("failed to copy %s", err)
+		}
 		res.Body.Close()
 	}()
 	if res.StatusCode/100 != 2 {

--- a/pkg/store/database.go
+++ b/pkg/store/database.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 
@@ -164,7 +165,9 @@ func (db *Database) initDatabase() error {
 	}
 
 	if notV1 {
-		db.tryTranslateRecords()
+		if err := db.tryTranslateRecords(); err != nil && !errors.Is(err, errdefs.ErrNotFound) {
+			return errors.Wrapf(err, "convert old database")
+		}
 	}
 
 	return nil
@@ -284,7 +287,12 @@ func (db *Database) NextInstanceSeq() (uint64, error) {
 	if err != nil {
 		return 0, errors.New("failed to start transaction")
 	}
-	defer tx.Rollback()
+
+	defer func() {
+		if rerr := tx.Rollback(); rerr != nil {
+			log.L.WithError(rerr).Errorf("Rollback error when getting next sequence")
+		}
+	}()
 
 	bk := getInstancesBucket(tx)
 

--- a/pkg/store/database_compat.go
+++ b/pkg/store/database_compat.go
@@ -128,11 +128,15 @@ func (db *Database) tryTranslateRecords() error {
 		}
 
 		if newDaemon != nil {
-			db.SaveDaemon(context.TODO(), newDaemon)
+			if err := db.SaveDaemon(context.TODO(), newDaemon); err != nil {
+				return err
+			}
 		}
 
 		if instance != nil {
-			db.AddInstance(context.TODO(), instance)
+			if err := db.AddInstance(context.TODO(), instance); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/store/database_test.go
+++ b/pkg/store/database_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +31,8 @@ func Test_daemon(t *testing.T) {
 	require.Nil(t, err)
 	err = db.SaveDaemon(ctx, &d2)
 	require.Nil(t, err)
-	db.SaveDaemon(ctx, &d3)
+	err = db.SaveDaemon(ctx, &d3)
+	assert.Nil(t, err)
 	require.Nil(t, err)
 	// duplicate daemon id should fail
 	err = db.SaveDaemon(ctx, &d1)
@@ -79,7 +81,8 @@ func TestLegacyRecordsMultipleDaemonModes(t *testing.T) {
 	_, err := io.Copy(dst, src)
 	require.Nil(t, err)
 	dst.Close()
-	NewDatabase("testdata")
+	_, err = NewDatabase("testdata")
+	assert.Nil(t, err)
 
 }
 
@@ -97,5 +100,6 @@ func TestLegacyRecordsSharedDaemonModes(t *testing.T) {
 	_, err := io.Copy(dst, src)
 	require.Nil(t, err)
 	dst.Close()
-	NewDatabase("testdata")
+	_, err = NewDatabase("testdata")
+	assert.Nil(t, err)
 }

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -300,7 +300,10 @@ func (su *Supervisor) SendStatesTimeout(to time.Duration) error {
 }
 
 func (su *Supervisor) FetchDaemonStates(trigger func() error) error {
-	su.sem.Acquire(context.TODO(), 1)
+	if err := su.sem.Acquire(context.TODO(), 1); err != nil {
+		return err
+	}
+
 	defer su.sem.Release(1)
 
 	receiver, err := su.waitStatesTimeout(0)

--- a/pkg/utils/signals/signal_test.go
+++ b/pkg/utils/signals/signal_test.go
@@ -29,7 +29,8 @@ func TestSetupSignalHandler(t *testing.T) {
 	}
 	go func1(signal)
 	go func2(signal)
-	syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	err := syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	require.Nil(t, err)
 	time.Sleep(1 * time.Second)
 	require.Equal(t, atomic.LoadInt32(&actual), expected)
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -267,32 +267,55 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, e
 	return usage, nil
 }
 
-func (o *snapshotter) getSnapShot(ctx context.Context, key string) (*storage.Snapshot, error) {
-	return snapshot.GetSnapshot(ctx, o.ms, key)
-}
-
 func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
-	log.G(ctx).Infof("mount snapshot with key %s", key)
-	s, err := o.getSnapShot(ctx, key)
+	var (
+		needRemoteMounts = false
+		metaSnapshotID   string
+	)
+
+	id, info, _, err := snapshot.GetSnapshotInfo(ctx, o.ms, key)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get active mount")
+		return nil, errors.Wrapf(err, "get snapshot %s info", key)
 	}
 
-	if id, _, rErr := o.findMetaLayer(ctx, key); rErr == nil {
+	log.L.Infof("[Mounts] snapshot %s ID %s Kind %s", key, id, info.Kind)
+
+	if isNydusMetaLayer(info.Labels) {
 		err = o.fs.WaitUntilReady(id)
 		if err != nil {
-			log.G(ctx).Errorf("snapshot %s is not ready, err: %v", id, err)
-			return nil, err
+			return nil, errors.Wrapf(err, "snapshot %s is not ready, err: %v", id, err)
 		}
-		return o.remoteMounts(ctx, *s, id)
+		needRemoteMounts = true
+		metaSnapshotID = id
 	}
 
-	_, snap, _, err := snapshot.GetSnapshotInfo(ctx, o.ms, key)
+	if info.Kind == snapshots.KindActive {
+		pKey := info.Parent
+		pID, info, _, err := snapshot.GetSnapshotInfo(ctx, o.ms, pKey)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to get info for snapshot %s", key))
+			return nil, errors.Wrapf(err, "get snapshot %s info", pKey)
 	}
 
-	return o.mounts(ctx, &snap, *s)
+		if isNydusMetaLayer(info.Labels) {
+			err = o.fs.WaitUntilReady(pID)
+			if err != nil {
+				return nil, errors.Wrapf(err, "snapshot %s is not ready, err: %v", pID, err)
+			}
+			metaSnapshotID = pID
+			needRemoteMounts = true
+		}
+	}
+
+	snap, err := snapshot.GetSnapshot(ctx, o.ms, key)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get snapshot %s", key)
+	}
+
+	if needRemoteMounts {
+		return o.remoteMounts(ctx, *snap, metaSnapshotID)
+	}
+
+	return o.mounts(ctx, &info, *snap)
 }
 
 func (o *snapshotter) prepareRemoteSnapshot(ctx context.Context, id string, labels map[string]string) error {
@@ -301,42 +324,43 @@ func (o *snapshotter) prepareRemoteSnapshot(ctx context.Context, id string, labe
 }
 
 func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
-	logCtx := log.G(ctx).WithField("key", key).WithField("parent", parent)
-	base, s, err := o.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
+	logger := log.L.WithField("key", key).WithField("parent", parent)
+	info, s, err := o.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
 	if err != nil {
 		return nil, err
 	}
-	logCtx.Debugf("prepare snapshot with labels %v", base.Labels)
+
+	logger.Debugf("prepare snapshot with labels %v", info.Labels)
 
 	// Handle nydus/stargz image data layers.
-	if target, ok := base.Labels[label.TargetSnapshotRef]; ok {
+	if target, ok := info.Labels[label.TargetSnapshotRef]; ok {
 		// check if image layer is nydus data layer
-		if isNydusDataLayer(base.Labels) {
-			logCtx.Infof("nydus data layer, skip download and unpack %s", key)
+		if isNydusDataLayer(info.Labels) {
+			logger.Infof("nydus data layer, skip download and unpack %s", key)
 
 			if o.blobMgr != nil {
-				err = o.blobMgr.PrepareBlobLayer(s, base.Labels)
+				err = o.blobMgr.PrepareBlobLayer(s, info.Labels)
 				if err != nil {
-					logCtx.Errorf("failed to prepare nydus data layer of snapshot ID %s, err: %v", s.ID, err)
+					logger.Errorf("failed to prepare nydus data layer of snapshot ID %s, err: %v", s.ID, err)
 					return nil, err
 				}
 			}
 
-			err := o.Commit(ctx, target, key, append(opts, snapshots.WithLabels(base.Labels))...)
+			err := o.Commit(ctx, target, key, append(opts, snapshots.WithLabels(info.Labels))...)
 			if err == nil || errdefs.IsAlreadyExists(err) {
 				return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
 			}
-		} else if !isNydusMetaLayer(base.Labels) {
+		} else if !isNydusMetaLayer(info.Labels) {
 			// Check if image layer is estargz layer
-			if ok, ref, layerDigest, blob := o.fs.IsStargzDataLayer(ctx, base.Labels); ok {
-				err = o.fs.PrepareStargzMetaLayer(ctx, blob, ref, layerDigest, s, base.Labels)
+			if ok, ref, layerDigest, blob := o.fs.IsStargzDataLayer(ctx, info.Labels); ok {
+				err = o.fs.PrepareStargzMetaLayer(ctx, blob, ref, layerDigest, s, info.Labels)
 				if err != nil {
-					logCtx.Errorf("prepare stargz layer of snapshot ID %s, err: %v", s.ID, err)
+					logger.Errorf("prepare stargz layer of snapshot ID %s, err: %v", s.ID, err)
 					// fallback to default OCIv1 handler
 				} else {
 					// Mark this snapshot as stargz layer
-					base.Labels[label.StargzLayer] = "true"
-					err := o.Commit(ctx, target, key, append(opts, snapshots.WithLabels(base.Labels))...)
+					info.Labels[label.StargzLayer] = "true"
+					err := o.Commit(ctx, target, key, append(opts, snapshots.WithLabels(info.Labels))...)
 					if err == nil || errdefs.IsAlreadyExists(err) {
 						return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
 					}
@@ -345,7 +369,8 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 		}
 	} else {
 		// Mount image for running container, which has a nydus/stargz image as parent.
-		logCtx.Infof("prepare for container layer %s", key)
+		logger.Infof("prepare for container layer %s", key)
+
 		if id, info, err := o.findMetaLayer(ctx, key); err == nil {
 			// For stargz layer, we need to merge all bootstraps into one.
 			if o.fs.StargzLayer(info.Labels) {
@@ -354,25 +379,29 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 				}
 			}
 
-			logCtx.Infof("found nydus meta layer id %s", id)
+			logger.Infof("Found nydus meta layer id %s", id)
 
 			if err := o.prepareRemoteSnapshot(ctx, id, info.Labels); err != nil {
 				return nil, err
 			}
 
+			// FIXME: What's strange it that we are providing meta snapshot
+			// contents but not wait for it reaching RUNNING
 			return o.remoteMounts(ctx, s, id)
 		}
 	}
 
-	return o.mounts(ctx, base, s)
+	return o.mounts(ctx, info, s)
 }
 
 func (o *snapshotter) findMetaLayer(ctx context.Context, key string) (string, snapshots.Info, error) {
-	return snapshot.FindSnapshot(ctx, o.ms, key, func(info snapshots.Info) bool {
-		_, ok := info.Labels[label.NydusMetaLayer]
+	return snapshot.IterateParentSnapshots(ctx, o.ms, key, func(id string, i snapshots.Info) bool {
+		ok := isNydusMetaLayer(i.Labels)
+
 		if !ok && o.fs.StargzEnabled() {
-			_, ok = info.Labels[label.StargzLayer]
+			_, ok = i.Labels[label.StargzLayer]
 		}
+
 		return ok
 	})
 }
@@ -636,6 +665,7 @@ type ExtraOption struct {
 	Version     string `json:"fs_version"`
 }
 
+// `s` is the upmost snapshot and `id` refers to the nydus meta snapshot
 func (o *snapshotter) remoteMounts(ctx context.Context, s storage.Snapshot, id string) ([]mount.Mount, error) {
 	var overlayOptions []string
 	if s.Kind == snapshots.KindActive {

--- a/tests/nydusd.go
+++ b/tests/nydusd.go
@@ -159,7 +159,8 @@ func NewNydusd(conf NydusdConfig) (*Nydusd, error) {
 }
 
 func (nydusd *Nydusd) Mount() error {
-	nydusd.Umount()
+	// Ignore the error since the nydusd may not ever start
+	_ = nydusd.Umount()
 
 	args := []string{
 		"--config",


### PR DESCRIPTION
1. Reduce unnecessary database queries
2. enable `errcheck` linter

This PR is very likely to reduce snapshot setup latency.