### PR TITLE
clear daemon state after nydusd dies

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -74,7 +74,8 @@ type Daemon struct {
 
 	stateGetterGroup singleflight.Group
 
-	ref   int32
+	ref int32
+	// Cache the nydusd daemon state to avoid frequently querying nydusd by API.
 	State types.DaemonState
 }
 


### PR DESCRIPTION
A new nydusd has to be brought up, so we have
to query the daemon state again.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>