### PR TITLE
converter: enhance nydus tar unpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ cover:
 
 smoke:
 	$(SUDO) NYDUS_BUILDER=${NYDUS_BUILDER} NYDUS_NYDUSD=${NYDUS_NYDUSD} ${GO_EXECUTABLE_PATH} test -race -v ./tests
-	$(SUDO) NYDUS_BUILDER=${NYDUS_BUILDER} NYDUS_NYDUSD=${NYDUS_NYDUSD} ${GO_EXECUTABLE_PATH} test -race -v ./tests -args -fs-version=6
+	$(SUDO) NYDUS_BUILDER=${NYDUS_BUILDER} NYDUS_NYDUSD=${NYDUS_NYDUSD} ${GO_EXECUTABLE_PATH} test -race -v ./tests
 
 .PHONY: integration
 integration:

--- a/tests/nydusd.go
+++ b/tests/nydusd.go
@@ -75,13 +75,6 @@ func makeConfig(conf NydusdConfig) error {
 	tpl := template.Must(template.New("").Parse(configTpl))
 
 	var ret bytes.Buffer
-	if conf.BackendType == "" {
-		conf.BackendType = "localfs"
-		conf.BackendConfig = `{"dir": "/fake"}`
-		conf.EnablePrefetch = false
-	} else {
-		conf.EnablePrefetch = true
-	}
 	if err := tpl.Execute(&ret, conf); err != nil {
 		return errors.New("prepare config template for Nydusd")
 	}


### PR DESCRIPTION
Unpacking file from nydus blob should seek until encountering the head
of blob stream, this patch ensures this to improve unpack compatibility
and refine the test codes.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>