### PR TITLE
remove scheme field in nydusd config

### DIFF
--- a/cmd/containerd-nydus-grpc/app/snapshotter/testdata/happypath/config.json
+++ b/cmd/containerd-nydus-grpc/app/snapshotter/testdata/happypath/config.json
@@ -3,7 +3,6 @@
     "backend": {
       "type": "registry",
       "config": {
-        "scheme": "https",
         "auth": "",
         "timeout": 5,
         "connect_timeout": 5,

--- a/config/daemonconfig/daemonconfig_test.go
+++ b/config/daemonconfig/daemonconfig_test.go
@@ -19,7 +19,6 @@ func TestLoadConfig(t *testing.T) {
     "backend": {
       "type": "registry",
       "config": {
-        "scheme": "https",
         "skip_verify": true,
         "host": "acr-nydus-registry-vpc.cn-hangzhou.cr.aliyuncs.com",
         "repo": "test/myserver",

--- a/misc/snapshotter/nydusd-config.fscache.json
+++ b/misc/snapshotter/nydusd-config.fscache.json
@@ -2,9 +2,7 @@
     "type": "bootstrap",
     "config": {
         "backend_type": "registry",
-        "backend_config": {
-            "scheme": "https"
-        },
+        "backend_config": {},
         "cache_type": "fscache",
         "prefetch_config": {
             "enable": true,

--- a/misc/snapshotter/nydusd-config.fusedev.json
+++ b/misc/snapshotter/nydusd-config.fusedev.json
@@ -3,7 +3,6 @@
     "backend": {
       "type": "registry",
       "config": {
-        "scheme": "https",
         "timeout": 5,
         "connect_timeout": 5,
         "retry_limit": 2

--- a/pkg/stargz/testdata/config/nydus.json
+++ b/pkg/stargz/testdata/config/nydus.json
@@ -3,7 +3,6 @@
     "backend": {
       "type": "registry",
       "config": {
-        "scheme": "https",
         "auth": "",
         "timeout": 5,
         "connect_timeout": 5,


### PR DESCRIPTION
remove scheme field in nydusd config

We have implemented automatically scheme detect for nydusd in this PR:

https://github.com/dragonflyoss/image-service/pull/893#merged-event

So we can remove the default scheme field in nydusd config file.