### PR TITLE
get rid of getting daemon state in single flight

### DIFF
--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -66,7 +66,7 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 		}
 
 		if err := d.WaitUntilState(types.DaemonStateRunning); err != nil {
-			log.L.Errorf("daemon %s is not managed to reach RUNNING state", d.ID())
+			log.L.WithError(err).Errorf("daemon %s is not managed to reach RUNNING state", d.ID())
 			return
 		}
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -257,7 +257,7 @@ func (m *Manager) doDaemonFailover(d *daemon.Daemon) {
 	}
 
 	if err := d.WaitUntilState(types.DaemonStateInit); err != nil {
-		log.L.Errorf("daemon din't reach state %s", types.DaemonStateInit)
+		log.L.WithError(err).Errorf("daemon didn't reach state %s,", types.DaemonStateInit)
 		return
 	}
 
@@ -311,8 +311,9 @@ func (m *Manager) handleDaemonDeathEvent() {
 			log.L.Warnf("Daemon %s was not found", ev.daemonID)
 			return
 		}
-
+		d.Lock()
 		d.State = types.DaemonStateUnknown
+		d.Unlock()
 		if m.RecoverPolicy == RecoverPolicyRestart {
 			log.L.Infof("Restart daemon %s", ev.daemonID)
 			go m.doDaemonRestart(d)


### PR DESCRIPTION
It is possible that snapshotter waits for RUNNING
state before waits for INIT stat which is a deadlock

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>