### PR TITLE
Resolve warnings in GitHub actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Log in to the container registry
         uses: docker/login-action@v2
         with:
@@ -86,7 +86,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: nydus-snapshotter_artifacts
           path: misc/snapshotter


### PR DESCRIPTION
Updates actions/checkout and actions/download-artifact packages from v2 to v3 to resolve NodeJS 12 warnings.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>