### PR TITLE
feat: add some nydusd-config for metrics work

### DIFF
--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -20,13 +20,14 @@ const CacheDir string = "cachedir"
 
 // Used when nydusd works as a FUSE daemon or vhost-user-fs backend
 type FuseDaemonConfig struct {
-	Device         *DeviceConfig `json:"device"`
-	Mode           string        `json:"mode"`
-	DigestValidate bool          `json:"digest_validate"`
-	IOStatsFiles   bool          `json:"iostats_files,omitempty"`
-	EnableXattr    bool          `json:"enable_xattr,omitempty"`
-
-	FSPrefetch `json:"fs_prefetch,omitempty"`
+	Device          *DeviceConfig `json:"device"`
+	Mode            string        `json:"mode"`
+	DigestValidate  bool          `json:"digest_validate"`
+	IOStatsFiles    bool          `json:"iostats_files,omitempty"`
+	EnableXattr     bool          `json:"enable_xattr,omitempty"`
+	AccessPattern   bool          `json:"access_pattern,omitempty"`
+	LatestReadFiles bool          `json:"latest_read_files,omitempty"`
+	FSPrefetch      `json:"fs_prefetch,omitempty"`
 }
 
 // Control how to perform prefetch from file system layer


### PR DESCRIPTION
Fix the issue#271 , just add the two fileds to the nudusd config,local test the containerd-nydus-grpc works well.
![image](https://user-images.githubusercontent.com/59167816/205545581-d2615f41-ddf5-48c2-81f0-679cab8e689a.png)
Also, this is my first PR, so I am not sure the work is right, It look like so simple, but I can't find any other correlation that needs to be modified.