### PR TITLE
maintenance api server's default socket should be under root dir

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -15,7 +15,6 @@ const (
 	defaultAddress           = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 	defaultLogLevel          = logrus.InfoLevel
 	defaultRootDir           = "/var/lib/containerd-nydus"
-	defaultAPISocket         = "/var/lib/containerd-nydus/api.sock"
 	defaultGCPeriod          = "24h"
 	defaultPublicKey         = "/signing/nydus-image-signing-public.key"
 	DefaultDaemonMode string = "multiple"
@@ -51,7 +50,7 @@ type Args struct {
 	EnableKubeconfigKeychain bool   `toml:"enable_kubeconfig_keychain"`
 	RecoverPolicy            string `toml:"recover_policy"`
 	PrintVersion             bool   `toml:"-"`
-	APISocket                string
+	EnableSystemController   bool
 }
 
 type Flags struct {
@@ -214,11 +213,11 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether to validate integrity of image bootstrap",
 			Destination: &args.ValidateSignature,
 		},
-		&cli.StringFlag{
-			Name:        "api-socket",
-			Value:       defaultAPISocket,
+		&cli.BoolFlag{
+			Name:        "enable-system-controller",
 			Usage:       "(experimental) unix domain socket path to serve HTTP-based system management",
-			Destination: &args.APISocket,
+			Destination: &args.EnableSystemController,
+			Value:       true,
 		},
 		&cli.StringFlag{
 			Name:        "kubeconfig-path",

--- a/config/config.go
+++ b/config/config.go
@@ -110,7 +110,7 @@ type Config struct {
 	RotateLogMaxAge          int           `toml:"log_rotate_max_age"`
 	RotateLogLocalTime       bool          `toml:"log_rotate_local_time"`
 	RotateLogCompress        bool          `toml:"log_rotate_compress"`
-	APISocket                string        `toml:"api_socket"`
+	EnableSystemController   bool          `toml:"enable_system_controller"`
 	RecoverPolicy            string        `toml:"recover_policy"`
 }
 
@@ -205,7 +205,7 @@ func SetStartupParameter(startupFlag *command.Args, cfg *Config) error {
 	cfg.GCPeriod = d
 
 	cfg.Address = startupFlag.Address
-	cfg.APISocket = startupFlag.APISocket
+	cfg.EnableSystemController = startupFlag.EnableSystemController
 	cfg.CleanupOnClose = startupFlag.CleanupOnClose
 	cfg.ConvertVpcRegistry = startupFlag.ConvertVpcRegistry
 	cfg.DisableCacheManager = startupFlag.DisableCacheManager

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -116,8 +116,8 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		}
 	}()
 
-	if cfg.APISocket != "" {
-		systemController, err := system.NewSystemController(manager, cfg.APISocket)
+	if cfg.EnableSystemController {
+		systemController, err := system.NewSystemController(manager, path.Join(cfg.RootDir, "system.sock"))
 		if err != nil {
 			return nil, errors.Wrap(err, "create system controller")
 		}


### PR DESCRIPTION
We should put all snapshotter's stuff under root dir which can be customized.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>