### PR TITLE
Check KubeSecretListener start error

### DIFF
--- a/cmd/containerd-nydus-grpc/app/snapshotter/main.go
+++ b/cmd/containerd-nydus-grpc/app/snapshotter/main.go
@@ -32,7 +32,9 @@ func Start(ctx context.Context, cfg config.Config) error {
 	}
 
 	if cfg.EnableKubeconfigKeychain {
-		auth.InitKubeSecretListener(ctx, cfg.KubeconfigPath)
+		if err := auth.InitKubeSecretListener(ctx, cfg.KubeconfigPath); err != nil {
+			return err
+		}
 	}
 
 	return Serve(ctx, rs, opt, stopSignal)

--- a/pkg/auth/kubesecret_test.go
+++ b/pkg/auth/kubesecret_test.go
@@ -13,14 +13,14 @@ import (
 const (
 	testDockerConfigJSONFmt = `
 {
-        "auths": {
-                "%s": {
-                        "username": "%s",
-						"password": "%s",
-						"email": "%s",
-						"auth": "%s"
-                }
-        }
+	"auths": {
+		"%s": {
+			"username": "%s",
+			"password": "%s",
+			"email": "%s",
+			"auth": "%s"
+		}
+	}
 }
 `
 	dockerConfigKey = "testKey"


### PR DESCRIPTION
Check if KubeSecretListener has start error, then return the error to prevent snapshotter to start.

Also this commit reduce a goroutine that is not required.

Signed-off-by: bin liu <liubin0329@gmail.com>