### PR TITLE
treewide: tidy up --config-path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,9 @@ clear:
 .PHONY: install
 install:
 	sudo install -D -m 755 bin/containerd-nydus-grpc /usr/local/bin/containerd-nydus-grpc
-	sudo install -D -m 755 misc/snapshotter/nydusd-config.${FS_DRIVER}.json /etc/nydus/config.json
+	sudo install -D -m 755 misc/snapshotter/nydusd-config.fusedev.json /etc/nydus/nydusd-config.fusedev.json
+	sudo install -D -m 755 misc/snapshotter/nydusd-config.fscache.json /etc/nydus/nydusd-config.fscache.json
+	sudo ln -s /etc/nydus/nydusd-config.${FS_DRIVER}.json /etc/nydus/nydusd-config.json
 	sudo install -D -m 644 misc/snapshotter/nydus-snapshotter.${FS_DRIVER}.service /etc/systemd/system/nydus-snapshotter.service
 
 	@if which systemctl; then sudo systemctl enable /etc/systemd/system/nydus-snapshotter.service;fi

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Or you can start nydus-snapshotter manually.
 # The default nydus-snapshotter work directory is located at `/var/lib/containerd-nydus`
 
 $ ./containerd-nydus-grpc \
-    --config-path /etc/nydusd-config.json \
+    --config-path /etc/nydus/nydusd-config.json \
     --address /run/containerd-nydus/containerd-nydus-grpc.sock \
     --nydusd-path /usr/local/bin/nydusd \
     --nydusimg-path /usr/local/bin/nydus-image \

--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ const (
 	DefaultLogLevel string = "info"
 	defaultGCPeriod        = 24 * time.Hour
 
-	defaultNydusDaemonConfigPath string = "/etc/nydus/config.json"
+	defaultNydusDaemonConfigPath string = "/etc/nydus/nydusd-config.json"
 	nydusdBinaryName             string = "nydusd"
 	nydusImageBinaryName         string = "nydus-image"
 

--- a/integration/entrypoint.sh
+++ b/integration/entrypoint.sh
@@ -144,7 +144,7 @@ function reboot_containerd {
     fi
 
     if [[ "${fs_driver}" == fusedev ]]; then
-        nydusd_config=/etc/nydus/config.json
+        nydusd_config=/etc/nydus/nydusd-config.json
     else
         nydusd_config="$FSCACHE_NYDUSD_CONFIG"
     fi
@@ -245,7 +245,7 @@ function start_single_container_on_stargz {
     sleep 0.5
 
     containerd-nydus-grpc --enable-stargz --daemon-mode multiple --fs-driver fusedev \
-        --recover-policy none --log-to-stdout --config-path /etc/nydus/config.json &
+        --recover-policy none --log-to-stdout --config-path /etc/nydus/nydusd-config.json &
 
     nerdctl --snapshotter nydus run -d --net none "${STARGZ_IMAGE}"
     detect_go_race
@@ -340,7 +340,7 @@ function kill_snapshotter_and_nydusd_recover {
     killall -9 containerd-nydus-grpc || true
 
     rm "${REMOTE_SNAPSHOTTER_SOCKET:?}"
-    containerd-nydus-grpc --daemon-mode "${daemon_mode}" --log-to-stdout --config-path /etc/nydus/config.json &
+    containerd-nydus-grpc --daemon-mode "${daemon_mode}" --log-to-stdout --config-path /etc/nydus/nydusd-config.json &
     retry ls "${REMOTE_SNAPSHOTTER_SOCKET}"
 
     echo "start new containers"
@@ -397,7 +397,7 @@ function only_restart_snapshotter {
     killall -9 containerd-nydus-grpc || true
 
     rm "${REMOTE_SNAPSHOTTER_SOCKET:?}"
-    containerd-nydus-grpc --daemon-mode "${daemon_mode}" --log-to-stdout --config-path /etc/nydus/config.json &
+    containerd-nydus-grpc --daemon-mode "${daemon_mode}" --log-to-stdout --config-path /etc/nydus/nydusd-config.json &
     retry ls "${REMOTE_SNAPSHOTTER_SOCKET}"
 
     if [[ "${daemon_mode}" == "shared" ]]; then

--- a/misc/snapshotter/nydus-snapshotter.fscache.service
+++ b/misc/snapshotter/nydus-snapshotter.fscache.service
@@ -6,7 +6,7 @@ Before=containerd.service
 [Service]
 Type=simple
 Environment=HOME=/root
-ExecStart=/usr/local/bin/containerd-nydus-grpc --fs-driver fscache --daemon-mode shared --config-path /etc/nydus/config.json
+ExecStart=/usr/local/bin/containerd-nydus-grpc --fs-driver fscache --daemon-mode shared --config-path /etc/nydus/nydusd-config.fscache.json
 Restart=always
 RestartSec=1
 KillMode=process

--- a/misc/snapshotter/nydus-snapshotter.fusedev.service
+++ b/misc/snapshotter/nydus-snapshotter.fusedev.service
@@ -6,7 +6,7 @@ Before=containerd.service
 [Service]
 Type=simple
 Environment=HOME=/root
-ExecStart=/usr/local/bin/containerd-nydus-grpc --config-path /etc/nydus/config.json
+ExecStart=/usr/local/bin/containerd-nydus-grpc --config-path /etc/nydus/nydusd-config.fusedev.json
 Restart=always
 RestartSec=1
 KillMode=process


### PR DESCRIPTION
1. --config-path "/etc/nydus/nydusd-config.fusedev.json" or
                 "/etc/nydus/nydusd-config.fscache.json"

2. Add a symlink /etc/nysud/nydusd-config.json to match the default configuration.

In order to match
https://github.com/dragonflyoss/image-service/pull/955

Signed-off-by: Gao Xiang \<hsiangkao@linux.alibaba.com\>