### PR TITLE
ignore existing symlink target existence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install:
 	sudo install -D -m 755 bin/containerd-nydus-grpc /usr/local/bin/containerd-nydus-grpc
 	sudo install -D -m 755 misc/snapshotter/nydusd-config.fusedev.json /etc/nydus/nydusd-config.fusedev.json
 	sudo install -D -m 755 misc/snapshotter/nydusd-config.fscache.json /etc/nydus/nydusd-config.fscache.json
-	sudo ln -s /etc/nydus/nydusd-config.${FS_DRIVER}.json /etc/nydus/nydusd-config.json
+	sudo ln -f -s /etc/nydus/nydusd-config.${FS_DRIVER}.json /etc/nydus/nydusd-config.json
 	sudo install -D -m 644 misc/snapshotter/nydus-snapshotter.${FS_DRIVER}.service /etc/systemd/system/nydus-snapshotter.service
 
 	@if which systemctl; then sudo systemctl enable /etc/systemd/system/nydus-snapshotter.service;fi


### PR DESCRIPTION
ln: failed to create symbolic link '/etc/nydus/nydusd-config.json': File exists

It's more convenient and does not disturb users

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>