### PR TITLE
converter: add stream mode to `Unpack`

### DIFF
--- a/pkg/converter/cs_proxy_unix.go
+++ b/pkg/converter/cs_proxy_unix.go
@@ -1,0 +1,164 @@
+//go:build !windows
+// +build !windows
+
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package converter
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/containerd/containerd/content"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type contentStoreProxy struct {
+	socketPath string
+	server     *http.Server
+}
+
+func setupContentStoreProxy(workDir string, ra content.ReaderAt) (*contentStoreProxy, error) {
+	sockP, err := os.CreateTemp(workDir, "nydus-cs-proxy-*.sock")
+	if err != nil {
+		return nil, errors.Wrap(err, "create unix socket file")
+	}
+	if err := os.Remove(sockP.Name()); err != nil {
+		return nil, err
+	}
+	listener, err := net.Listen("unix", sockP.Name())
+	if err != nil {
+		return nil, errors.Wrap(err, "listen unix socket when setup content store proxy")
+	}
+
+	server := &http.Server{
+		Handler: contentProxyHandler(ra),
+	}
+
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			logrus.WithError(err).Warn("serve content store proxy")
+		}
+	}()
+
+	return &contentStoreProxy{
+		socketPath: sockP.Name(),
+		server:     server,
+	}, nil
+}
+
+func (p *contentStoreProxy) close() error {
+	defer os.Remove(p.socketPath)
+	if err := p.server.Shutdown(context.Background()); err != nil {
+		return errors.Wrap(err, "shutdown content store proxy")
+	}
+	return nil
+}
+
+func parseRangeHeader(rangeStr string, totalLen int64) (start, wantedLen int64, err error) {
+	rangeList := strings.Split(rangeStr, "-")
+	start, err = strconv.ParseInt(rangeList[0], 10, 64)
+	if err != nil {
+		err = errors.Wrap(err, "parse range header")
+		return
+	}
+	if len(rangeList) == 2 {
+		var end int64
+		end, err = strconv.ParseInt(rangeList[1], 10, 64)
+		if err != nil {
+			err = errors.Wrap(err, "parse range header")
+			return
+		}
+		wantedLen = end - start + 1
+	} else {
+		wantedLen = totalLen - start
+	}
+	if start < 0 || start >= totalLen || wantedLen <= 0 {
+		err = fmt.Errorf("invalid range header: %s", rangeStr)
+		return
+	}
+	return
+}
+
+func contentProxyHandler(ra content.ReaderAt) http.Handler {
+	var (
+		dataReader io.Reader
+		curPos     int64
+
+		tarHeader *tar.Header
+		totalLen  int64
+	)
+	resetReader := func() {
+		seekFile(ra, EntryBlob, func(reader io.Reader, hdr *tar.Header) error {
+			dataReader, tarHeader = reader, hdr
+			return nil
+		})
+		curPos = 0
+	}
+
+	resetReader()
+	if tarHeader != nil {
+		totalLen = tarHeader.Size
+	} else {
+		totalLen = ra.Size()
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			{
+				w.Header().Set("Content-Length", strconv.FormatInt(totalLen, 10))
+				w.Header().Set("Content-Type", "application/octet-stream")
+				return
+			}
+		case http.MethodGet:
+			{
+				start, wantedLen, err := parseRangeHeader(strings.TrimPrefix(r.Header.Get("Range"), "bytes="), totalLen)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(err.Error()))
+					return
+				}
+
+				// we need to make sure that the dataReader is at the right position
+				if start < curPos {
+					resetReader()
+				}
+				if start > curPos {
+					_, err = io.CopyN(io.Discard, dataReader, start-curPos)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(err.Error()))
+						return
+					}
+					curPos = start
+				}
+				// then, the curPos must be equal to start
+
+				readLen, err := io.CopyN(w, dataReader, wantedLen)
+				if err != nil && !errors.Is(err, io.EOF) {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(err.Error()))
+					return
+				}
+				curPos += readLen
+				w.Header().Set("Content-Length", strconv.FormatInt(readLen, 10))
+				w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+readLen-1, totalLen))
+				w.Header().Set("Content-Type", "application/octet-stream")
+				return
+			}
+		}
+	}
+	return http.HandlerFunc(handler)
+}

--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -60,11 +60,12 @@ type MergeOption struct {
 }
 
 type UnpackOption struct {
-	BuilderPath   string
-	BootstrapPath string
-	BlobPath      string
-	TarPath       string
-	Timeout       *time.Duration
+	BuilderPath       string
+	BootstrapPath     string
+	BlobPath          string
+	BackendConfigPath string
+	TarPath           string
+	Timeout           *time.Duration
 }
 
 type outputJSON struct {
@@ -290,7 +291,10 @@ func Unpack(option UnpackOption) error {
 		"--output",
 		option.TarPath,
 	}
-	if option.BlobPath != "" {
+
+	if option.BackendConfigPath != "" {
+		args = append(args, "--backend-config", option.BackendConfigPath)
+	} else if option.BlobPath != "" {
 		args = append(args, "--blob", option.BlobPath)
 	}
 

--- a/pkg/converter/types.go
+++ b/pkg/converter/types.go
@@ -110,6 +110,9 @@ type UnpackOption struct {
 	BuilderPath string
 	// Timeout cancels execution once exceed the specified time.
 	Timeout *time.Duration
+	// Stream enables streaming mode, which doesn't unpack the blob data to disk,
+	// but setup a http server to serve the blob data.
+	Stream bool
 }
 
 type TOCEntry struct {

--- a/tests/converter_test.go
+++ b/tests/converter_test.go
@@ -180,12 +180,12 @@ func buildOCILowerTar(t *testing.T, n int) (io.ReadCloser, map[string]string) {
 	return pr, fileTree
 }
 
-func buildOCIUpperTar(t *testing.T, teePath string, lowerFileTree map[string]string) (io.ReadCloser, map[string]string) {
+func buildOCIUpperTar(t *testing.T, teePath string, lowerFileTree map[string]string, tarSize int) (io.ReadCloser, map[string]string) {
 	if lowerFileTree == nil {
 		lowerFileTree = map[string]string{}
 	}
 
-	hugeStr := hugeString(3)
+	hugeStr := hugeString(tarSize)
 	pr, pw := io.Pipe()
 
 	go func() {
@@ -293,11 +293,13 @@ func packLayerRef(t *testing.T, gzipSource io.ReadCloser, workDir string) (strin
 	return tarBlobMetaFilePath, blobMetaDigest, gzipBlobDigest
 }
 
-func unpackLayer(t *testing.T, workDir string, ra content.ReaderAt) (string, digest.Digest) {
+func unpackLayer(t *testing.T, workDir string, ra content.ReaderAt, stream bool) (string, digest.Digest) {
 	var data bytes.Buffer
 	writer := io.Writer(&data)
 
-	err := converter.Unpack(context.TODO(), ra, writer, converter.UnpackOption{})
+	err := converter.Unpack(context.TODO(), ra, writer, converter.UnpackOption{
+		Stream: stream,
+	})
 	require.NoError(t, err)
 
 	digester := digest.Canonical.Digester()
@@ -423,7 +425,7 @@ func testPack(t *testing.T, fsVersion string) {
 	defer os.RemoveAll(workDir)
 
 	lowerOCITarReader, expectedLowerFileTree := buildOCILowerTar(t, 100)
-	upperOCITarReader, expectedOverlayFileTree := buildOCIUpperTar(t, "", expectedLowerFileTree)
+	upperOCITarReader, expectedOverlayFileTree := buildOCIUpperTar(t, "", expectedLowerFileTree, 3)
 
 	blobDir := filepath.Join(workDir, "blobs")
 	err = os.MkdirAll(blobDir, 0755)
@@ -561,31 +563,33 @@ func TestPackRef(t *testing.T) {
 
 // sudo go test -v -count=1 -run TestUnpack ./tests
 func TestUnpack(t *testing.T) {
-	testUnpack(t, "5")
-	testUnpack(t, "6")
+	testUnpack(t, "5", 3)
+	testUnpack(t, "6", 3)
 }
 
-func testUnpack(t *testing.T, fsVersion string) {
+func testUnpack(t *testing.T, fsVersion string, tarSize int) {
 	workDir, err := os.MkdirTemp("", "nydus-converter-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 
 	ociTar := filepath.Join(workDir, "oci.tar")
-	ociTarReader, _ := buildOCIUpperTar(t, ociTar, nil)
+	ociTarReader, _ := buildOCIUpperTar(t, ociTar, nil, tarSize)
 	nydusTar, _ := packLayer(t, ociTarReader, "", workDir, fsVersion)
 
 	tarTa, err := local.OpenReader(nydusTar)
 	require.NoError(t, err)
 	defer tarTa.Close()
 
-	_, newTarDigest := unpackLayer(t, workDir, tarTa)
-
 	ociTarReader, err = os.OpenFile(ociTar, os.O_RDONLY, 0644)
 	require.NoError(t, err)
 	ociTarDigest, err := digest.Canonical.FromReader(ociTarReader)
 	require.NoError(t, err)
 
-	require.Equal(t, ociTarDigest, newTarDigest)
+	for _, stream := range []bool{true, false} {
+		tarPath, newTarDigest := unpackLayer(t, workDir, tarTa, stream)
+		os.RemoveAll(tarPath)
+		require.Equal(t, ociTarDigest, newTarDigest)
+	}
 }
 
 type ConvertTestOption struct {


### PR DESCRIPTION
This patch adds stream mode to `Unpack`, which avoids to unpack the blob data to the local disk but sets up a local http server to proxy the blob data reading.

Signed-off-by: Nan Li <loheagn@icloud.com>