### PR TITLE
metrics: support HTTP metrics server

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -39,7 +39,7 @@ type Args struct {
 	DaemonMode               string `toml:"daemon_mode"`
 	FsDriver                 string `toml:"fs_driver"`
 	SyncRemove               bool   `toml:"sync_remove"`
-	EnableMetrics            bool   `toml:"enable_metrics"`
+	MetricsAddress           string `toml:"metrics_address"`
 	MetricsFile              string `toml:"metrics_file"`
 	EnableStargz             bool   `toml:"enable_stargz"`
 	DisableCacheManager      bool   `toml:"disable_cache_manager"`
@@ -111,10 +111,11 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether to disable blob cache manager",
 			Destination: &args.DisableCacheManager,
 		},
-		&cli.BoolFlag{
-			Name:        "enable-metrics",
-			Usage:       "whether to collect metrics",
-			Destination: &args.EnableMetrics,
+		&cli.StringFlag{
+			Name:        "metrics-address",
+			Value:       "",
+			Usage:       "Enable metrics server by setting to an `ADDRESS` such as \"localhost:8080\", \":8080\"",
+			Destination: &args.MetricsAddress,
 		},
 		&cli.BoolFlag{
 			Name:        "enable-nydus-overlayfs",

--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	DaemonMode               DaemonMode    `toml:"daemon_mode"`
 	FsDriver                 string        `toml:"fs_driver"`
 	SyncRemove               bool          `toml:"sync_remove"`
-	EnableMetrics            bool          `toml:"enable_metrics"`
+	MetricsAddress           string        `toml:"metrics_address"`
 	MetricsFile              string        `toml:"metrics_file"`
 	EnableStargz             bool          `toml:"enable_stargz"`
 	LogLevel                 string        `toml:"-"`
@@ -239,7 +239,7 @@ func ProcessParameters(args *command.Args, cfg *Config) error {
 	cfg.EnableNydusOverlayFS = args.EnableNydusOverlayFS
 	cfg.FsDriver = args.FsDriver
 
-	cfg.EnableMetrics = args.EnableMetrics
+	cfg.MetricsAddress = args.MetricsAddress
 	cfg.MetricsFile = args.MetricsFile
 
 	cfg.NydusdBinaryPath = args.NydusdBinaryPath

--- a/pkg/metrics/serve.go
+++ b/pkg/metrics/serve.go
@@ -111,7 +111,7 @@ func (s *Server) CollectFsMetrics(ctx context.Context) {
 	}
 }
 
-func (s *Server) StartCollectMetrics(ctx context.Context, enableMetrics bool) error {
+func (s *Server) StartCollectMetrics(ctx context.Context) error {
 	// TODO(renzhen): make collect interval time configurable
 	timer := time.NewTicker(time.Duration(1) * time.Minute)
 
@@ -119,10 +119,8 @@ outer:
 	for {
 		select {
 		case <-timer.C:
-			if enableMetrics {
-				s.CollectFsMetrics(ctx)
-			}
-
+			// Collect FS metrics.
+			s.CollectFsMetrics(ctx)
 			// Collect snapshotter metrics.
 			s.snCollector.Collect()
 		case <-ctx.Done():


### PR DESCRIPTION
The common way to display prometheus format data is through the HTTP server. For instance, [Grafana](https://grafana.com/grafana) does not support collecting metrics from `unix domain socket`. Therefore, we should change the `unix domain socket` server to a HTTP server.

Here is an example:
```shell
containerd-nydus-grpc --config-path /etc/nydus/config.json -metrics-address :9010 --log-to-stdout
curl http://localhost:9010/metrics
```
Then, you will see the prometheus metrics.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>