### PR TITLE
config: add warmup option for nydus daemon

### DIFF
--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -28,6 +28,8 @@ type FuseDaemonConfig struct {
 	AccessPattern   bool          `json:"access_pattern,omitempty"`
 	LatestReadFiles bool          `json:"latest_read_files,omitempty"`
 	FSPrefetch      `json:"fs_prefetch,omitempty"`
+	// (experimental) The nydus daemon could cache more data to increase hit ratio when enabled the warmup feature.
+	Warmup uint64 `json:"warmup,omitempty"`
 }
 
 // Control how to perform prefetch from file system layer


### PR DESCRIPTION
This is an experimental feature. With the warmup option, the nydus daemon could cache more data on the local disk to increase hit ratio.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>