### PR TITLE
metrics: add nydus daemon version

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -77,6 +77,7 @@ type Daemon struct {
 	// How much CPU nydusd is utilizing when starts since full prefetch might
 	// consume many CPU cycles
 	StartupCPUUtilization float64
+	Version               types.BuildTimeInfo
 
 	ref int32
 	// Cache the nydusd daemon state to avoid frequently querying nydusd by API.
@@ -413,6 +414,15 @@ func (d *Daemon) GetFsMetrics(sid string) (*types.FsMetrics, error) {
 	}
 
 	return c.GetFsMetrics(sid)
+}
+
+func (d *Daemon) GetDaemonInfo() (*types.DaemonInfo, error) {
+	c, err := d.GetClient()
+	if err != nil {
+		return nil, errors.Wrapf(err, "get daemon information")
+	}
+
+	return c.GetDaemonInfo()
 }
 
 func (d *Daemon) GetCacheMetrics(sid string) (*types.CacheMetrics, error) {

--- a/pkg/daemon/types/types.go
+++ b/pkg/daemon/types/types.go
@@ -67,16 +67,21 @@ type FsMetrics struct {
 	FopCumulativeLatencyTotal []uint64 `json:"fop_cumulative_latency_total"`
 	ReadLatencyDist           []uint64 `json:"read_latency_dist"`
 	NrOpens                   uint64   `json:"nr_opens"`
-	NrMaxOpens                uint64   `json:"nr_max_opens"`
-	LastFopTp                 uint64   `json:"last_fop_tp"`
 }
 
 type CacheMetrics struct {
-	ID              string   `json:"id"`
-	UnderlyingFiles []string `json:"underlying_files"`
-	StorePath       string   `json:"store_path"`
-	PartialHits     uint64   `json:"partial_hits"`
-	WholeHits       uint64   `json:"whole_hits"`
-	Total           uint64   `json:"total"`
-	EntriesCount    uint32   `json:"entries_count"`
+	ID                           string   `json:"id"`
+	UnderlyingFiles              []string `json:"underlying_files"`
+	StorePath                    string   `json:"store_path"`
+	PartialHits                  uint64   `json:"partial_hits"`
+	WholeHits                    uint64   `json:"whole_hits"`
+	Total                        uint64   `json:"total"`
+	EntriesCount                 uint64   `json:"entries_count"`
+	PrefetchDataAmount           uint64   `json:"prefetch_data_amount"`
+	PrefetchRequestsCount        uint64   `json:"prefetch_requests_count"`
+	PrefetchWorkers              uint     `json:"prefetch_workers"`
+	PrefetchCumulativeTimeMillis uint64   `json:"prefetch_cumulative_time_millis"`
+	PrefetchBeginTimeSecs        uint64   `json:"prefetch_begin_time_secs"`
+	PrefetchEndTimeSecs          uint64   `json:"prefetch_end_time_secs"`
+	BufferedBackendSize          uint64   `json:"buffered_backend_size"`
 }

--- a/pkg/daemon/types/types.go
+++ b/pkg/daemon/types/types.go
@@ -36,6 +36,10 @@ func (info *DaemonInfo) DaemonState() DaemonState {
 	return info.State
 }
 
+func (info *DaemonInfo) DaemonVersion() BuildTimeInfo {
+	return info.Version
+}
+
 type ErrorMessage struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -311,6 +311,7 @@ func (m *Manager) handleDaemonDeathEvent() {
 			log.L.Warnf("Daemon %s was not found", ev.daemonID)
 			return
 		}
+		collector.NewDaemonInfoCollector(&d.Version, -1).Collect()
 		d.Lock()
 		d.State = types.DaemonStateUnknown
 		d.Unlock()
@@ -518,6 +519,7 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 	}
 
 	collector.NewDaemonEventCollector(string(types.DaemonStateDestroyed)).Collect()
+	collector.NewDaemonInfoCollector(&d.Version, -1).Collect()
 
 	return nil
 }

--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -30,6 +30,10 @@ func NewFsMetricsCollector(m *types.FsMetrics, imageRef string) *FsMetricsCollec
 	return &FsMetricsCollector{m, imageRef}
 }
 
+func NewDaemonInfoCollector(version *types.BuildTimeInfo, value float64) *DaemonInfoCollector {
+	return &DaemonInfoCollector{version, value}
+}
+
 func NewSnapshotterMetricsCollector(ctx context.Context, cacheDir string, pid int) (*SnapshotterMetricsCollector, error) {
 	currentStat, err := tool.GetProcessStat(pid)
 	if err != nil {

--- a/pkg/metrics/collector/daemon.go
+++ b/pkg/metrics/collector/daemon.go
@@ -7,6 +7,8 @@
 package collector
 
 import (
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/data"
 )
 
@@ -14,6 +16,19 @@ type DaemonEventCollector struct {
 	event string
 }
 
+type DaemonInfoCollector struct {
+	Version *types.BuildTimeInfo
+	value   float64
+}
+
 func (d *DaemonEventCollector) Collect() {
 	data.NydusdEventCount.WithLabelValues(d.event).Inc()
+}
+
+func (d *DaemonInfoCollector) Collect() {
+	if d.Version == nil {
+		log.L.Warnf("failed to collect daemon count, version is invalid")
+		return
+	}
+	data.NydusdCount.WithLabelValues(d.Version.PackageVer).Add(d.value)
 }

--- a/pkg/metrics/collector/fs.go
+++ b/pkg/metrics/collector/fs.go
@@ -22,10 +22,8 @@ func (f *FsMetricsCollector) Collect() {
 		log.L.Warnf("can not collect FS metrics: Metrics is nil")
 		return
 	}
-	data.ReadCount.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.DataRead))
+	data.TotalRead.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.DataRead))
 	data.OpenFdCount.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.NrOpens))
-	data.OpenFdMaxCount.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.NrMaxOpens))
-	data.LastFopTimestamp.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.LastFopTp))
 
 	for _, h := range data.MetricHists {
 		o, err := h.ToConstHistogram(f.Metrics, f.ImageRef)

--- a/pkg/metrics/data/daemon.go
+++ b/pkg/metrics/data/daemon.go
@@ -9,7 +9,8 @@ package data
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	nydusdEventLabel = "nydusd_event"
+	nydusdEventLabel   = "nydusd_event"
+	nydusdVersionLabel = "version"
 )
 
 var (
@@ -19,5 +20,12 @@ var (
 			Help: "The lifetime events of nydus daemon.",
 		},
 		[]string{nydusdEventLabel},
+	)
+	NydusdCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "nydusd_counts",
+			Help: "The counts of nydus daemon.",
+		},
+		[]string{nydusdVersionLabel},
 	)
 )

--- a/pkg/metrics/data/fs.go
+++ b/pkg/metrics/data/fs.go
@@ -19,11 +19,10 @@ var (
 )
 
 var (
-	// Counters
-	ReadCount = ttl.NewGaugeVecWithTTL(
+	TotalRead = ttl.NewGaugeVecWithTTL(
 		prometheus.GaugeOpts{
-			Name: "nydusd_read_count",
-			Help: "Total number read of a nydus fs, in Byte.",
+			Name: "nydusd_total_read_bytes",
+			Help: "Total bytes read against the nydus filesystem",
 		},
 		[]string{imageRefLabel},
 		ttl.DefaultTTL,
@@ -31,26 +30,8 @@ var (
 
 	OpenFdCount = ttl.NewGaugeVecWithTTL(
 		prometheus.GaugeOpts{
-			Name: "nydusd_open_fd_count",
-			Help: "Number of current open files.",
-		},
-		[]string{imageRefLabel},
-		ttl.DefaultTTL,
-	)
-
-	OpenFdMaxCount = ttl.NewGaugeVecWithTTL(
-		prometheus.GaugeOpts{
-			Name: "nydusd_open_fd_max_count",
-			Help: "Number of max open files.",
-		},
-		[]string{imageRefLabel},
-		ttl.DefaultTTL,
-	)
-
-	LastFopTimestamp = ttl.NewGaugeVecWithTTL(
-		prometheus.GaugeOpts{
-			Name: "nydusd_last_fop_timestamp",
-			Help: "Timestamp of last file operation.",
+			Name: "nydusd_total_open_fd_counts",
+			Help: "Total number of files that are currently open.",
 		},
 		[]string{imageRefLabel},
 		ttl.DefaultTTL,
@@ -61,8 +42,8 @@ var (
 var MetricHists = []*mtypes.MetricHistogram{
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_block_count_read_hist",
-			"Read size histogram, in 1KB, 4KB, 16KB, 64KB, 128KB, 512K, 1024K.",
+			"nydusd_cumulative_read_block_bytes_hist",
+			"Cumulative read size histogram for different block size, in bytes.",
 			[]string{imageRefLabel},
 			prometheus.Labels{},
 		),
@@ -74,8 +55,8 @@ var MetricHists = []*mtypes.MetricHistogram{
 
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_fop_hit_hist",
-			"File operations histogram",
+			"nydusd_file_operation_hit_hist",
+			"Successful various file operations histogram",
 			[]string{imageRefLabel},
 			prometheus.Labels{},
 		),
@@ -87,8 +68,8 @@ var MetricHists = []*mtypes.MetricHistogram{
 
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_fop_errors_hist",
-			"File operations' error histogram",
+			"nydusd_file_operation_error_hist",
+			"Failed file operations histogram",
 			[]string{imageRefLabel},
 			prometheus.Labels{},
 		),
@@ -100,7 +81,7 @@ var MetricHists = []*mtypes.MetricHistogram{
 
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_read_latency_hist",
+			"nydusd_read_latency_microseconds_hist",
 			"Read latency histogram, in microseconds",
 			[]string{imageRefLabel},
 			prometheus.Labels{},

--- a/pkg/metrics/data/fs.go
+++ b/pkg/metrics/data/fs.go
@@ -42,7 +42,7 @@ var (
 var MetricHists = []*mtypes.MetricHistogram{
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_cumulative_read_block_bytes_hist",
+			"nydusd_cumulative_read_block_bytes",
 			"Cumulative read size histogram for different block size, in bytes.",
 			[]string{imageRefLabel},
 			prometheus.Labels{},
@@ -55,7 +55,7 @@ var MetricHists = []*mtypes.MetricHistogram{
 
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_file_operation_hit_hist",
+			"nydusd_file_operation_hits",
 			"Successful various file operations histogram",
 			[]string{imageRefLabel},
 			prometheus.Labels{},
@@ -68,7 +68,7 @@ var MetricHists = []*mtypes.MetricHistogram{
 
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_file_operation_error_hist",
+			"nydusd_file_operation_errors",
 			"Failed file operations histogram",
 			[]string{imageRefLabel},
 			prometheus.Labels{},
@@ -81,7 +81,7 @@ var MetricHists = []*mtypes.MetricHistogram{
 
 	{
 		Desc: prometheus.NewDesc(
-			"nydusd_read_latency_microseconds_hist",
+			"nydusd_read_latency_microseconds",
 			"Read latency histogram, in microseconds",
 			[]string{imageRefLabel},
 			prometheus.Labels{},

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -20,6 +20,7 @@ func init() {
 		data.TotalRead,
 		data.OpenFdCount,
 		data.NydusdEventCount,
+		data.NydusdCount,
 		data.SnapshotEventElapsedHists,
 		data.CacheUsage,
 		data.CPUUsage,

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -17,10 +17,8 @@ var (
 
 func init() {
 	Registry.MustRegister(
-		data.ReadCount,
+		data.TotalRead,
 		data.OpenFdCount,
-		data.OpenFdMaxCount,
-		data.LastFopTimestamp,
 		data.NydusdEventCount,
 		data.SnapshotEventElapsedHists,
 		data.CacheUsage,


### PR DESCRIPTION
Add nydus daemon version to prometheus format metrics.

```=
# HELP nydusd_version_string The version of nydus daemon.
# TYPE nydusd_version_string counter
nydusd_version_string{version="v2.1.0-rc.3.1-473-gf4dd9e1c"} 1
```

Moreover, remove some metrics that have been deleted in nydus and improve descriptions for daemon FS metrics.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>