### PR TITLE
metrics: improve FS metrics and remove unused metrics

### DIFF
--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -30,6 +30,10 @@ func NewFsMetricsCollector(m *types.FsMetrics, imageRef string) *FsMetricsCollec
 	return &FsMetricsCollector{m, imageRef}
 }
 
+func NewFsMetricsVecCollector() *FsMetricsVecCollector {
+	return &FsMetricsVecCollector{}
+}
+
 func NewDaemonInfoCollector(version *types.BuildTimeInfo, value float64) *DaemonInfoCollector {
 	return &DaemonInfoCollector{version, value}
 }

--- a/pkg/metrics/collector/fs.go
+++ b/pkg/metrics/collector/fs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/data"
+	mtypes "github.com/containerd/nydus-snapshotter/pkg/metrics/types"
 )
 
 type FsMetricsCollector struct {
@@ -17,13 +18,18 @@ type FsMetricsCollector struct {
 	ImageRef string
 }
 
+type FsMetricsVecCollector struct {
+	MetricsVec []FsMetricsCollector
+}
+
 func (f *FsMetricsCollector) Collect() {
 	if f.Metrics == nil {
 		log.L.Warnf("can not collect FS metrics: Metrics is nil")
 		return
 	}
-	data.TotalRead.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.DataRead))
-	data.OpenFdCount.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.NrOpens))
+	data.FsTotalRead.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.DataRead))
+	data.FsReadHit.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.FopHits[mtypes.Read]))
+	data.FsReadError.WithLabelValues(f.ImageRef).Set(float64(f.Metrics.FopErrors[mtypes.Read]))
 
 	for _, h := range data.MetricHists {
 		o, err := h.ToConstHistogram(f.Metrics, f.ImageRef)
@@ -32,5 +38,18 @@ func (f *FsMetricsCollector) Collect() {
 			return
 		}
 		h.Save(o)
+	}
+}
+
+func (f *FsMetricsVecCollector) Clear() {
+	for _, h := range data.MetricHists {
+		h.Clear()
+	}
+}
+
+func (f *FsMetricsVecCollector) Collect() {
+	f.Clear()
+	for _, fsMetrics := range f.MetricsVec {
+		fsMetrics.Collect()
 	}
 }

--- a/pkg/metrics/data/fs.go
+++ b/pkg/metrics/data/fs.go
@@ -19,7 +19,7 @@ var (
 )
 
 var (
-	TotalRead = ttl.NewGaugeVecWithTTL(
+	FsTotalRead = ttl.NewGaugeVecWithTTL(
 		prometheus.GaugeOpts{
 			Name: "nydusd_total_read_bytes",
 			Help: "Total bytes read against the nydus filesystem",
@@ -28,10 +28,18 @@ var (
 		ttl.DefaultTTL,
 	)
 
-	OpenFdCount = ttl.NewGaugeVecWithTTL(
+	FsReadHit = ttl.NewGaugeVecWithTTL(
 		prometheus.GaugeOpts{
-			Name: "nydusd_total_open_fd_counts",
-			Help: "Total number of files that are currently open.",
+			Name: "nydusd_read_hits",
+			Help: "Total number of successful read operations.",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+	FsReadError = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_read_errors",
+			Help: "Total number of failed read operations.",
 		},
 		[]string{imageRefLabel},
 		ttl.DefaultTTL,
@@ -52,33 +60,6 @@ var MetricHists = []*mtypes.MetricHistogram{
 			return m.BlockCountRead
 		},
 	},
-
-	{
-		Desc: prometheus.NewDesc(
-			"nydusd_file_operation_hits",
-			"Successful various file operations histogram",
-			[]string{imageRefLabel},
-			prometheus.Labels{},
-		),
-		Buckets: mtypes.MakeFopBuckets(),
-		GetCounters: func(m *types.FsMetrics) []uint64 {
-			return m.FopHits
-		},
-	},
-
-	{
-		Desc: prometheus.NewDesc(
-			"nydusd_file_operation_errors",
-			"Failed file operations histogram",
-			[]string{imageRefLabel},
-			prometheus.Labels{},
-		),
-		Buckets: mtypes.MakeFopBuckets(),
-		GetCounters: func(m *types.FsMetrics) []uint64 {
-			return m.FopErrors
-		},
-	},
-
 	{
 		Desc: prometheus.NewDesc(
 			"nydusd_read_latency_microseconds",

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -17,8 +17,9 @@ var (
 
 func init() {
 	Registry.MustRegister(
-		data.TotalRead,
-		data.OpenFdCount,
+		data.FsTotalRead,
+		data.FsReadHit,
+		data.FsReadError,
 		data.NydusdEventCount,
 		data.NydusdCount,
 		data.SnapshotEventElapsedHists,


### PR DESCRIPTION
Improve FS metrics to collect histograms with labels. Moreover, remove unused metric OpenFdCount.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>