### PR TITLE
nydus-snapshotter own configuration file

### DIFF
--- a/cmd/containerd-nydus-grpc/app/snapshotter/snapshotter.go
+++ b/cmd/containerd-nydus-grpc/app/snapshotter/snapshotter.go
@@ -18,10 +18,10 @@ import (
 	"github.com/containerd/nydus-snapshotter/snapshot"
 )
 
-func Start(ctx context.Context, cfg config.Config) error {
+func Start(ctx context.Context, cfg *config.SnapshotterConfig) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	rs, err := snapshot.NewSnapshotter(ctx, &cfg)
+	rs, err := snapshot.NewSnapshotter(ctx, cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize snapshotter")
 	}
@@ -29,12 +29,12 @@ func Start(ctx context.Context, cfg config.Config) error {
 	stopSignal := signals.SetupSignalHandler()
 	opt := ServeOptions{
 		ListeningSocketPath: cfg.Address,
-		EnableCRIKeychain:   cfg.EnableCRIKeychain,
-		ImageServiceAddress: cfg.ImageServiceAddress,
+		EnableCRIKeychain:   cfg.RemoteConfig.AuthConfig.EnableCRIKeychain,
+		ImageServiceAddress: cfg.RemoteConfig.AuthConfig.ImageServiceAddress,
 	}
 
-	if cfg.EnableKubeconfigKeychain {
-		if err := auth.InitKubeSecretListener(ctx, cfg.KubeconfigPath); err != nil {
+	if cfg.RemoteConfig.AuthConfig.EnableKubeconfigKeychain {
+		if err := auth.InitKubeSecretListener(ctx, cfg.RemoteConfig.AuthConfig.KubeconfigPath); err != nil {
 			return err
 		}
 	}

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -23,36 +23,37 @@ const (
 )
 
 type Args struct {
-	Address                  string `toml:"address"`
-	LogLevel                 string `toml:"log_level"`
-	LogDir                   string `toml:"log_dir"`
-	ConfigPath               string `toml:"config_path"`
-	RootDir                  string `toml:"root_dir"`
-	CacheDir                 string `toml:"cache_dir"`
-	GCPeriod                 string `toml:"gc_period"`
-	ValidateSignature        bool   `toml:"validate_signature"`
-	PublicKeyFile            string `toml:"public_key_file"`
-	ConvertVpcRegistry       bool   `toml:"convert_vpc_registry"`
-	NydusdBinaryPath         string `toml:"nydusd_binary_path"`
-	NydusImageBinaryPath     string `toml:"nydus_image_binary_path"`
-	SharedDaemon             bool   `toml:"-"`
-	DaemonMode               string `toml:"daemon_mode"`
-	FsDriver                 string `toml:"fs_driver"`
-	SyncRemove               bool   `toml:"sync_remove"`
-	MetricsAddress           string `toml:"metrics_address"`
-	EnableStargz             bool   `toml:"enable_stargz"`
-	DisableCacheManager      bool   `toml:"disable_cache_manager"`
-	LogToStdout              bool   `toml:"log_to_stdout"`
-	EnableNydusOverlayFS     bool   `toml:"enable_nydus_overlay_fs"`
-	NydusdThreadNum          int    `toml:"nydusd_thread_num"`
-	CleanupOnClose           bool   `toml:"cleanup_on_close"`
-	KubeconfigPath           string `toml:"kubeconfig_path"`
-	EnableKubeconfigKeychain bool   `toml:"enable_kubeconfig_keychain"`
-	RecoverPolicy            string `toml:"recover_policy"`
-	PrintVersion             bool   `toml:"-"`
+	Address                  string
+	LogLevel                 string
+	LogDir                   string
+	ConfigPath               string
+	SnapshotterConfigPath    string
+	RootDir                  string
+	CacheDir                 string
+	GCPeriod                 string
+	ValidateSignature        bool
+	PublicKeyFile            string
+	ConvertVpcRegistry       bool
+	NydusdPath               string
+	NydusImagePath           string
+	SharedDaemon             bool
+	DaemonMode               string
+	FsDriver                 string
+	SyncRemove               bool
+	MetricsAddress           string
+	EnableStargz             bool
+	DisableCacheManager      bool
+	LogToStdout              bool
+	EnableNydusOverlayFS     bool
+	NydusdThreadsNumber      int
+	CleanupOnClose           bool
+	KubeconfigPath           string
+	EnableKubeconfigKeychain bool
+	RecoverPolicy            string
+	PrintVersion             bool
 	EnableSystemController   bool
-	EnableCRIKeychain        bool   `toml:"enable_cri_keychain"`
-	ImageServiceAddress      string `toml:"image_service_address"`
+	EnableCRIKeychain        bool
+	ImageServiceAddress      string
 }
 
 type Flags struct {
@@ -89,9 +90,14 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "config-path",
-			Aliases:     []string{"c", "config"},
-			Usage:       "path to the configuration `FILE`",
+			Aliases:     []string{"nydusd-config"},
+			Usage:       "path to the nydusd configuration",
 			Destination: &args.ConfigPath,
+		},
+		&cli.StringFlag{
+			Name:        "config",
+			Usage:       "path to the nydus-snapshotter configuration",
+			Destination: &args.SnapshotterConfigPath,
 		},
 		&cli.BoolFlag{
 			Name:        "convert-vpc-registry",
@@ -163,19 +169,19 @@ func buildFlags(args *Args) []cli.Flag {
 			Value:       "",
 			Aliases:     []string{"nydusimg-path"},
 			Usage:       "set `PATH` to the nydus-image binary, default to lookup nydus-image in $PATH",
-			Destination: &args.NydusImageBinaryPath,
+			Destination: &args.NydusImagePath,
 		},
 		&cli.StringFlag{
 			Name:        "nydusd",
 			Value:       "",
 			Aliases:     []string{"nydusd-path"},
 			Usage:       "set `PATH` to the nydusd binary, default to lookup nydusd in $PATH",
-			Destination: &args.NydusdBinaryPath,
+			Destination: &args.NydusdPath,
 		},
 		&cli.IntFlag{
 			Name:        "nydusd-thread-num",
 			Usage:       "set worker thread number for nydusd, default to the number of CPUs",
-			Destination: &args.NydusdThreadNum,
+			Destination: &args.NydusdThreadsNumber,
 		},
 		&cli.StringFlag{
 			Name:        "publickey-file",

--- a/cmd/containerd-nydus-grpc/pkg/logging/setup.go
+++ b/cmd/containerd-nydus-grpc/pkg/logging/setup.go
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020. Ant Group. All rights reserved.
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadSnapshotterTOMLConfig(t *testing.T) {
+	A := assert.New(t)
+
+	cfg, err := LoadSnapshotterConfig("../misc/snapshotter/config.toml")
+	A.NoError(err)
+
+	exampleConfig := SnapshotterConfig{
+		Version:                1,
+		Root:                   "/var/lib/containerd-nydus",
+		Address:                "/run/containerd-nydus/containerd-nydus-grpc.sock",
+		DaemonMode:             "multiple",
+		EnableSystemController: true,
+		MetricsAddress:         ":9110",
+		EnableStargz:           false,
+		CleanupOnClose:         false,
+		DaemonConfig: DaemonConfig{
+			NydusdPath:       "/usr/local/bin/nydusd",
+			NydusImagePath:   "/usr/local/bin/nydus-image",
+			FsDriver:         "fusedev",
+			RecoverPolicy:    "restart",
+			NydusdConfigPath: "/etc/nydus/config.json",
+			ThreadsNumber:    4,
+		},
+		SnapshotsConfig: SnapshotConfig{
+			EnableNydusOverlayFS: false,
+			SyncRemove:           false,
+		},
+		RemoteConfig: RemoteConfig{
+			ConvertVpcRegistry: false,
+			AuthConfig: AuthConfig{
+				EnableKubeconfigKeychain: false,
+				KubeconfigPath:           "",
+			}},
+		ImageConfig: ImageConfig{
+			PublicKeyFile:     "",
+			ValidateSignature: false,
+		},
+		CacheManagerConfig: CacheManagerConfig{
+			Disable:  false,
+			GCPeriod: "24h",
+			CacheDir: "",
+		},
+		LoggingConfig: LoggingConfig{
+			LogLevel:            "info",
+			RotateLogCompress:   true,
+			RotateLogLocalTime:  true,
+			RotateLogMaxAge:     7,
+			RotateLogMaxBackups: 5,
+			RotateLogMaxSize:    1,
+			LogToStdout:         false,
+		},
+	}
+
+	A.EqualValues(cfg, &exampleConfig)
+
+	err = ProcessConfigurations(cfg)
+	A.NoError(err)
+
+	A.Equal(GetCacheGCPeriod(), time.Hour*24)
+}

--- a/config/default.go
+++ b/config/default.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package config
+
+import (
+	"os/exec"
+	"path/filepath"
+
+	"github.com/containerd/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
+)
+
+const (
+	DefaultDaemonMode string = string(DaemonModeMultiple)
+
+	DefaultLogLevel string = "info"
+	defaultGCPeriod string = "24h"
+
+	defaultNydusDaemonConfigPath string = "/etc/nydus/nydusd-config.json"
+	nydusdBinaryName             string = "nydusd"
+	nydusImageBinaryName         string = "nydus-image"
+
+	defaultRootDir    = "/var/lib/containerd-nydus"
+	oldDefaultRootDir = "/var/lib/containerd-nydus-grpc"
+
+	// Log rotation
+	defaultRotateLogMaxSize    = 200 // 200 megabytes
+	defaultRotateLogMaxBackups = 10
+	defaultRotateLogMaxAge     = 0 // days
+	defaultRotateLogLocalTime  = true
+	defaultRotateLogCompress   = true
+)
+
+func (c *SnapshotterConfig) FillUpWithDefaults() error {
+	// essential configuration
+	if c.DaemonMode == "" {
+		c.DaemonMode = DefaultDaemonMode
+	}
+
+	// logging configuration
+	logConfig := &c.LoggingConfig
+	if logConfig.LogLevel == "" {
+		logConfig.LogLevel = DefaultLogLevel
+	}
+	if len(logConfig.LogDir) == 0 {
+		logConfig.LogDir = filepath.Join(c.Root, logging.DefaultLogDirName)
+	}
+	logConfig.RotateLogMaxSize = defaultRotateLogMaxSize
+	logConfig.RotateLogMaxBackups = defaultRotateLogMaxBackups
+	logConfig.RotateLogMaxAge = defaultRotateLogMaxAge
+	logConfig.RotateLogLocalTime = defaultRotateLogLocalTime
+	logConfig.RotateLogCompress = defaultRotateLogCompress
+
+	// daemon configuration
+	daemonConfig := &c.DaemonConfig
+	if daemonConfig.NydusdConfigPath == "" {
+		daemonConfig.NydusdConfigPath = defaultNydusDaemonConfigPath
+	}
+
+	// cache configuration
+	cacheConfig := &c.CacheManagerConfig
+	if cacheConfig.GCPeriod == "" {
+		cacheConfig.GCPeriod = defaultGCPeriod
+	}
+	if len(cacheConfig.CacheDir) == 0 {
+		cacheConfig.CacheDir = filepath.Join(c.Root, "cache")
+	}
+
+	c.Root = defaultRootDir
+
+	return c.SetupNydusBinaryPaths()
+}
+
+func (c *SnapshotterConfig) SetupNydusBinaryPaths() error {
+	// when using DaemonMode = none, nydusd and nydus-image binaries are not required
+	if c.DaemonMode == string(DaemonModeNone) {
+		return nil
+	}
+
+	// resolve nydusd path
+	path, err := exec.LookPath(nydusdBinaryName)
+	if err != nil {
+		return err
+	}
+	c.DaemonConfig.NydusdPath = path
+
+	// resolve nydus-image path
+	path, err = exec.LookPath(nydusImageBinaryName)
+	if err != nil {
+		return err
+	}
+	c.DaemonConfig.NydusImagePath = path
+
+	return nil
+}

--- a/config/global.go
+++ b/config/global.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Expose configurations across nydus-snapshotter, the configurations is parsed
+// and extracted from nydus-snapshotter toml based configuration file or command line
+
+package config
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	globalConfig GlobalConfig
+)
+
+// Retain the configurations that must be parsed and converted and the
+// configurations that are not easy to access from some modules.
+// Or avoid calculating repeatedly
+type GlobalConfig struct {
+	origin           *SnapshotterConfig
+	SnapshotsDir     string
+	DaemonMode       DaemonMode
+	SocketRoot       string
+	ConfigRoot       string
+	DaemonThreadsNum int
+	CacheGCPeriod    time.Duration
+}
+
+func GetDaemonMode() DaemonMode {
+	return globalConfig.DaemonMode
+}
+
+func GetSnapshotsRootDir() string {
+	return globalConfig.SnapshotsDir
+}
+
+func GetSocketRoot() string {
+	return globalConfig.SocketRoot
+}
+
+func GetConfigRoot() string {
+	return globalConfig.ConfigRoot
+
+}
+
+func GetFsDriver() string {
+	return globalConfig.origin.DaemonConfig.FsDriver
+}
+
+func GetCacheGCPeriod() time.Duration {
+	return globalConfig.CacheGCPeriod
+}
+
+func GetLogDir() string {
+	return globalConfig.origin.LoggingConfig.LogDir
+}
+
+func GetLogLevel() string {
+	return globalConfig.origin.LoggingConfig.LogLevel
+}
+
+func GetDaemonThreadsNumber() int {
+	return globalConfig.origin.DaemonConfig.ThreadsNumber
+}
+
+func GetLogToStdout() bool {
+	return globalConfig.origin.LoggingConfig.LogToStdout
+}
+
+func ProcessConfigurations(c *SnapshotterConfig) error {
+	globalConfig.origin = c
+
+	globalConfig.SnapshotsDir = filepath.Join(c.Root, "snapshots")
+	globalConfig.ConfigRoot = filepath.Join(c.Root, "config")
+	globalConfig.SocketRoot = filepath.Join(c.Root, "socket")
+
+	if c.CacheManagerConfig.GCPeriod != "" {
+		d, err := time.ParseDuration(c.CacheManagerConfig.GCPeriod)
+		if err != nil {
+			return errors.Errorf("invalid GC period %s", c.CacheManagerConfig.GCPeriod)
+		}
+		globalConfig.CacheGCPeriod = d
+	}
+
+	m, err := parseDaemonMode(c.DaemonMode)
+	if err != nil {
+		return err
+	}
+	globalConfig.DaemonMode = m
+
+	return nil
+}

--- a/export/snapshotter/snapshotter.go
+++ b/export/snapshotter/snapshotter.go
@@ -13,18 +13,19 @@ func init() {
 	plugin.Register(&plugin.Registration{
 		Type:   plugin.SnapshotPlugin,
 		ID:     "nydus",
-		Config: &config.Config{},
+		Config: &config.SnapshotterConfig{},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
 
-			cfg, ok := ic.Config.(*config.Config)
+			cfg, ok := ic.Config.(*config.SnapshotterConfig)
 			if !ok {
 				return nil, errors.New("invalid nydus snapshotter configuration")
 			}
 
-			if cfg.RootDir == "" {
-				cfg.RootDir = ic.Root
+			if cfg.Root == "" {
+				cfg.Root = ic.Root
 			}
+
 			if err := cfg.FillUpWithDefaults(); err != nil {
 				return nil, errors.New("failed to fill up nydus configuration with defaults")
 			}

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -1,0 +1,65 @@
+version = 1
+# Snapshotter's own home directory where it stores and creates necessary resources
+root = "/var/lib/containerd-nydus"
+# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+daemon_mode = "multiple"
+# Snapshotter's debug and trace HTTP server interface
+enable_system_controller = true
+# Enable by assigning an address, empty indicates metrics server is disabled
+metrics_address = ":9110"
+# Whether tp enable stargz support
+enable_stargz = false
+# Whether snapshotter should try to clean up resources when it is closed
+cleanup_on_close = false
+
+[daemon]
+nydusd_path = "/usr/local/bin/nydusd"
+nydusimage_path = "/usr/local/bin/nydus-image"
+# fusedev or fscache
+fs_driver = "fusedev"
+# Specify nydusd log level
+log_level = "info"
+# How to process when daemon dies: "none", "restart" or "failover"
+recover_policy = "restart"
+# Speicfy a configuration file for nydusd
+nydusd_config = "/etc/nydus/config.json"
+# The fuse or fscache IO working threads started by nydusd
+threads_number = 4
+
+[log]
+# Snapshotter's log level
+level = "info"
+log_rotation_compress = true
+log_rotation_local_time = true
+# Max number of days to retain logs
+log_rotation_max_age = 7
+log_rotation_max_backups = 5
+# In unit MB(megabytes)
+log_rotation_max_size = 1
+log_to_stdout = false
+
+[remote]
+convert_vpc_registry = false
+
+[remote.auth]
+# Fetch the pricate registry auth by listening to K8s API server
+enable_kubeconfig_keychain = false
+kubeconfig_path = ""
+# Fetch the private regsitry auth as CRI image service proxy
+enable_cri_keychain = false
+image_service_address = ""
+
+[snapshot]
+enable_nydus_overlayfs = false
+# Whether to remove resources when a snapshot is removed
+sync_remove = false
+
+[cache_manager]
+disable = false
+gc_period = "24h"
+cache_dir = ""
+
+[image]
+public_key_file = ""
+validate_signature = false

--- a/pkg/daemon/rafs.go
+++ b/pkg/daemon/rafs.go
@@ -115,7 +115,7 @@ type Rafs struct {
 }
 
 func NewRafs(snapshotID, imageID string) (*Rafs, error) {
-	snapshotDir := path.Join(config.SnapshotsDir, snapshotID)
+	snapshotDir := path.Join(config.GetSnapshotsRootDir(), snapshotID)
 	rafs := &Rafs{SnapshotID: snapshotID,
 		ImageID:     imageID,
 		SnapshotDir: snapshotDir,

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -469,12 +469,12 @@ func (fs *Filesystem) TryStopSharedDaemon() {
 func (fs *Filesystem) createDaemon(mountpoint string, ref int32) (d *daemon.Daemon, err error) {
 	opts := []daemon.NewDaemonOpt{
 		daemon.WithRef(ref),
-		daemon.WithSocketDir(config.NydusConfig.SocketRoot()),
-		daemon.WithConfigDir(config.NydusConfig.ConfigRoot()),
-		daemon.WithLogDir(config.NydusConfig.LogDir),
-		daemon.WithLogLevel(config.NydusConfig.LogLevel),
-		daemon.WithLogToStdout(config.NydusConfig.LogToStdout),
-		daemon.WithNydusdThreadNum(config.NydusConfig.NydusdThreadNum),
+		daemon.WithSocketDir(config.GetSocketRoot()),
+		daemon.WithConfigDir(config.GetConfigRoot()),
+		daemon.WithLogDir(config.GetLogDir()),
+		daemon.WithLogLevel(config.GetLogLevel()),
+		daemon.WithLogToStdout(config.GetLogToStdout()),
+		daemon.WithNydusdThreadNum(config.GetDaemonThreadsNumber()),
 		daemon.WithFsDriver(config.GetFsDriver())}
 
 	if mountpoint != "" {
@@ -504,5 +504,5 @@ func (fs *Filesystem) createDaemon(mountpoint string, ref int32) (d *daemon.Daem
 }
 
 func (fs *Filesystem) DaemonBacked() bool {
-	return config.NydusConfig.DaemonMode != config.DaemonModeNone
+	return config.GetDaemonMode() != config.DaemonModeNone
 }

--- a/pkg/filesystem/stargz_adaptor.go
+++ b/pkg/filesystem/stargz_adaptor.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (fs *Filesystem) UpperPath(id string) string {
-	return filepath.Join(config.NydusConfig.RootDir, "snapshots", id, "fs")
+	return filepath.Join(config.GetSnapshotsRootDir(), id, "fs")
 }
 
 func (fs *Filesystem) StargzEnabled() bool {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -147,7 +147,6 @@ func (sc *Controller) registerRouter() {
 func (sc *Controller) describeDaemons() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		daemons := sc.manager.ListDaemons()
-		log.L.Infof("list daemons %v", daemons)
 
 		info := make([]daemonInfo, 0, 10)
 


### PR DESCRIPTION
Introduce nydus-snapshotter's own TOML based configuration file.

At present, nydus-snapshotter can only be configured by command line parameters which have a large number. Moreover, those parameters tend to expand in the future as more and more features are developed.

Current command line parameters still have a high priority and override the items in the configuration file. We are planning to remove the command line parameters in the future.

Addresses  https://github.com/containerd/nydus-snapshotter/issues/215