### PR TITLE
metrics: add metrics for FS hang IOs

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -419,6 +419,15 @@ func (d *Daemon) GetFsMetrics(sid string) (*types.FsMetrics, error) {
 	return c.GetFsMetrics(sid)
 }
 
+func (d *Daemon) GetInflightMetrics() (*types.InflightMetrics, error) {
+	c, err := d.GetClient()
+	if err != nil {
+		return nil, errors.Wrapf(err, "get inflight metrics")
+	}
+
+	return c.GetInflightMetrics()
+}
+
 func (d *Daemon) GetDaemonInfo() (*types.DaemonInfo, error) {
 	c, err := d.GetClient()
 	if err != nil {

--- a/pkg/daemon/types/types.go
+++ b/pkg/daemon/types/types.go
@@ -73,6 +73,15 @@ type FsMetrics struct {
 	NrOpens                   uint64   `json:"nr_opens"`
 }
 
+type InflightMetrics struct {
+	Values []struct {
+		Inode         uint64 `json:"inode"`
+		Opcode        uint32 `json:"opcode"`
+		Unique        uint64 `json:"unique"`
+		TimestampSecs uint64 `json:"timestamp_secs"`
+	}
+}
+
 type CacheMetrics struct {
 	ID                           string   `json:"id"`
 	UnderlyingFiles              []string `json:"underlying_files"`

--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -8,6 +8,7 @@ package collector
 
 import (
 	"context"
+	"time"
 
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/data"
 
@@ -32,6 +33,12 @@ func NewFsMetricsCollector(m *types.FsMetrics, imageRef string) *FsMetricsCollec
 
 func NewFsMetricsVecCollector() *FsMetricsVecCollector {
 	return &FsMetricsVecCollector{}
+}
+
+func NewInflightMetricsVecCollector(hungIOInterval time.Duration) *InflightMetricsVecCollector {
+	return &InflightMetricsVecCollector{
+		HungIOInterval: hungIOInterval,
+	}
 }
 
 func NewDaemonInfoCollector(version *types.BuildTimeInfo, value float64) *DaemonInfoCollector {

--- a/pkg/metrics/collector/fs.go
+++ b/pkg/metrics/collector/fs.go
@@ -7,11 +7,17 @@
 package collector
 
 import (
+	"time"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/data"
 	mtypes "github.com/containerd/nydus-snapshotter/pkg/metrics/types"
 )
+
+var OPCodeMap = map[uint32]string{
+	15: "OP_READ",
+}
 
 type FsMetricsCollector struct {
 	Metrics  *types.FsMetrics
@@ -20,6 +26,11 @@ type FsMetricsCollector struct {
 
 type FsMetricsVecCollector struct {
 	MetricsVec []FsMetricsCollector
+}
+
+type InflightMetricsVecCollector struct {
+	MetricsVec     []*types.InflightMetrics
+	HungIOInterval time.Duration
 }
 
 func (f *FsMetricsCollector) Collect() {
@@ -39,6 +50,30 @@ func (f *FsMetricsCollector) Collect() {
 		}
 		h.Save(o)
 	}
+}
+
+func (i *InflightMetricsVecCollector) Collect() {
+	if i.MetricsVec == nil {
+		log.L.Warnf("can not collect inflight metrics: Metrics is nil")
+		return
+	}
+
+	// The TimestampSecs of inflight IO is the beginning time of this request.
+	// We can calculate the elapsed time by time.Now().Unix() - TimestampSecs.
+	// The inflight IOs which have a longer elapsed time than the HungIOInterval (default 10 seconds) are hung IOs.
+	totalHungIOMap := 0
+	nowTime := time.Now()
+	for _, daemonInflightIOMetrics := range i.MetricsVec {
+		for _, inflightIOMetric := range daemonInflightIOMetrics.Values {
+			elapsed := nowTime.Sub(time.Unix(int64(inflightIOMetric.TimestampSecs), 0))
+			if elapsed >= i.HungIOInterval {
+				totalHungIOMap++
+				log.L.Debugf("Record hung IO, Inode: %v, Opcode: %v, Unique: %v, Elapsed: %v",
+					inflightIOMetric.Inode, inflightIOMetric.Opcode, inflightIOMetric.Unique, elapsed)
+			}
+		}
+	}
+	data.TotalHungIO.Set(float64(totalHungIOMap))
 }
 
 func (f *FsMetricsVecCollector) Clear() {

--- a/pkg/metrics/data/fs.go
+++ b/pkg/metrics/data/fs.go
@@ -44,6 +44,12 @@ var (
 		[]string{imageRefLabel},
 		ttl.DefaultTTL,
 	)
+	TotalHungIO = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "nydusd_hung_io_counts",
+			Help: "Total number of hung IOs.",
+		},
+	)
 )
 
 // Fs metric histograms

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -20,6 +20,7 @@ func init() {
 		data.FsTotalRead,
 		data.FsReadHit,
 		data.FsReadError,
+		data.TotalHungIO,
 		data.NydusdEventCount,
 		data.NydusdCount,
 		data.SnapshotEventElapsedHists,


### PR DESCRIPTION
Add the metric TotalHangIO to record the total hang IO counts of FS. The inflight IOs data are from nydus daemon API `/api/v1/metrics/inflight`.

Output:
```
# HELP nydusd_hang_IO_counts Total number of hang IOs.
# TYPE nydusd_hang_IO_counts counter
nydusd_hang_IO_counts{opcode="OP_READ"} 2
```

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>