### PR TITLE
misc: fix 404 for snapshotter dockerfile

### DIFF
--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -2,7 +2,10 @@ FROM alpine:3.17.0 AS sourcer
 
 RUN apk add --no-cache curl
 RUN apk add --no-cache --upgrade grep
-RUN export NYDUS_VERSION=$(curl --silent "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")') && \
+RUN unset NYDUS_VERSION && RETRY_COUNT=0 && \
+    while [ -z $NYDUS_VERSION ] && [ $RETRY_COUNT != 600 ]; do \
+    export NYDUS_VERSION=$(curl --silent "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'); RETRY_COUNT=$(($RETRY_COUNT+1)); sleep 1; done && \
+    echo nydus version: $NYDUS_VERSION after $RETRY_COUNT times && if [ -z $NYDUS_VERSION ]; then echo Invalid NYDUS_VERSION && exit -1; fi && \
     wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-linux-amd64.tgz && \
     echo $NYDUS_VERSION > /.nydus_version && \
     tar xzf nydus-static-$NYDUS_VERSION-linux-amd64.tgz && \


### PR DESCRIPTION
The github workflow frequently causes errors to break tests:
```
Step 4/18 : RUN export NYDUS_VERSION=$(curl --silent "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")') &&     wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-linux-amd64.tgz &&     echo $NYDUS_VERSION > /.nydus_version &&     tar xzf nydus-static-$NYDUS_VERSION-linux-amd64.tgz &&     rm nydus-static-$NYDUS_VERSION-linux-amd64.tgz
 ---> Running in 39df2748e06d
Connecting to github.com (140.82.112.4:443)
wget: server returned error: HTTP/1.1 404 Not Found
The command '/bin/sh -c export NYDUS_VERSION=$(curl --silent "https://api.github.com/repos/dragonflyoss/image-service/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")') &&     wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-linux-amd64.tgz &&     echo $NYDUS_VERSION > /.nydus_version &&     tar xzf nydus-static-$NYDUS_VERSION-linux-amd64.tgz &&     rm nydus-static-$NYDUS_VERSION-linux-amd64.tgz' returned a non-zero code: 1
```

I guess the reason for this situation is the `$NYDUS_VERSION` is an invalid value.
This PR tries to verify it by adding an `echo` command.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>