### PR TITLE
metrics: avoid to collect inflight metrics for fscache driver

### DIFF
--- a/pkg/metrics/serve.go
+++ b/pkg/metrics/serve.go
@@ -140,7 +140,9 @@ outer:
 			s.snCollector.Collect()
 		case <-InflightTimer.C:
 			// Collect inflight metrics.
-			s.CollectInflightMetrics(ctx)
+			if config.GetFsDriver() != config.FsDriverFscache {
+				s.CollectInflightMetrics(ctx)
+			}
 		case <-ctx.Done():
 			log.G(ctx).Infof("cancel metrics collecting")
 			break outer


### PR DESCRIPTION
Similar to FS metrics. The metrics for /api/v1/metrics/inflight are in the RAFS of nydus daemon.
When the driver is fscache, there are no metrics in RAFS.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>