### PR TITLE
update e2e test nydusd deps

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -4,7 +4,7 @@ ARG CONTAINERD_PROJECT=/containerd
 ARG RUNC_VERSION=1.1.3
 ARG NYDUS_SNAPSHOTTER_PROJECT=/nydus-snapshotter
 ARG DOWNLOADS_MIRROR="https://github.com"
-ARG NYDUS_VER=2.1.0-rc.4
+ARG NYDUS_VER=2.1.2
 ARG NERDCTL_VER=0.22.2
 
 FROM golang:1.18.7-bullseye AS golang-base


### PR DESCRIPTION
It's time to update nydusd dependency to v2.1.2 