### PR TITLE
Remove some cli parameters

### DIFF
--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -66,6 +66,10 @@ func main() {
 				return errors.Wrap(err, "process configurations")
 			}
 
+			if err := config.ValidateConfig(&snapshotterConfig); err != nil {
+				return errors.Wrapf(err, "validate configuration")
+			}
+
 			ctx := logging.WithContext()
 			logConfig := &snapshotterConfig.LoggingConfig
 			logRotateArgs := &logging.RotateLogArgs{

--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -75,7 +75,8 @@ func main() {
 				RotateLogLocalTime:  logConfig.RotateLogLocalTime,
 				RotateLogCompress:   logConfig.RotateLogCompress,
 			}
-			if err := logging.SetUp(flags.Args.LogLevel, flags.Args.LogToStdout, flags.Args.LogDir, flags.Args.RootDir, logRotateArgs); err != nil {
+
+			if err := logging.SetUp(logConfig.LogLevel, logConfig.LogToStdout, logConfig.LogDir, logRotateArgs); err != nil {
 				return errors.Wrap(err, "set up logger")
 			}
 

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -25,28 +25,17 @@ const (
 type Args struct {
 	Address                  string
 	LogLevel                 string
-	LogDir                   string
 	ConfigPath               string
 	SnapshotterConfigPath    string
 	RootDir                  string
-	CacheDir                 string
-	GCPeriod                 string
-	ValidateSignature        bool
-	PublicKeyFile            string
-	ConvertVpcRegistry       bool
 	NydusdPath               string
 	NydusImagePath           string
 	SharedDaemon             bool
 	DaemonMode               string
 	FsDriver                 string
-	SyncRemove               bool
 	MetricsAddress           string
-	EnableStargz             bool
-	DisableCacheManager      bool
 	LogToStdout              bool
 	EnableNydusOverlayFS     bool
-	NydusdThreadsNumber      int
-	CleanupOnClose           bool
 	KubeconfigPath           string
 	EnableKubeconfigKeychain bool
 	RecoverPolicy            string
@@ -76,19 +65,6 @@ func buildFlags(args *Args) []cli.Flag {
 			Destination: &args.Address,
 		},
 		&cli.StringFlag{
-			Name:        "cache-dir",
-			Value:       "",
-			Aliases:     []string{"C"},
-			Usage:       "set `DIRECTORY` to store/cache downloaded image data",
-			Destination: &args.CacheDir,
-		},
-		&cli.BoolFlag{
-			Name:        "cleanup-on-close",
-			Value:       false,
-			Usage:       "whether to clean up on exit",
-			Destination: &args.CleanupOnClose,
-		},
-		&cli.StringFlag{
 			Name:        "config-path",
 			Aliases:     []string{"nydusd-config"},
 			Usage:       "path to the nydusd configuration",
@@ -99,22 +75,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "path to the nydus-snapshotter configuration",
 			Destination: &args.SnapshotterConfigPath,
 		},
-		&cli.BoolFlag{
-			Name:        "convert-vpc-registry",
-			Usage:       "whether to automatically convert the image to vpc registry to accelerate image pulling",
-			Destination: &args.ConvertVpcRegistry,
-		},
 		&cli.StringFlag{
 			Name:        "daemon-mode",
 			Value:       DefaultDaemonMode,
 			Aliases:     []string{"M"},
 			Usage:       "set daemon working `MODE`, one of \"multiple\", \"shared\" or \"none\"",
 			Destination: &args.DaemonMode,
-		},
-		&cli.BoolFlag{
-			Name:        "disable-cache-manager",
-			Usage:       "whether to disable blob cache manager",
-			Destination: &args.DisableCacheManager,
 		},
 		&cli.StringFlag{
 			Name:        "metrics-address",
@@ -127,30 +93,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether to enable nydus-overlayfs",
 			Destination: &args.EnableNydusOverlayFS,
 		},
-		&cli.BoolFlag{
-			Name:        "enable-stargz",
-			Usage:       "whether to enable support of estargz image (experimental)",
-			Destination: &args.EnableStargz,
-		},
 		&cli.StringFlag{
 			Name:        "fs-driver",
 			Value:       FsDriverFusedev,
 			Aliases:     []string{"daemon-backend"},
 			Usage:       "backend `DRIVER` to serve the filesystem, one of \"fusedev\", \"fscache\"",
 			Destination: &args.FsDriver,
-		},
-		&cli.StringFlag{
-			Name:        "gc-period",
-			Value:       defaultGCPeriod,
-			Usage:       "blob cache garbage collection `INTERVAL`, duration string(for example, 1m, 2h)",
-			Destination: &args.GCPeriod,
-		},
-		&cli.StringFlag{
-			Name:        "log-dir",
-			Value:       "",
-			Aliases:     []string{"L"},
-			Usage:       "set `DIRECTORY` to store log files",
-			Destination: &args.LogDir,
 		},
 		&cli.StringFlag{
 			Name:        "log-level",
@@ -178,17 +126,7 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "set `PATH` to the nydusd binary, default to lookup nydusd in $PATH",
 			Destination: &args.NydusdPath,
 		},
-		&cli.IntFlag{
-			Name:        "nydusd-thread-num",
-			Usage:       "set worker thread number for nydusd, default to the number of CPUs",
-			Destination: &args.NydusdThreadsNumber,
-		},
-		&cli.StringFlag{
-			Name:        "publickey-file",
-			Value:       defaultPublicKey,
-			Usage:       "path to the publickey `FILE` for signature validation",
-			Destination: &args.PublicKeyFile,
-		},
+
 		&cli.StringFlag{
 			Name:        "root",
 			Value:       defaultRootDir,
@@ -206,16 +144,6 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "Policy on recovering nydus filesystem service [none, restart, failover], default to restart",
 			Destination: &args.RecoverPolicy,
 			Value:       "restart",
-		},
-		&cli.BoolFlag{
-			Name:        "sync-remove",
-			Usage:       "whether to clean up snapshots in synchronous mode, default to asynchronous mode",
-			Destination: &args.SyncRemove,
-		},
-		&cli.BoolFlag{
-			Name:        "validate-signature",
-			Usage:       "whether to validate integrity of image bootstrap",
-			Destination: &args.ValidateSignature,
 		},
 		&cli.BoolFlag{
 			Name:        "enable-system-controller",

--- a/cmd/containerd-nydus-grpc/pkg/logging/setup.go
+++ b/cmd/containerd-nydus-grpc/pkg/logging/setup.go
@@ -31,8 +31,7 @@ type RotateLogArgs struct {
 	RotateLogCompress   bool
 }
 
-func SetUp(logLevel string, logToStdout bool, logDir string,
-	rootDir string, logRotateArgs *RotateLogArgs) error {
+func SetUp(logLevel string, logToStdout bool, logDir string, logRotateArgs *RotateLogArgs) error {
 	lvl, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		return err
@@ -45,9 +44,7 @@ func SetUp(logLevel string, logToStdout bool, logDir string,
 		if logRotateArgs == nil {
 			return errors.New("logRotateArgs is needed when logToStdout is false")
 		}
-		if len(logDir) == 0 {
-			logDir = filepath.Join(rootDir, DefaultLogDirName)
-		}
+
 		if err := os.MkdirAll(logDir, 0755); err != nil {
 			return errors.Wrapf(err, "create log dir %s", logDir)
 		}

--- a/cmd/containerd-nydus-grpc/pkg/logging/setup_test.go
+++ b/cmd/containerd-nydus-grpc/pkg/logging/setup_test.go
@@ -50,13 +50,13 @@ func TestSetUp(t *testing.T) {
 	}
 	logLevel := logrus.InfoLevel.String()
 
-	err := SetUp(logLevel, true, TestLogDirName, TestRootDirName, nil)
+	err := SetUp(logLevel, true, TestLogDirName, nil)
 	assert.NilError(t, err, nil)
 
-	err = SetUp(logLevel, false, TestLogDirName, TestRootDirName, nil)
+	err = SetUp(logLevel, false, TestLogDirName, nil)
 	assert.ErrorContains(t, err, "logRotateArgs is needed when logToStdout is false")
 
-	err = SetUp(logLevel, false, TestLogDirName, TestRootDirName, logRotateArgs)
+	err = SetUp(logLevel, false, TestLogDirName, logRotateArgs)
 	assert.NilError(t, err)
 	for i := 0; i < 100000; i++ { // total 9.1MB
 		log.L.Infof("test log, now: %s", time.Now().Format("2006-01-02 15:04:05"))

--- a/config/config.go
+++ b/config/config.go
@@ -178,12 +178,9 @@ func ValidateConfig(c *SnapshotterConfig) error {
 // Parse command line arguments and fill the nydus-snapshotter configuration
 // Always let options from CLI override those from configuration file.
 func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
-
 	// --- essential configuration
 	cfg.Address = args.Address
 	cfg.EnableSystemController = args.EnableSystemController
-	cfg.CleanupOnClose = args.CleanupOnClose
-	cfg.EnableStargz = args.EnableStargz
 	cfg.MetricsAddress = args.MetricsAddress
 	cfg.Root = args.RootDir
 
@@ -194,9 +191,7 @@ func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
 	}
 
 	// --- image processor configuration
-	imageConfig := &cfg.ImageConfig
-	imageConfig.PublicKeyFile = args.PublicKeyFile
-	imageConfig.ValidateSignature = args.ValidateSignature
+	// empty
 
 	// --- daemon configuration
 	daemonConfig := &cfg.DaemonConfig
@@ -207,27 +202,18 @@ func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
 	if args.NydusImagePath != "" {
 		daemonConfig.NydusImagePath = args.NydusImagePath
 	}
-	daemonConfig.ThreadsNumber = args.NydusdThreadsNumber
 	daemonConfig.RecoverPolicy = args.RecoverPolicy
 	daemonConfig.FsDriver = args.FsDriver
 
 	// --- cache manager configuration
-	cacheMangerConfig := &cfg.CacheManagerConfig
-	if args.CacheDir != "" {
-		cacheMangerConfig.CacheDir = args.CacheDir
-	}
-	cacheMangerConfig.GCPeriod = args.GCPeriod
-	cacheMangerConfig.Disable = args.DisableCacheManager
+	// empty
 
 	// --- logging configuration
 	logConfig := &cfg.LoggingConfig
 	logConfig.LogLevel = args.LogLevel
 	logConfig.LogToStdout = args.LogToStdout
-	logConfig.LogDir = args.LogDir
 
 	// --- remote storage configuration
-	remoteConfig := &cfg.RemoteConfig
-	remoteConfig.ConvertVpcRegistry = args.ConvertVpcRegistry
 	AuthConfig := &cfg.RemoteConfig.AuthConfig
 
 	AuthConfig.KubeconfigPath = args.KubeconfigPath
@@ -238,7 +224,6 @@ func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
 	// --- snapshot configuration
 	snapshotConfig := &cfg.SnapshotsConfig
 	snapshotConfig.EnableNydusOverlayFS = args.EnableNydusOverlayFS
-	snapshotConfig.SyncRemove = args.SyncRemove
 
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -146,29 +146,29 @@ func LoadSnapshotterConfig(path string) (*SnapshotterConfig, error) {
 	return &config, nil
 }
 
-func ValidateParameters(args *command.Args) error {
-	if args == nil {
-		return errors.New("no startup parameter provided")
+func ValidateConfig(c *SnapshotterConfig) error {
+	if c == nil {
+		return errors.Wrapf(errdefs.ErrInvalidArgument, "configuration is none")
 	}
 
-	if args.ValidateSignature {
-		if args.PublicKeyFile == "" {
+	if c.ImageConfig.ValidateSignature {
+		if c.ImageConfig.PublicKeyFile == "" {
 			return errors.New("need to specify publicKey file for signature validation")
-		} else if _, err := os.Stat(args.PublicKeyFile); err != nil {
-			return errors.Wrapf(err, "failed to find publicKey file %q", args.PublicKeyFile)
+		} else if _, err := os.Stat(c.ImageConfig.PublicKeyFile); err != nil {
+			return errors.Wrapf(err, "failed to find publicKey file %q", c.ImageConfig.PublicKeyFile)
 		}
 	}
 
-	daemonMode, err := parseDaemonMode(args.DaemonMode)
+	daemonMode, err := parseDaemonMode(c.DaemonMode)
 	if err != nil {
 		return err
 	}
 
-	if args.FsDriver == FsDriverFscache && daemonMode != DaemonModeShared {
+	if c.DaemonConfig.FsDriver == FsDriverFscache && daemonMode != DaemonModeShared {
 		return errors.New("`fscache` driver only supports `shared` daemon mode")
 	}
 
-	if len(args.RootDir) == 0 {
+	if len(c.Root) == 0 {
 		return errors.New("empty root directory")
 	}
 

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -8,7 +8,7 @@ LEVEL="${LEVEL:-info}"
 
 set -eu
 BACKEND_TYPE="${BACKEND_TYPE:-config}"
-NYDUSD_DAEMON_MODE="${NYDUSD_DAEMON_MODE:-shared}"
+NYDUSD_DAEMON_MODE="${NYDUSD_DAEMON_MODE:-multiple}"
 
 if [ "$#" -eq 0 ]; then
 	containerd-nydus-grpc \

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -17,10 +17,7 @@ if [ "$#" -eq 0 ]; then
 		--root ${NYDUS_LIB} \
 		--address ${NYDUS_RUN}/containerd-nydus-grpc.sock \
 		--log-level ${LEVEL} \
-		--enable-metrics=${ENABLE_METRICS} \
-		--enable-nydus-overlayfs=${ENABLE_NYDUS_OVERLAY} \
 		--daemon-mode ${NYDUSD_DAEMON_MODE} \
-		--enable-stargz \
 		--log-to-stdout
 fi
 


### PR DESCRIPTION
Nydus-snapshotter now has its own toml based configuration file whose entries are duplicated with CLI startup parameters.
In the first phase, we will remove those not frequently used cli parameters and suggest users to migrate the configuration to toml based configuration file.