### PR TITLE
fix k8s e2e test docker file

### DIFF
--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -2,8 +2,6 @@
 
 NYDUS_LIB="${NYDUS_LIB:-/var/lib/containerd-nydus}"
 NYDUS_RUN="${NYDUS_RUN:-/run/containerd-nydus}"
-ENABLE_NYDUS_OVERLAY="${ENABLE_NYDUS_OVERLAY:-true}"
-ENABLE_METRICS="${ENABLE_METRICS:-false}"
 LEVEL="${LEVEL:-info}"
 
 set -eu

--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -17,10 +17,7 @@ if [ "$#" -eq 0 ]; then
 		--root ${NYDUS_LIB} \
 		--address ${NYDUS_RUN}/containerd-nydus-grpc.sock \
 		--log-level ${LEVEL} \
-		--enable-metrics=${ENABLE_METRICS} \
-		--enable-nydus-overlayfs=${ENABLE_NYDUS_OVERLAY} \
 		--daemon-mode ${NYDUSD_DAEMON_MODE} \
-		--enable-stargz \
 		--log-to-stdout
 fi
 

--- a/tests/e2e/k8s/snapshotter-cri.yaml
+++ b/tests/e2e/k8s/snapshotter-cri.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   name: nydus-system
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,7 +10,6 @@ metadata:
   namespace: nydus-system
 
 ---
-
 apiVersion: v1
 kind: Pod
 metadata:
@@ -19,69 +17,65 @@ metadata:
   namespace: nydus-system
 spec:
   containers:
-  - env:
-    - name: ENABLE_NYDUS_OVERLAY
-      value: "false"
-    name: nydus-snapshotter
-    image: local-dev:e2e
-    imagePullPolicy: IfNotPresent
-    args:
-      - containerd-nydus-grpc
-      - --nydusd-path /usr/local/bin/nydusd
-      - --config-path /etc/nydus/config.json
-      - --root /var/lib/containerd-nydus
-      - --address /run/containerd-nydus/containerd-nydus-grpc.sock
-      - --log-level debug
-      - --daemon-mode shared
-      - --log-to-stdout
-      - --enable-cri-keychain
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - mountPath: /etc/nydus/
-      name: config
-    - mountPath: /var/lib/containerd-nydus
-      mountPropagation: Bidirectional
-      name: nydus-lib
-    - mountPath: /run/containerd-nydus
-      mountPropagation: Bidirectional
-      name: nydus-run
-    - mountPath: /run/containerd
-      mountPropagation: Bidirectional
-      name: containerd-run
-    - mountPath: /dev/fuse
-      name: fuse
-    - mountPath: /etc/containerd/config.toml
-      name: containerd-conf
+    - name: nydus-snapshotter
+      image: local-dev:e2e
+      imagePullPolicy: IfNotPresent
+      args:
+        - containerd-nydus-grpc
+        - --nydusd-path /usr/local/bin/nydusd
+        - --config-path /etc/nydus/config.json
+        - --root /var/lib/containerd-nydus
+        - --address /run/containerd-nydus/containerd-nydus-grpc.sock
+        - --log-level debug
+        - --daemon-mode shared
+        - --log-to-stdout
+        - --enable-cri-keychain
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - mountPath: /etc/nydus/
+          name: config
+        - mountPath: /var/lib/containerd-nydus
+          mountPropagation: Bidirectional
+          name: nydus-lib
+        - mountPath: /run/containerd-nydus
+          mountPropagation: Bidirectional
+          name: nydus-run
+        - mountPath: /run/containerd
+          mountPropagation: Bidirectional
+          name: containerd-run
+        - mountPath: /dev/fuse
+          name: fuse
+        - mountPath: /etc/containerd/config.toml
+          name: containerd-conf
   hostNetwork: true
   hostPID: true
   serviceAccountName: nydus-snapshotter-sa
   volumes:
-  - configMap:
-      defaultMode: 420
-      name: nydus-snapshotter
-    name: config
-  - hostPath:
-      path: /run/containerd-nydus
-      type: DirectoryOrCreate
-    name: nydus-run
-  - hostPath:
-      path: /var/lib/containerd-nydus
-      type: DirectoryOrCreate
-    name: nydus-lib
-  - hostPath:
-      path: /run/containerd
-      type: Directory
-    name: containerd-run
-  - hostPath:
-      path: /dev/fuse
-    name: fuse
-  - hostPath:
-      path: /etc/containerd/config.toml
-      type: ""
-    name: containerd-conf
+    - configMap:
+        defaultMode: 420
+        name: nydus-snapshotter
+      name: config
+    - hostPath:
+        path: /run/containerd-nydus
+        type: DirectoryOrCreate
+      name: nydus-run
+    - hostPath:
+        path: /var/lib/containerd-nydus
+        type: DirectoryOrCreate
+      name: nydus-lib
+    - hostPath:
+        path: /run/containerd
+        type: Directory
+      name: containerd-run
+    - hostPath:
+        path: /dev/fuse
+      name: fuse
+    - hostPath:
+        path: /etc/containerd/config.toml
+        type: ""
+      name: containerd-conf
 ---
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/tests/e2e/k8s/snapshotter-kubeconf.yaml
+++ b/tests/e2e/k8s/snapshotter-kubeconf.yaml
@@ -4,7 +4,6 @@ metadata:
   name: nydus-system
 
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,23 +11,21 @@ metadata:
   namespace: nydus-system
 
 ---
-
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nydus-snapshotter-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
-
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -38,12 +35,11 @@ roleRef:
   name: nydus-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
-- kind: ServiceAccount
-  name: nydus-snapshotter-sa
-  namespace: nydus-system
+  - kind: ServiceAccount
+    name: nydus-snapshotter-sa
+    namespace: nydus-system
 
 ---
-
 apiVersion: v1
 kind: Pod
 metadata:
@@ -51,62 +47,58 @@ metadata:
   namespace: nydus-system
 spec:
   containers:
-  - env:
-    - name: ENABLE_NYDUS_OVERLAY
-      value: "false"
-    name: nydus-snapshotter
-    image: local-dev:e2e
-    imagePullPolicy: IfNotPresent
-    args:
-      - containerd-nydus-grpc
-      - --nydusd-path /usr/local/bin/nydusd
-      - --config-path /etc/nydus/config.json
-      - --root /var/lib/containerd-nydus
-      - --address /run/containerd-nydus/containerd-nydus-grpc.sock
-      - --log-level debug
-      - --daemon-mode shared
-      - --log-to-stdout
-      - --enable-kubeconfig-keychain
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - mountPath: /etc/nydus/
-      name: config
-    - mountPath: /var/lib/containerd-nydus
-      mountPropagation: Bidirectional
-      name: nydus-lib
-    - mountPath: /run/containerd-nydus
-      mountPropagation: Bidirectional
-      name: nydus-run
-    - mountPath: /dev/fuse
-      name: fuse
-    - mountPath: /etc/containerd/config.toml
-      name: containerd-conf
+    - name: nydus-snapshotter
+      image: local-dev:e2e
+      imagePullPolicy: IfNotPresent
+      args:
+        - containerd-nydus-grpc
+        - --nydusd-path /usr/local/bin/nydusd
+        - --config-path /etc/nydus/config.json
+        - --root /var/lib/containerd-nydus
+        - --address /run/containerd-nydus/containerd-nydus-grpc.sock
+        - --log-level debug
+        - --daemon-mode shared
+        - --log-to-stdout
+        - --enable-kubeconfig-keychain
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - mountPath: /etc/nydus/
+          name: config
+        - mountPath: /var/lib/containerd-nydus
+          mountPropagation: Bidirectional
+          name: nydus-lib
+        - mountPath: /run/containerd-nydus
+          mountPropagation: Bidirectional
+          name: nydus-run
+        - mountPath: /dev/fuse
+          name: fuse
+        - mountPath: /etc/containerd/config.toml
+          name: containerd-conf
   hostNetwork: true
   hostPID: true
   serviceAccountName: nydus-snapshotter-sa
   volumes:
-  - configMap:
-      defaultMode: 420
-      name: nydus-snapshotter
-    name: config
-  - hostPath:
-      path: /run/containerd-nydus
-      type: DirectoryOrCreate
-    name: nydus-run
-  - hostPath:
-      path: /var/lib/containerd-nydus
-      type: DirectoryOrCreate
-    name: nydus-lib
-  - hostPath:
-      path: /dev/fuse
-    name: fuse
-  - hostPath:
-      path: /etc/containerd/config.toml
-      type: ""
-    name: containerd-conf
+    - configMap:
+        defaultMode: 420
+        name: nydus-snapshotter
+      name: config
+    - hostPath:
+        path: /run/containerd-nydus
+        type: DirectoryOrCreate
+      name: nydus-run
+    - hostPath:
+        path: /var/lib/containerd-nydus
+        type: DirectoryOrCreate
+      name: nydus-lib
+    - hostPath:
+        path: /dev/fuse
+      name: fuse
+    - hostPath:
+        path: /etc/containerd/config.toml
+        type: ""
+      name: containerd-conf
 ---
-
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Fix the nydus-snapshotter CLI parameters in k8s e2e test docker file where several CLI parameters are removed