### PR TITLE
fix that nydusd lifecycle event might be duplicated

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -23,7 +23,6 @@ import (
 	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
-	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
 	"github.com/containerd/nydus-snapshotter/pkg/supervisor"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/erofs"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/mount"
@@ -196,7 +195,6 @@ func (d *Daemon) WaitUntilState(expected types.DaemonState) error {
 			return errors.Errorf("daemon %s is not %s yet, current state %s",
 				d.ID(), expected, state)
 		}
-		collector.NewDaemonEventCollector(string(expected)).Collect()
 
 		return nil
 	},

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -89,6 +89,9 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 			log.L.WithError(err).Errorf("daemon %s is not managed to reach RUNNING state", d.ID())
 			return
 		}
+
+		collector.NewDaemonEventCollector(types.DaemonStateRunning).Collect()
+
 		daemonInfo, err := d.GetDaemonInfo()
 		if err != nil {
 			log.L.WithError(err).Errorf("failed to get daemon %s information", d.ID())

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -518,7 +518,7 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 		log.L.Warnf("Failed to wait for daemon, %v", err)
 	}
 
-	collector.NewDaemonEventCollector(string(types.DaemonStateDestroyed)).Collect()
+	collector.NewDaemonEventCollector(types.DaemonStateDestroyed).Collect()
 	collector.NewDaemonInfoCollector(&d.Version, -1).Collect()
 
 	return nil

--- a/pkg/manager/monitor.go
+++ b/pkg/manager/monitor.go
@@ -219,7 +219,7 @@ func (m *livenessMonitor) Run() {
 
 				if ev.Events&(unix.EPOLLHUP|unix.EPOLLERR) != 0 {
 					log.L.Warnf("Daemon %s died", target.id)
-					collector.NewDaemonEventCollector(string(types.DaemonStateDied)).Collect()
+					collector.NewDaemonEventCollector(types.DaemonStateDied).Collect()
 					// Notify subscribers that death event happens
 					target.notifier <- deathEvent{daemonID: target.id, path: target.path}
 				}

--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -23,8 +23,8 @@ type Collector interface {
 	Collect()
 }
 
-func NewDaemonEventCollector(event string) *DaemonEventCollector {
-	return &DaemonEventCollector{event}
+func NewDaemonEventCollector(ev types.DaemonState) *DaemonEventCollector {
+	return &DaemonEventCollector{event: ev}
 }
 
 func NewFsMetricsCollector(m *types.FsMetrics, imageRef string) *FsMetricsCollector {

--- a/pkg/metrics/collector/daemon.go
+++ b/pkg/metrics/collector/daemon.go
@@ -13,7 +13,7 @@ import (
 )
 
 type DaemonEventCollector struct {
-	event string
+	event types.DaemonState
 }
 
 type DaemonInfoCollector struct {
@@ -22,7 +22,7 @@ type DaemonInfoCollector struct {
 }
 
 func (d *DaemonEventCollector) Collect() {
-	data.NydusdEventCount.WithLabelValues(d.event).Inc()
+	data.NydusdEventCount.WithLabelValues(string(d.event)).Inc()
 }
 
 func (d *DaemonInfoCollector) Collect() {


### PR DESCRIPTION
There is a race that multiple goroutines can call WaitUntilState() at the same time and waiting for the same expected state. So they can both escape from the very beginning state check ending up with an extra event record.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>