### PR TITLE
fix a gorace when retrieving Version from daemon object

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -311,8 +311,9 @@ func (m *Manager) handleDaemonDeathEvent() {
 			log.L.Warnf("Daemon %s was not found", ev.daemonID)
 			return
 		}
-		collector.NewDaemonInfoCollector(&d.Version, -1).Collect()
+
 		d.Lock()
+		collector.NewDaemonInfoCollector(&d.Version, -1).Collect()
 		d.State = types.DaemonStateUnknown
 		d.Unlock()
 		if m.RecoverPolicy == RecoverPolicyRestart {


### PR DESCRIPTION
go race detected

WARNING: DATA RACE
Read at 0x00c0000bed48 by goroutine 34:
  github.com/containerd/nydus-snapshotter/pkg/metrics/collector.(*DaemonInfoCollector).Collect()
      /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/metrics/collector/daemon.go:33 +0x78
  github.com/containerd/nydus-snapshotter/pkg/manager.(*Manager).handleDaemonDeathEvent()
      /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/manager/manager.go:314 +0x212
  github.com/containerd/nydus-snapshotter/pkg/manager.NewManager.func1()
      /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/manager/manager.go:364 +0x39

Previous write at 0x00c0000bed48 by goroutine 88:
  github.com/containerd/nydus-snapshotter/pkg/manager.(*Manager).StartDaemon.func2()
      /home/runner/work/nydus-snapshotter/nydus-snapshotter/pkg/manager/daemon_adaptor.go:97 +0x5d3

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>