### PR TITLE
Remove CLI K8s auth passing related parameters 

### DIFF
--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -49,12 +49,14 @@ func main() {
 
 			// Once snapshotter's configuration file is provided, parse it and let command line parameters override it.
 			if snapshotterConfigPath != "" {
-				if c, err := config.LoadSnapshotterConfig(snapshotterConfigPath); err != nil {
+				if c, err := config.LoadSnapshotterConfig(snapshotterConfigPath); err == nil {
 					// Command line parameters override the snapshotter's configurations for backwards compatibility
 					if err := config.ParseParameters(flags.Args, c); err != nil {
 						return errors.Wrap(err, "parse parameters")
 					}
 					snapshotterConfig = *c
+				} else {
+					return errors.Wrapf(err, "Failed to load snapshotter's configuration at %q", snapshotterConfigPath)
 				}
 			} else {
 				if err := config.ParseParameters(flags.Args, &snapshotterConfig); err != nil {

--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -41,9 +41,10 @@ func main() {
 			}
 
 			snapshotterConfigPath := flags.Args.SnapshotterConfigPath
+			var defaultSnapshotterConfig config.SnapshotterConfig
 			var snapshotterConfig config.SnapshotterConfig
 
-			if err := snapshotterConfig.FillUpWithDefaults(); err != nil {
+			if err := defaultSnapshotterConfig.FillUpWithDefaults(); err != nil {
 				return errors.New("failed to fill up nydus configuration with defaults")
 			}
 
@@ -64,12 +65,16 @@ func main() {
 				}
 			}
 
-			if err := config.ProcessConfigurations(&snapshotterConfig); err != nil {
-				return errors.Wrap(err, "process configurations")
+			if err := config.MergeConfig(&snapshotterConfig, &defaultSnapshotterConfig); err != nil {
+				return errors.Wrap(err, "merge configurations")
 			}
 
 			if err := config.ValidateConfig(&snapshotterConfig); err != nil {
-				return errors.Wrapf(err, "validate configuration")
+				return errors.Wrapf(err, "validate configurations")
+			}
+
+			if err := config.ProcessConfigurations(&snapshotterConfig); err != nil {
+				return errors.Wrap(err, "process configurations")
 			}
 
 			ctx := logging.WithContext()

--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020. Ant Group. All rights reserved.
+ * Copyright (c) 2022. Nydus Developers. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,7 +8,6 @@
 package command
 
 import (
-	"github.com/containerd/nydus-snapshotter/pkg/auth"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -16,33 +16,27 @@ const (
 	defaultAddress           = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 	defaultLogLevel          = logrus.InfoLevel
 	defaultRootDir           = "/var/lib/containerd-nydus"
-	defaultGCPeriod          = "24h"
-	defaultPublicKey         = "/signing/nydus-image-signing-public.key"
 	DefaultDaemonMode string = "multiple"
 	FsDriverFusedev   string = "fusedev"
 )
 
 type Args struct {
-	Address                  string
-	LogLevel                 string
-	ConfigPath               string
-	SnapshotterConfigPath    string
-	RootDir                  string
-	NydusdPath               string
-	NydusImagePath           string
-	SharedDaemon             bool
-	DaemonMode               string
-	FsDriver                 string
-	MetricsAddress           string
-	LogToStdout              bool
-	EnableNydusOverlayFS     bool
-	KubeconfigPath           string
-	EnableKubeconfigKeychain bool
-	RecoverPolicy            string
-	PrintVersion             bool
-	EnableSystemController   bool
-	EnableCRIKeychain        bool
-	ImageServiceAddress      string
+	Address                string
+	LogLevel               string
+	ConfigPath             string
+	SnapshotterConfigPath  string
+	RootDir                string
+	NydusdPath             string
+	NydusImagePath         string
+	SharedDaemon           bool
+	DaemonMode             string
+	FsDriver               string
+	MetricsAddress         string
+	LogToStdout            bool
+	EnableNydusOverlayFS   bool
+	RecoverPolicy          string
+	PrintVersion           bool
+	EnableSystemController bool
 }
 
 type Flags struct {
@@ -150,30 +144,6 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "(experimental) unix domain socket path to serve HTTP-based system management",
 			Destination: &args.EnableSystemController,
 			Value:       true,
-		},
-		&cli.StringFlag{
-			Name:        "kubeconfig-path",
-			Value:       "",
-			Usage:       "path to the kubeconfig file",
-			Destination: &args.KubeconfigPath,
-		},
-		&cli.BoolFlag{
-			Name:        "enable-kubeconfig-keychain",
-			Value:       false,
-			Usage:       "synchronize `kubernetes.io/dockerconfigjson` secret from kubernetes API server with provided `--kubeconfig-path` (default `$KUBECONFIG` or `~/.kube/config`)",
-			Destination: &args.EnableKubeconfigKeychain,
-		},
-		&cli.BoolFlag{
-			Name:        "enable-cri-keychain",
-			Value:       false,
-			Usage:       "enable a CRI image proxy and retrieve image secret when proxying image request",
-			Destination: &args.EnableCRIKeychain,
-		},
-		&cli.StringFlag{
-			Name:        "image-service-address",
-			Value:       auth.DefaultImageServiceAddress,
-			Usage:       "the target image service when using image proxy",
-			Destination: &args.ImageServiceAddress,
 		},
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ package config
 import (
 	"os"
 
+	"github.com/imdario/mergo"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 
@@ -144,6 +145,15 @@ func LoadSnapshotterConfig(path string) (*SnapshotterConfig, error) {
 		return nil, errors.Wrapf(err, "unmarshal snapshotter configuration file %q", path)
 	}
 	return &config, nil
+}
+
+func MergeConfig(to, from *SnapshotterConfig) error {
+	err := mergo.Merge(to, from)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ValidateConfig(c *SnapshotterConfig) error {

--- a/config/config.go
+++ b/config/config.go
@@ -219,12 +219,7 @@ func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
 	logConfig.LogToStdout = args.LogToStdout
 
 	// --- remote storage configuration
-	AuthConfig := &cfg.RemoteConfig.AuthConfig
-
-	AuthConfig.KubeconfigPath = args.KubeconfigPath
-	AuthConfig.EnableKubeconfigKeychain = args.EnableKubeconfigKeychain
-	AuthConfig.EnableCRIKeychain = args.EnableCRIKeychain
-	AuthConfig.ImageServiceAddress = args.ImageServiceAddress
+	// empty
 
 	// --- snapshot configuration
 	snapshotConfig := &cfg.SnapshotsConfig

--- a/config/config.go
+++ b/config/config.go
@@ -172,6 +172,11 @@ func ValidateConfig(c *SnapshotterConfig) error {
 		return errors.New("empty root directory")
 	}
 
+	if c.RemoteConfig.AuthConfig.EnableCRIKeychain && c.RemoteConfig.AuthConfig.EnableKubeconfigKeychain {
+		return errors.Wrapf(errdefs.ErrInvalidArgument,
+			"\"enable_cri_keychain\" and \"enable_kubeconfig_keychain\" can't be set at the same time")
+	}
+
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,10 @@ func ValidateConfig(c *SnapshotterConfig) error {
 			"\"enable_cri_keychain\" and \"enable_kubeconfig_keychain\" can't be set at the same time")
 	}
 
+	if !c.CacheManagerConfig.Disable && c.CacheManagerConfig.CacheDir == "" {
+		return errors.Wrapf(errdefs.ErrInvalidArgument, "cache directory is specified to empty")
+	}
+
 	return nil
 }
 

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -45,9 +45,11 @@ convert_vpc_registry = false
 [remote.auth]
 # Fetch the pricate registry auth by listening to K8s API server
 enable_kubeconfig_keychain = false
+# synchronize `kubernetes.io/dockerconfigjson` secret from kubernetes API server with specified kubeconfig (default `$KUBECONFIG` or `~/.kube/config`)
 kubeconfig_path = ""
 # Fetch the private regsitry auth as CRI image service proxy
 enable_cri_keychain = false
+# the target image service when using image proxy
 image_service_address = ""
 
 [snapshot]

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -22,7 +22,7 @@ fs_driver = "fusedev"
 log_level = "info"
 # How to process when daemon dies: "none", "restart" or "failover"
 recover_policy = "restart"
-# Speicfy a configuration file for nydusd
+# Specify a configuration file for nydusd
 nydusd_config = "/etc/nydus/config.json"
 # The fuse or fscache IO working threads started by nydusd
 threads_number = 4

--- a/tests/e2e/k8s/containerd.config.toml
+++ b/tests/e2e/k8s/containerd.config.toml
@@ -2,32 +2,32 @@
 version = 2
 
 [debug]
-  level = "debug"
+level = "debug"
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
-  # save disk space when using a single snapshotter
-  discard_unpacked_layers = false
-  # explicitly use default snapshotter so we can sed it in entrypoint
-  snapshotter = "overlayfs"
-  # explicit default here, as we're configuring it below
-  default_runtime_name = "runc"
-  # nydus snapshotter needs this config
-  disable_snapshot_annotations = false
+# save disk space when using a single snapshotter
+discard_unpacked_layers = false
+# explicitly use default snapshotter so we can sed it in entrypoint
+snapshotter = "overlayfs"
+# explicit default here, as we're configuring it below
+default_runtime_name = "runc"
+# nydus snapshotter needs this config
+disable_snapshot_annotations = false
 
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-  # set default runtime handler to v2, which has a per-pod shim
-  runtime_type = "io.containerd.runc.v2"
+# set default runtime handler to v2, which has a per-pod shim
+runtime_type = "io.containerd.runc.v2"
 
 # Setup a runtime with the magic name ("test-handler") used for Kubernetes
 # runtime class tests ...
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
-  runtime_type = "io.containerd.runc.v2"
+runtime_type = "io.containerd.runc.v2"
 
 [plugins."io.containerd.grpc.v1.cri"]
-  # use fixed sandbox image
-  sandbox_image = "k8s.gcr.io/pause:3.6"
-  # allow hugepages controller to be missing
-  # see https://github.com/containerd/cri/pull/1501
-  tolerate_missing_hugepages_controller = true
-  # restrict_oom_score_adj needs to be true when running inside UserNS (rootless)
-  restrict_oom_score_adj = false
+# use fixed sandbox image
+sandbox_image = "k8s.gcr.io/pause:3.6"
+# allow hugepages controller to be missing
+# see https://github.com/containerd/cri/pull/1501
+tolerate_missing_hugepages_controller = true
+# restrict_oom_score_adj needs to be true when running inside UserNS (rootless)
+restrict_oom_score_adj = false

--- a/tests/e2e/k8s/snapshotter-cri.yaml
+++ b/tests/e2e/k8s/snapshotter-cri.yaml
@@ -23,18 +23,16 @@ spec:
       args:
         - containerd-nydus-grpc
         - --nydusd-path /usr/local/bin/nydusd
-        - --config-path /etc/nydus/config.json
-        - --root /var/lib/containerd-nydus
-        - --address /run/containerd-nydus/containerd-nydus-grpc.sock
+        - --config-path /etc/nydus/nydusd.json
+        - --config /etc/nydus/config.toml
         - --log-level debug
         - --daemon-mode shared
         - --log-to-stdout
-        - --enable-cri-keychain
       securityContext:
         privileged: true
       volumeMounts:
         - mountPath: /etc/nydus/
-          name: config
+          name: nydus-all-config
         - mountPath: /var/lib/containerd-nydus
           mountPropagation: Bidirectional
           name: nydus-lib
@@ -52,10 +50,13 @@ spec:
   hostPID: true
   serviceAccountName: nydus-snapshotter-sa
   volumes:
-    - configMap:
-        defaultMode: 420
-        name: nydus-snapshotter
-      name: config
+    - name: nydus-all-config
+      projected:
+        sources:
+          - configMap:
+              name: nydusd-config
+          - configMap:
+              name: snapshotter-config
     - hostPath:
         path: /run/containerd-nydus
         type: DirectoryOrCreate
@@ -79,10 +80,10 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nydus-snapshotter
+  name: nydusd-config
   namespace: nydus-system
 data:
-  config.json: |-
+  nydusd.json: |-
     {
       "device": {
         "backend": {
@@ -113,3 +114,75 @@ data:
         "bandwidth_rate": 1048576
       }
     }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snapshotter-config
+  namespace: nydus-system
+data:
+  config.toml: |-
+    version = 1
+    root = "/var/lib/containerd-nydus"
+    address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+    daemon_mode = "multiple"
+    enable_system_controller = true
+    # Enable by assigning an address, empty indicates metrics server is disabled
+    metrics_address = ":9110"
+    # Whether tp enable stargz support
+    enable_stargz = false
+    # Whether snapshotter should try to clean up resources when it is closed
+    cleanup_on_close = false
+
+    [daemon]
+    nydusd_path = "/usr/local/bin/nydusd"
+    nydusimage_path = "/usr/local/bin/nydus-image"
+    # fusedev or fscache
+    fs_driver = "fusedev"
+    # Specify nydusd log level
+    log_level = "info"
+    # How to process when daemon dies: "none", "restart" or "failover"
+    recover_policy = "restart"
+    # Specify a configuration file for nydusd
+    nydusd_config = "/etc/nydus/nydusd.json"
+    # The fuse or fscache IO working threads started by nydusd
+    threads_number = 4
+
+    [log]
+    # Snapshotter's log level
+    level = "info"
+    log_rotation_compress = true
+    log_rotation_local_time = true
+    # Max number of days to retain logs
+    log_rotation_max_age = 7
+    log_rotation_max_backups = 5
+    # In unit MB(megabytes)
+    log_rotation_max_size = 1
+    log_to_stdout = false
+
+    [remote]
+    convert_vpc_registry = false
+
+    [remote.auth]
+    # Fetch the private registry auth by listening to K8s API server
+    enable_kubeconfig_keychain = false
+    # synchronize `kubernetes.io/dockerconfigjson` secret from kubernetes API server with specified kubeconfig (default `$KUBECONFIG` or `~/.kube/config`)
+    kubeconfig_path = ""
+    # Fetch the private registry auth as CRI image service proxy
+    enable_cri_keychain = true
+    # the target image service when using image proxy
+    image_service_address = ""
+
+    [snapshot]
+    enable_nydus_overlayfs = false
+    # Whether to remove resources when a snapshot is removed
+    sync_remove = false
+
+    [cache_manager]
+    disable = false
+    gc_period = "24h"
+    cache_dir = ""
+
+    [image]
+    public_key_file = ""
+    validate_signature = false

--- a/tests/e2e/k8s/snapshotter-kubeconf.yaml
+++ b/tests/e2e/k8s/snapshotter-kubeconf.yaml
@@ -53,18 +53,16 @@ spec:
       args:
         - containerd-nydus-grpc
         - --nydusd-path /usr/local/bin/nydusd
-        - --config-path /etc/nydus/config.json
-        - --root /var/lib/containerd-nydus
-        - --address /run/containerd-nydus/containerd-nydus-grpc.sock
+        - --config-path /etc/nydus/nydusd.json
+        - --config /etc/nydus/config.toml
         - --log-level debug
         - --daemon-mode shared
         - --log-to-stdout
-        - --enable-kubeconfig-keychain
       securityContext:
         privileged: true
       volumeMounts:
         - mountPath: /etc/nydus/
-          name: config
+          name: nydus-all-config
         - mountPath: /var/lib/containerd-nydus
           mountPropagation: Bidirectional
           name: nydus-lib
@@ -79,10 +77,13 @@ spec:
   hostPID: true
   serviceAccountName: nydus-snapshotter-sa
   volumes:
-    - configMap:
-        defaultMode: 420
-        name: nydus-snapshotter
-      name: config
+    - name: nydus-all-config
+      projected:
+        sources:
+          - configMap:
+              name: nydusd-config
+          - configMap:
+              name: snapshotter-config
     - hostPath:
         path: /run/containerd-nydus
         type: DirectoryOrCreate
@@ -102,10 +103,10 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nydus-snapshotter
+  name: nydusd-config
   namespace: nydus-system
 data:
-  config.json: |-
+  nydusd.json: |-
     {
       "device": {
         "backend": {
@@ -136,3 +137,75 @@ data:
         "bandwidth_rate": 1048576
       }
     }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snapshotter-config
+  namespace: nydus-system
+data:
+  config.toml: |-
+    version = 1
+    root = "/var/lib/containerd-nydus"
+    address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+    daemon_mode = "multiple"
+    enable_system_controller = true
+    # Enable by assigning an address, empty indicates metrics server is disabled
+    metrics_address = ":9110"
+    # Whether tp enable stargz support
+    enable_stargz = false
+    # Whether snapshotter should try to clean up resources when it is closed
+    cleanup_on_close = false
+
+    [daemon]
+    nydusd_path = "/usr/local/bin/nydusd"
+    nydusimage_path = "/usr/local/bin/nydus-image"
+    # fusedev or fscache
+    fs_driver = "fusedev"
+    # Specify nydusd log level
+    log_level = "info"
+    # How to process when daemon dies: "none", "restart" or "failover"
+    recover_policy = "restart"
+    # Specify a configuration file for nydusd
+    nydusd_config = "/etc/nydus/nydusd.json"
+    # The fuse or fscache IO working threads started by nydusd
+    threads_number = 4
+
+    [log]
+    # Snapshotter's log level
+    level = "info"
+    log_rotation_compress = true
+    log_rotation_local_time = true
+    # Max number of days to retain logs
+    log_rotation_max_age = 7
+    log_rotation_max_backups = 5
+    # In unit MB(megabytes)
+    log_rotation_max_size = 1
+    log_to_stdout = false
+
+    [remote]
+    convert_vpc_registry = false
+
+    [remote.auth]
+    # Fetch the private registry auth by listening to K8s API server
+    enable_kubeconfig_keychain = true
+    # synchronize `kubernetes.io/dockerconfigjson` secret from kubernetes API server with specified kubeconfig (default `$KUBECONFIG` or `~/.kube/config`)
+    kubeconfig_path = ""
+    # Fetch the private registry auth as CRI image service proxy
+    enable_cri_keychain = false
+    # the target image service when using image proxy
+    image_service_address = ""
+
+    [snapshot]
+    enable_nydus_overlayfs = false
+    # Whether to remove resources when a snapshot is removed
+    sync_remove = false
+
+    [cache_manager]
+    disable = false
+    gc_period = "24h"
+    cache_dir = ""
+
+    [image]
+    public_key_file = ""
+    validate_signature = false


### PR DESCRIPTION
In this phase, we are going to remove K8s auth passing related parameters and suggest users to migrate to nydus-snapshotter's toml configuration file to achieve it