### PR TITLE
move metrics config to a separated section

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,10 @@ type RemoteConfig struct {
 	ConvertVpcRegistry bool       `toml:"convert_vpc_registry"`
 }
 
+type MetricsConfig struct {
+	Address string `toml:"address"`
+}
+
 type SnapshotterConfig struct {
 	// Configuration format version
 	Version int `toml:"version"`
@@ -117,12 +121,12 @@ type SnapshotterConfig struct {
 	Root                   string `toml:"root"`
 	Address                string `toml:"address"`
 	EnableSystemController bool   `toml:"enable_system_controller"`
-	MetricsAddress         string `toml:"metrics_address"`
 	DaemonMode             string `toml:"daemon_mode"`
 	EnableStargz           bool   `toml:"enable_stargz"`
 	// Clean up all the resources when snapshotter is closed
 	CleanupOnClose bool `toml:"cleanup_on_close"`
 
+	MetricsConfig      MetricsConfig      `toml:"metrics"`
 	DaemonConfig       DaemonConfig       `toml:"daemon"`
 	SnapshotsConfig    SnapshotConfig     `toml:"snapshot"`
 	RemoteConfig       RemoteConfig       `toml:"remote"`
@@ -200,7 +204,6 @@ func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
 	// --- essential configuration
 	cfg.Address = args.Address
 	cfg.EnableSystemController = args.EnableSystemController
-	cfg.MetricsAddress = args.MetricsAddress
 	cfg.Root = args.RootDir
 
 	// Give --shared-daemon higher priority
@@ -238,6 +241,10 @@ func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
 	// --- snapshot configuration
 	snapshotConfig := &cfg.SnapshotsConfig
 	snapshotConfig.EnableNydusOverlayFS = args.EnableNydusOverlayFS
+
+	// --- metrics configuration
+	metricsConfig := &cfg.MetricsConfig
+	metricsConfig.Address = args.MetricsAddress
 
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,6 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 		Address:                "/run/containerd-nydus/containerd-nydus-grpc.sock",
 		DaemonMode:             "multiple",
 		EnableSystemController: true,
-		MetricsAddress:         ":9110",
 		EnableStargz:           false,
 		CleanupOnClose:         false,
 		DaemonConfig: DaemonConfig{
@@ -63,6 +62,9 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 			RotateLogMaxBackups: 5,
 			RotateLogMaxSize:    1,
 			LogToStdout:         false,
+		},
+		MetricsConfig: MetricsConfig{
+			Address: ":9110",
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/imdario/mergo v0.3.12
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -6,8 +6,6 @@ address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 daemon_mode = "multiple"
 # Snapshotter's debug and trace HTTP server interface
 enable_system_controller = true
-# Enable by assigning an address, empty indicates metrics server is disabled
-metrics_address = ":9110"
 # Whether tp enable stargz support
 enable_stargz = false
 # Whether snapshotter should try to clean up resources when it is closed
@@ -38,6 +36,10 @@ log_rotation_max_backups = 5
 # In unit MB(megabytes)
 log_rotation_max_size = 1
 log_to_stdout = false
+
+[metrics]
+# Enable by assigning an address, empty indicates metrics server is disabled
+address = ":9110"
 
 [remote]
 convert_vpc_registry = false

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -109,9 +109,9 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 
 	// Start to collect metrics.
-	if cfg.MetricsAddress != "" {
+	if cfg.MetricsConfig.Address != "" {
 		go func() {
-			if err := metrics.NewHTTPListener(cfg.MetricsAddress); err != nil {
+			if err := metrics.NewHTTPListener(cfg.MetricsConfig.Address); err != nil {
 				log.L.WithError(err).Error("Failed to start metrics HTTP server")
 			}
 		}()


### PR DESCRIPTION
We are pursuing a more fine-grained configuration section for metrcis, e.g. scrape interval, etc

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>