### PR TITLE
config: support configuring mirror registry without reloading snapshotter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ clear:
 .PHONY: install
 install:
 	sudo install -D -m 755 bin/containerd-nydus-grpc /usr/local/bin/containerd-nydus-grpc
+	sudo mkdir -p /etc/nydus/certs.d
 	sudo install -D -m 755 misc/snapshotter/nydusd-config.fusedev.json /etc/nydus/nydusd-config.fusedev.json
 	sudo install -D -m 755 misc/snapshotter/nydusd-config.fscache.json /etc/nydus/nydusd-config.fscache.json
 	sudo ln -f -s /etc/nydus/nydusd-config.${FS_DRIVER}.json /etc/nydus/nydusd-config.json

--- a/config/config.go
+++ b/config/config.go
@@ -148,8 +148,13 @@ type AuthConfig struct {
 
 // Configure remote storage like container registry
 type RemoteConfig struct {
-	AuthConfig         AuthConfig `toml:"auth"`
-	ConvertVpcRegistry bool       `toml:"convert_vpc_registry"`
+	AuthConfig         AuthConfig    `toml:"auth"`
+	ConvertVpcRegistry bool          `toml:"convert_vpc_registry"`
+	MirrorsConfig      MirrorsConfig `toml:"mirrors_config"`
+}
+
+type MirrorsConfig struct {
+	Dir string `toml:"dir"`
 }
 
 type MetricsConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,7 +44,11 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 			AuthConfig: AuthConfig{
 				EnableKubeconfigKeychain: false,
 				KubeconfigPath:           "",
-			}},
+			},
+			MirrorsConfig: MirrorsConfig{
+				Dir: "/etc/nydus/certs.d",
+			},
+		},
 		ImageConfig: ImageConfig{
 			PublicKeyFile:     "",
 			ValidateSignature: false,

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -32,6 +32,7 @@ type DaemonConfig interface {
 	// Provide auth
 	FillAuth(kc *auth.PassKeyChain)
 	StorageBackendType() string
+	UpdateMirrors(mirrorsConfigDir string) error
 	DumpString() (string, error)
 	DumpFile(path string) error
 }

--- a/config/daemonconfig/fscache.go
+++ b/config/daemonconfig/fscache.go
@@ -68,6 +68,17 @@ func LoadFscacheConfig(p string) (*FscacheDaemonConfig, error) {
 	return &cfg, nil
 }
 
+func (c *FscacheDaemonConfig) UpdateMirrors(mirrorsConfigDir string) error {
+	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir)
+	if err != nil {
+		return err
+	}
+	if len(mirrors) > 0 {
+		c.Config.BackendConfig.Mirrors = mirrors
+	}
+	return nil
+}
+
 func (c *FscacheDaemonConfig) StorageBackendType() string {
 	return c.Config.BackendType
 }

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -75,6 +75,17 @@ func (c *FuseDaemonConfig) FillAuth(kc *auth.PassKeyChain) {
 	}
 }
 
+func (c *FuseDaemonConfig) UpdateMirrors(mirrorsConfigDir string) error {
+	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir)
+	if err != nil {
+		return err
+	}
+	if len(mirrors) > 0 {
+		c.Device.Backend.Config.Mirrors = mirrors
+	}
+	return nil
+}
+
 func (c *FuseDaemonConfig) StorageBackendType() string {
 	return c.Device.Backend.BackendType
 }

--- a/config/daemonconfig/mirrors.go
+++ b/config/daemonconfig/mirrors.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package daemonconfig
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/log"
+	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
+)
+
+// Copied from containerd, for compatibility with containerd's toml configuration file.
+type hostFileConfig struct {
+	Capabilities []string               `toml:"capabilities"`
+	CACert       interface{}            `toml:"ca"`
+	Client       interface{}            `toml:"client"`
+	SkipVerify   *bool                  `toml:"skip_verify"`
+	Header       map[string]interface{} `toml:"header"`
+	OverridePath bool                   `toml:"override_path"`
+
+	// The following configuration items are specific to nydus.
+	AuthThrough         bool   `toml:"auth_through,omitempty"`
+	HealthCheckInterval int    `toml:"health_check_interval,omitempty"`
+	FailureLimit        uint8  `toml:"failure_limit,omitempty"`
+	PingURL             string `toml:"ping_url,omitempty"`
+}
+
+func isDirExisted(path string) (bool, error) {
+	s, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return s.IsDir(), nil
+}
+
+func makeStringSlice(slice []interface{}, cb func(string) string) ([]string, error) {
+	out := make([]string, len(slice))
+	for i, value := range slice {
+		str, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("unable to cast %v to string", value)
+		}
+
+		if cb != nil {
+			out[i] = cb(str)
+		} else {
+			out[i] = str
+		}
+	}
+	return out, nil
+}
+
+func parseMirrorsConfigFromToml(b []byte) ([]MirrorConfig, error) {
+	var parsedMirrors []MirrorConfig
+
+	type HostFileConfig = hostFileConfig
+	c := struct {
+		HostConfigs map[string]hostFileConfig `toml:"host"`
+	}{}
+	tree, err := toml.LoadBytes(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TOML: %w", err)
+	}
+	if err := tree.Unmarshal(&c); err != nil {
+		return nil, err
+	}
+
+	for key, value := range c.HostConfigs {
+		mirror := MirrorConfig{
+			Host:                key,
+			AuthThrough:         value.AuthThrough,
+			HealthCheckInterval: value.HealthCheckInterval,
+			FailureLimit:        value.FailureLimit,
+			PingURL:             value.PingURL,
+		}
+		if value.Header != nil {
+			header := http.Header{}
+			mirrorHeader := make(map[string]string, 0)
+			for key, ty := range value.Header {
+				switch v := ty.(type) {
+				case string:
+					header[key] = []string{v}
+				case []interface{}:
+					header[key], err = makeStringSlice(v, nil)
+					if err != nil {
+						return nil, err
+					}
+				default:
+					return nil, fmt.Errorf("invalid type %v for header %q", ty, key)
+				}
+				mirrorHeader[key] = header.Get(key)
+				if len(header[key]) > 1 {
+					log.L.Warnf("some values of the header[%q] are omitted: %#v", key, header.Values(key)[1:])
+				}
+			}
+			mirror.Headers = mirrorHeader
+
+		}
+		parsedMirrors = append(parsedMirrors, mirror)
+	}
+
+	return parsedMirrors, nil
+}
+
+func parseMirrorsConfig(path string, b []byte) ([]MirrorConfig, error) {
+	format := strings.Trim(filepath.Ext(path), ".")
+
+	var parsedMirrors []MirrorConfig
+	var err error
+	switch format {
+	case "toml":
+		parsedMirrors, err = parseMirrorsConfigFromToml(b)
+	default:
+		return nil, errors.Errorf("invalid file path: %v, supported suffix includes [ \"toml\" ]", path)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid config file %s", path)
+	}
+	return parsedMirrors, nil
+}
+
+func LoadMirrorsConfig(mirrorsConfigDir string) ([]MirrorConfig, error) {
+	var mirrors []MirrorConfig
+
+	if mirrorsConfigDir == "" {
+		return mirrors, nil
+	}
+	dirExisted, err := isDirExisted(mirrorsConfigDir)
+	if err != nil {
+		return nil, err
+	}
+	if !dirExisted {
+		return nil, errors.Errorf("mirrors config directory %s is not existed", mirrorsConfigDir)
+	}
+
+	if err := filepath.Walk(mirrorsConfigDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return errors.Errorf("read mirror configuration file %s failed: %v", path, err)
+		}
+
+		parsedMirrors, err := parseMirrorsConfig(path, b)
+		if err != nil {
+			return errors.Errorf("parse mirrors config failed: %v", err)
+		}
+		mirrors = append(mirrors, parsedMirrors...)
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return mirrors, nil
+}

--- a/config/daemonconfig/mirrors_test.go
+++ b/config/daemonconfig/mirrors_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package daemonconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadMirrorConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer os.RemoveAll(tmpDir)
+
+	mirrorsConfigDir := filepath.Join(tmpDir, "certs.d")
+	mirrorsInvalidConfigDir := filepath.Join(tmpDir, "certs.d.file")
+	mirrorsConfigPath1 := filepath.Join(mirrorsConfigDir, "test1.toml")
+	mirrorsConfigPath2 := filepath.Join(mirrorsConfigDir, "test2.toml")
+	mirrorsConfigPath3 := filepath.Join(mirrorsConfigDir, "test3.toml")
+	mirrorsConfigPath4 := filepath.Join(mirrorsConfigDir, "test4.yaml")
+	mirrorsConfigPath5 := filepath.Join(mirrorsConfigDir, "test5.toml")
+	mirrorsInvalidConfigPath1 := filepath.Join(mirrorsConfigDir, "dir")
+
+	mirrors, err := LoadMirrorsConfig("")
+	require.Nil(t, err)
+	require.Nil(t, mirrors)
+
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
+	require.Error(t, err)
+	require.Nil(t, mirrors)
+
+	os.Mkdir(mirrorsConfigDir, os.ModePerm)
+
+	os.WriteFile(mirrorsInvalidConfigDir, []byte(`""`), 0600)
+	mirrors, err = LoadMirrorsConfig(mirrorsInvalidConfigDir)
+	require.ErrorContains(t, err, "is not existed")
+	require.Nil(t, mirrors)
+
+	buf1 := []byte(`server = "https://docker.hub.com"
+
+	[host]
+
+	  [host."http://p2p-mirror1:65001"]
+		auth_through = false
+
+		[host."http://p2p-mirror1:65001".header]
+		  X-Dragonfly-Registry = ["https://docker.hub.com"]`)
+	os.WriteFile(mirrorsConfigPath1, buf1, 0600)
+
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
+	require.Nil(t, err)
+	require.Equal(t, len(mirrors), 1)
+	require.Equal(t, mirrors[0].Host, "http://p2p-mirror1:65001")
+	require.Equal(t, mirrors[0].AuthThrough, false)
+	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
+
+	os.Mkdir(mirrorsInvalidConfigPath1, os.ModePerm)
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
+	require.Nil(t, err)
+	require.Equal(t, len(mirrors), 1)
+
+	buf2 := []byte(`server = "https://docker.hub.com"
+
+	[host]
+
+	  [host."http://p2p-mirror2:65001"]
+		auth_through = false
+	
+		[host."http://p2p-mirror2:65001".header]
+		  X-Dragonfly-Registry = ["https://docker.hub.com"]`)
+	os.WriteFile(mirrorsConfigPath2, buf2, 0600)
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
+	require.Nil(t, err)
+	require.Equal(t, len(mirrors), 2)
+
+	buf3 := []byte(`server = "https://docker.hub.com"
+
+	[host]
+
+	  [host."http://127.0.0.1:65001"]
+	    capabilities = ["pull", "resolve"]
+	    auth_through = true
+
+	    [host."http://127.0.0.1:65001".header]
+	      X-Dragonfly-Registry = ["https://docker.hub.com"]`)
+	os.WriteFile(mirrorsConfigPath3, buf3, 0600)
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
+	require.Nil(t, err)
+	require.Equal(t, len(mirrors), 3)
+	require.Equal(t, mirrors[2].Host, "http://127.0.0.1:65001")
+	require.Equal(t, mirrors[2].AuthThrough, true)
+	require.Equal(t, mirrors[2].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
+
+	buf4 := []byte(`[test]`)
+	os.WriteFile(mirrorsConfigPath4, buf4, 0600)
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
+	require.ErrorContains(t, err, "invalid file path")
+	require.Equal(t, len(mirrors), 0)
+
+	buf5 := []byte(`}`)
+	os.Mkdir(mirrorsConfigDir, os.ModePerm)
+	os.WriteFile(mirrorsConfigPath5, buf5, 0600)
+
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
+	require.ErrorContains(t, err, "invalid file path")
+	require.Equal(t, len(mirrors), 0)
+}

--- a/config/global.go
+++ b/config/global.go
@@ -32,6 +32,7 @@ type GlobalConfig struct {
 	ConfigRoot       string
 	DaemonThreadsNum int
 	CacheGCPeriod    time.Duration
+	MirrorsConfig    MirrorsConfig
 }
 
 func GetDaemonMode() DaemonMode {
@@ -48,7 +49,10 @@ func GetSocketRoot() string {
 
 func GetConfigRoot() string {
 	return globalConfig.ConfigRoot
+}
 
+func GetMirrorsConfigDir() string {
+	return globalConfig.MirrorsConfig.Dir
 }
 
 func GetFsDriver() string {
@@ -81,6 +85,8 @@ func ProcessConfigurations(c *SnapshotterConfig) error {
 	globalConfig.SnapshotsDir = filepath.Join(c.Root, "snapshots")
 	globalConfig.ConfigRoot = filepath.Join(c.Root, "config")
 	globalConfig.SocketRoot = filepath.Join(c.Root, "socket")
+
+	globalConfig.MirrorsConfig = c.RemoteConfig.MirrorsConfig
 
 	if c.CacheManagerConfig.GCPeriod != "" {
 		d, err := time.ParseDuration(c.CacheManagerConfig.GCPeriod)

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -45,6 +45,12 @@ address = ":9110"
 [remote]
 convert_vpc_registry = false
 
+[remote.mirrors_config]
+# Snapshotter will overwrite daemon's mirrors configuration
+# if the values loaded from this driectory are not null before starting a daemon.
+# Set to "" or an empty directory to disable it.
+dir = "/etc/nydus/certs.d"
+
 [remote.auth]
 # Fetch the pricate registry auth by listening to K8s API server
 enable_kubeconfig_keychain = false

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -243,6 +243,10 @@ func (fs *Filesystem) Mount(snapshotID string, labels map[string]string) (err er
 		daemonconfig.CacheDir: cacheDir}
 
 	cfg := deepcopy.Copy(fs.Manager.DaemonConfig).(daemonconfig.DaemonConfig)
+
+	if err := cfg.UpdateMirrors(config.GetMirrorsConfigDir()); err != nil {
+		return errors.Wrap(err, "update mirrors config")
+	}
 	err = daemonconfig.SupplementDaemonConfig(cfg, imageID, snapshotID, false, labels, params)
 	if err != nil {
 		return errors.Wrap(err, "supplement configuration")


### PR DESCRIPTION
Now, the mirror registry is configured with nydusd config file. Reloading service is needed if we modify it after the nydus-snapshotter is run.

This commit solves this problem.
Snapshotter will overwrite the daemon's mirror configuration if the values loaded from this directory are not null before starting a daemon.

This PR is addressing #341 

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>