### PR TITLE
enable more golang linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,13 @@ linters-settings:
     # If lower than 0, disable the check.
     # Default: 40
     statements: 80
+  nilnil:
+    checked-types:
+      - ptr
+      - func
+      - iface
+      - map
+      - chan
 
 linters:
   enable:
@@ -37,7 +44,7 @@ linters:
     - bodyclose
     # - cyclop
     - dogsled
-    # - nilnil
+    - nilnil
     - unparam
     - nilerr
     # - goerr113
@@ -49,5 +56,5 @@ linters:
     - tenv
     # - funlen
     - exhaustive
-  disable:
     - errcheck
+  disable:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -169,9 +169,11 @@ func TestMergeConfig(t *testing.T) {
 	var defaultSnapshotterConfig SnapshotterConfig
 	var snapshotterConfig1 SnapshotterConfig
 
-	defaultSnapshotterConfig.FillUpWithDefaults()
+	err := defaultSnapshotterConfig.FillUpWithDefaults()
+	A.NoError(err)
 
-	MergeConfig(&snapshotterConfig1, &defaultSnapshotterConfig)
+	err = MergeConfig(&snapshotterConfig1, &defaultSnapshotterConfig)
+	A.NoError(err)
 	A.Equal(snapshotterConfig1.Root, defaultRootDir)
 	A.Equal(snapshotterConfig1.LoggingConfig.LogDir, "")
 	A.Equal(snapshotterConfig1.CacheManagerConfig.CacheDir, "")
@@ -191,7 +193,8 @@ func TestMergeConfig(t *testing.T) {
 	var snapshotterConfig2 SnapshotterConfig
 	snapshotterConfig2.Root = "/snapshotter/root"
 
-	MergeConfig(&snapshotterConfig2, &defaultSnapshotterConfig)
+	err = MergeConfig(&snapshotterConfig2, &defaultSnapshotterConfig)
+	A.NoError(err)
 	A.Equal(snapshotterConfig2.Root, "/snapshotter/root")
 	A.Equal(snapshotterConfig2.LoggingConfig.LogDir, "")
 	A.Equal(snapshotterConfig2.CacheManagerConfig.CacheDir, "")
@@ -202,10 +205,11 @@ func TestProcessConfigurations(t *testing.T) {
 	var defaultSnapshotterConfig SnapshotterConfig
 	var snapshotterConfig1 SnapshotterConfig
 
-	defaultSnapshotterConfig.FillUpWithDefaults()
-
-	MergeConfig(&snapshotterConfig1, &defaultSnapshotterConfig)
-	err := ValidateConfig(&snapshotterConfig1)
+	err := defaultSnapshotterConfig.FillUpWithDefaults()
+	A.NoError(err)
+	err = MergeConfig(&snapshotterConfig1, &defaultSnapshotterConfig)
+	A.NoError(err)
+	err = ValidateConfig(&snapshotterConfig1)
 	A.NoError(err)
 	err = ProcessConfigurations(&snapshotterConfig1)
 	A.NoError(err)
@@ -216,7 +220,8 @@ func TestProcessConfigurations(t *testing.T) {
 	var snapshotterConfig2 SnapshotterConfig
 	snapshotterConfig2.Root = "/snapshotter/root"
 
-	MergeConfig(&snapshotterConfig2, &defaultSnapshotterConfig)
+	err = MergeConfig(&snapshotterConfig2, &defaultSnapshotterConfig)
+	A.NoError(err)
 	err = ValidateConfig(&snapshotterConfig2)
 	A.NoError(err)
 	err = ProcessConfigurations(&snapshotterConfig2)

--- a/config/daemonconfig/mirrors_test.go
+++ b/config/daemonconfig/mirrors_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,9 +36,11 @@ func TestLoadMirrorConfig(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, mirrors)
 
-	os.Mkdir(mirrorsConfigDir, os.ModePerm)
+	err = os.Mkdir(mirrorsConfigDir, os.ModePerm)
+	assert.NoError(t, err)
 
-	os.WriteFile(mirrorsInvalidConfigDir, []byte(`""`), 0600)
+	err = os.WriteFile(mirrorsInvalidConfigDir, []byte(`""`), 0600)
+	assert.NoError(t, err)
 	mirrors, err = LoadMirrorsConfig(mirrorsInvalidConfigDir)
 	require.ErrorContains(t, err, "is not existed")
 	require.Nil(t, mirrors)
@@ -51,8 +54,8 @@ func TestLoadMirrorConfig(t *testing.T) {
 
 		[host."http://p2p-mirror1:65001".header]
 		  X-Dragonfly-Registry = ["https://docker.hub.com"]`)
-	os.WriteFile(mirrorsConfigPath1, buf1, 0600)
-
+	err = os.WriteFile(mirrorsConfigPath1, buf1, 0600)
+	assert.NoError(t, err)
 	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
 	require.Nil(t, err)
 	require.Equal(t, len(mirrors), 1)
@@ -60,7 +63,8 @@ func TestLoadMirrorConfig(t *testing.T) {
 	require.Equal(t, mirrors[0].AuthThrough, false)
 	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
 
-	os.Mkdir(mirrorsInvalidConfigPath1, os.ModePerm)
+	err = os.Mkdir(mirrorsInvalidConfigPath1, os.ModePerm)
+	assert.NoError(t, err)
 	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
 	require.Nil(t, err)
 	require.Equal(t, len(mirrors), 1)
@@ -74,7 +78,8 @@ func TestLoadMirrorConfig(t *testing.T) {
 	
 		[host."http://p2p-mirror2:65001".header]
 		  X-Dragonfly-Registry = ["https://docker.hub.com"]`)
-	os.WriteFile(mirrorsConfigPath2, buf2, 0600)
+	err = os.WriteFile(mirrorsConfigPath2, buf2, 0600)
+	assert.NoError(t, err)
 	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
 	require.Nil(t, err)
 	require.Equal(t, len(mirrors), 2)
@@ -89,7 +94,8 @@ func TestLoadMirrorConfig(t *testing.T) {
 
 	    [host."http://127.0.0.1:65001".header]
 	      X-Dragonfly-Registry = ["https://docker.hub.com"]`)
-	os.WriteFile(mirrorsConfigPath3, buf3, 0600)
+	err = os.WriteFile(mirrorsConfigPath3, buf3, 0600)
+	assert.NoError(t, err)
 	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
 	require.Nil(t, err)
 	require.Equal(t, len(mirrors), 3)
@@ -98,14 +104,17 @@ func TestLoadMirrorConfig(t *testing.T) {
 	require.Equal(t, mirrors[2].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
 
 	buf4 := []byte(`[test]`)
-	os.WriteFile(mirrorsConfigPath4, buf4, 0600)
+	err = os.WriteFile(mirrorsConfigPath4, buf4, 0600)
+	assert.NoError(t, err)
 	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
 	require.ErrorContains(t, err, "invalid file path")
 	require.Equal(t, len(mirrors), 0)
 
 	buf5 := []byte(`}`)
-	os.Mkdir(mirrorsConfigDir, os.ModePerm)
-	os.WriteFile(mirrorsConfigPath5, buf5, 0600)
+	err = os.MkdirAll(mirrorsConfigDir, os.ModePerm)
+	assert.NoError(t, err)
+	err = os.WriteFile(mirrorsConfigPath5, buf5, 0600)
+	assert.NoError(t, err)
 
 	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
 	require.ErrorContains(t, err, "invalid file path")

--- a/pkg/auth/kubesecret.go
+++ b/pkg/auth/kubesecret.go
@@ -113,7 +113,7 @@ func (kubelistener *KubeSecretListener) SyncKubeSecrets(ctx context.Context, cli
 		cache.Indexers{},
 	)
 	kubelistener.informer = informer
-	kubelistener.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := kubelistener.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err != nil {
@@ -144,6 +144,9 @@ func (kubelistener *KubeSecretListener) SyncKubeSecrets(ctx context.Context, cli
 			kubelistener.deleteDockerConfig(key)
 		}},
 	)
+	if err != nil {
+		return errors.Wrap(err, "add event handler to informer")
+	}
 	go kubelistener.informer.Run(ctx.Done())
 	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
 		return fmt.Errorf("timed out for syncing cache")

--- a/pkg/auth/kubesecret_test.go
+++ b/pkg/auth/kubesecret_test.go
@@ -33,7 +33,8 @@ func TestGetCredentialsStore(t *testing.T) {
 	assert := assert.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	InitKubeSecretListener(ctx, "")
+	// Host may not has kubeconfig, so ignore the error and continue the test
+	_ = InitKubeSecretListener(ctx, "")
 	assert.NotNil(kubeSecretListener)
 
 	var obj interface{} = &corev1.Secret{

--- a/pkg/backend/oss.go
+++ b/pkg/backend/oss.go
@@ -137,7 +137,7 @@ func (b *OSSBackend) push(ctx context.Context, cs content.Store, desc ocispec.De
 	}
 
 	if err := g.Wait(); err != nil {
-		b.bucket.AbortMultipartUpload(imur)
+		_ = b.bucket.AbortMultipartUpload(imur)
 		close(partsChan)
 		return errors.Wrap(err, "upload parts")
 	}

--- a/pkg/converter/cs_proxy_unix.go
+++ b/pkg/converter/cs_proxy_unix.go
@@ -101,7 +101,8 @@ func contentProxyHandler(ra content.ReaderAt) http.Handler {
 		totalLen  int64
 	)
 	resetReader := func() {
-		seekFile(ra, EntryBlob, func(reader io.Reader, hdr *tar.Header) error {
+		// TODO: Handle error?
+		_, _ = seekFile(ra, EntryBlob, func(reader io.Reader, hdr *tar.Header) error {
 			dataReader, tarHeader = reader, hdr
 			return nil
 		})
@@ -127,7 +128,8 @@ func contentProxyHandler(ra content.ReaderAt) http.Handler {
 				start, wantedLen, err := parseRangeHeader(strings.TrimPrefix(r.Header.Get("Range"), "bytes="), totalLen)
 				if err != nil {
 					w.WriteHeader(http.StatusBadRequest)
-					w.Write([]byte(err.Error()))
+					// TODO: Handle error?
+					_, _ = w.Write([]byte(err.Error()))
 					return
 				}
 
@@ -139,7 +141,8 @@ func contentProxyHandler(ra content.ReaderAt) http.Handler {
 					_, err = io.CopyN(io.Discard, dataReader, start-curPos)
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
-						w.Write([]byte(err.Error()))
+						// TODO: Handle error?
+						_, _ = w.Write([]byte(err.Error()))
 						return
 					}
 					curPos = start
@@ -149,7 +152,8 @@ func contentProxyHandler(ra content.ReaderAt) http.Handler {
 				readLen, err := io.CopyN(w, dataReader, wantedLen)
 				if err != nil && !errors.Is(err, io.EOF) {
 					w.WriteHeader(http.StatusInternalServerError)
-					w.Write([]byte(err.Error()))
+					// TODO: Handle error?
+					_, _ = w.Write([]byte(err.Error()))
 					return
 				}
 				curPos += readLen

--- a/pkg/daemon/rafs.go
+++ b/pkg/daemon/rafs.go
@@ -200,7 +200,7 @@ func (d *Daemon) UmountAllInstances() error {
 	return nil
 }
 
-func (d *Daemon) CloneInstances(src *Daemon) error {
+func (d *Daemon) CloneInstances(src *Daemon) {
 	src.Instances.Lock()
 	defer src.Instances.Unlock()
 
@@ -209,8 +209,6 @@ func (d *Daemon) CloneInstances(src *Daemon) error {
 	d.Lock()
 	defer d.Unlock()
 	d.Instances.instances = instances
-
-	return nil
 }
 
 func (d *Daemon) UmountInstance(r *Rafs) error {


### PR DESCRIPTION
In addition, fix linter warnings reported by new linter.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>