### PR TITLE
Migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/docs/run_nydus_in_kubernetes.md
+++ b/docs/run_nydus_in_kubernetes.md
@@ -42,11 +42,10 @@ version = 2
   runtime_type = "io.containerd.runc.v2"
 
 [plugins."io.containerd.grpc.v1.cri"]
-  sandbox_image = "k8s.gcr.io/pause:3.6"
+  sandbox_image = "registry.k8s.io/pause:3.6"
 ```
 
 With these two configuration files, we can create a kind cluster.
-
 
 ```bash
 $ kind create cluster --config=kind-config.yaml

--- a/tests/e2e/k8s/containerd.config.toml
+++ b/tests/e2e/k8s/containerd.config.toml
@@ -25,7 +25,7 @@ runtime_type = "io.containerd.runc.v2"
 
 [plugins."io.containerd.grpc.v1.cri"]
 # use fixed sandbox image
-sandbox_image = "k8s.gcr.io/pause:3.6"
+sandbox_image = "registry.k8s.io/pause:3.6"
 # allow hugepages controller to be missing
 # see https://github.com/containerd/cri/pull/1501
 tolerate_missing_hugepages_controller = true


### PR DESCRIPTION
This PR migrate from `k8s.gcr.io` to `registry.k8s.io`

Part Of https://github.com/kubernetes/k8s.io/issues/4780