### PR TITLE
only do umount against nydusd that has host mounted

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -514,7 +514,9 @@ func (d *Daemon) Wait() error {
 		// nydus-snapshotter, p.Wait() will return err, so here should exclude this case
 		if _, err = p.Wait(); err != nil && !errors.Is(err, syscall.ECHILD) {
 			log.L.Errorf("failed to process wait, %v", err)
-		} else {
+		} else if d.HostMountpoint() != "" || config.GetFsDriver() != config.FsDriverFscache {
+			// No need to umount if the nydusd never performs mount. In other word, it does not
+			// associate with a host mountpoint.
 			if err := mount.WaitUntilUnmounted(d.HostMountpoint()); err != nil {
 				log.L.WithError(err).Errorf("umount %s", d.HostMountpoint())
 			}


### PR DESCRIPTION
For fscache driver, the unique and shared  nydusd does not ever mount a filesystem on host. So we don't have to clean up
the mounts when deleting snapshots.