### PR TITLE
fix system controller default socket address

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 		CleanupOnClose: false,
 		SystemControllerConfig: SystemControllerConfig{
 			Enable:  true,
-			Address: "/var/lib/containerd-nydus/system.sock",
+			Address: "/var/run/containerd-nydus/system.sock",
 			DebugConfig: DebugConfig{
 				ProfileDuration: 5,
 			},

--- a/config/default.go
+++ b/config/default.go
@@ -25,7 +25,7 @@ const (
 
 	defaultRootDir                 = "/var/lib/containerd-nydus"
 	oldDefaultRootDir              = "/var/lib/containerd-nydus-grpc"
-	defaultSystemControllerAddress = "/var/lib/containerd-nydus/system.sock"
+	defaultSystemControllerAddress = "/var/run/containerd-nydus/system.sock"
 
 	// Log rotation
 	defaultRotateLogMaxSize    = 200 // 200 megabytes

--- a/docs/configure_nydus.md
+++ b/docs/configure_nydus.md
@@ -133,4 +133,4 @@ Nydusd records metrics in its own format. The metrics are exported via a HTTP se
 ## Diagnose
 
 A system controller can be ran insides nydus-snapshotter.
-By setting `system.enable` to `true`,  nydus-snapshotter will start a simple HTTP serve on unix domain socket `system.address` path and exports some internal working status to users. The address defaults to `$ROOT/system.sock`
+By setting `system.enable` to `true`,  nydus-snapshotter will start a simple HTTP serve on unix domain socket `system.address` path and exports some internal working status to users. The address defaults to `/var/run/containerd-nydus/system.sock`

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -11,7 +11,7 @@ cleanup_on_close = false
 # Snapshotter's debug and trace HTTP server interface
 enable = true
 # Unix domain socket path where system controller is listening on
-address = "/var/lib/containerd-nydus/system.sock"
+address = "/var/run/containerd-nydus/system.sock"
 
 [system.debug]
 # Snapshotter can profile the CPU utilization of each nydusd daemon when it is being started.


### PR DESCRIPTION
The default address should locate at
/var/run/containerd-nydus/system.sock