### PR TITLE
Add pprof HTTP server for snapshotter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -166,7 +166,8 @@ type MetricsConfig struct {
 }
 
 type DebugConfig struct {
-	ProfileDuration int64 `toml:"daemon_cpu_profile_duration_secs"`
+	ProfileDuration int64  `toml:"daemon_cpu_profile_duration_secs"`
+	PprofAddress    string `toml:"pprof_address"`
 }
 
 type SystemControllerConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,6 +31,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 			Address: "/var/run/containerd-nydus/system.sock",
 			DebugConfig: DebugConfig{
 				ProfileDuration: 5,
+				PprofAddress:    "",
 			},
 		},
 		DaemonConfig: DaemonConfig{

--- a/config/global.go
+++ b/config/global.go
@@ -87,6 +87,10 @@ func SystemControllerAddress() string {
 	return globalConfig.origin.SystemControllerConfig.Address
 }
 
+func SystemControllerPprofAddress() string {
+	return globalConfig.origin.SystemControllerConfig.DebugConfig.PprofAddress
+}
+
 func GetDaemonProfileCPUDuration() int64 {
 	return globalConfig.origin.SystemControllerConfig.DebugConfig.ProfileDuration
 }

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -17,6 +17,8 @@ address = "/var/run/containerd-nydus/system.sock"
 # Snapshotter can profile the CPU utilization of each nydusd daemon when it is being started.
 # This option specifies the profile duration when nydusd is downloading and uncomproessing data.
 daemon_cpu_profile_duration_secs = 5
+# Enable by assigning an address, empty indicates pprof server is disabled
+pprof_address = ""
 
 [daemon]
 nydusd_path = "/usr/local/bin/nydusd"

--- a/pkg/metrics/listener.go
+++ b/pkg/metrics/listener.go
@@ -18,8 +18,8 @@ import (
 // Endpoint for prometheus metrics
 var endpointPromMetrics = "/v1/metrics"
 
-// NewListener creates a new TCP listener bound to the given address.
-func NewHTTPListener(addr string) error {
+// NewMetricsHTTPListener creates a new TCP listener bound to the given address for metrics server.
+func NewMetricsHTTPListener(addr string) error {
 	if addr == "" {
 		return fmt.Errorf("the address for metrics HTTP server is invalid")
 	}

--- a/pkg/pprof/listener.go
+++ b/pkg/pprof/listener.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package pprof
+
+import (
+	"net"
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
+)
+
+func NewPprofHTTPListener(addr string) error {
+	if addr == "" {
+		return errors.New("the address for pprof HTTP server is invalid")
+	}
+
+	http.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	http.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	http.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	http.Handle("/debug/pprof/block", pprof.Handler("block"))
+	http.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	http.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return errors.Wrapf(err, "pprof server listener, addr=%s", addr)
+	}
+
+	go func() {
+		log.L.Infof("Start pprof HTTP server on %s", addr)
+
+		if err := http.Serve(l, nil); err != nil && !errors.Is(err, net.ErrClosed) {
+			log.L.Errorf("Pprof server fails to listen or serve %s: %v", addr, err)
+		}
+	}()
+
+	return nil
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
+	"github.com/containerd/nydus-snapshotter/pkg/pprof"
 
 	"github.com/containerd/nydus-snapshotter/pkg/resolve"
 	"github.com/containerd/nydus-snapshotter/pkg/store"
@@ -133,6 +134,12 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 				log.L.WithError(err).Error("Failed to start system controller")
 			}
 		}()
+		pprofAddress := config.SystemControllerPprofAddress()
+		if pprofAddress != "" {
+			if err := pprof.NewPprofHTTPListener(pprofAddress); err != nil {
+				return nil, errors.Wrap(err, "Failed to start pprof HTTP server")
+			}
+		}
 	}
 
 	opts := []filesystem.NewFSOpt{

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -113,7 +113,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	// Start to collect metrics.
 	if cfg.MetricsConfig.Address != "" {
 		go func() {
-			if err := metrics.NewHTTPListener(cfg.MetricsConfig.Address); err != nil {
+			if err := metrics.NewMetricsHTTPListener(cfg.MetricsConfig.Address); err != nil {
 				log.L.WithError(err).Error("Failed to start metrics HTTP server")
 			}
 		}()


### PR DESCRIPTION
As titled. This PR is addressing #359

![image](https://user-images.githubusercontent.com/20137756/220580734-4f4bd6f4-2fb4-4b4d-9ead-079a06ddbff0.png)

To visualise:
```shell
go tool pprof -http :LOCAL_PORT http://HOST:PORT/debug/pprof/goroutine
```
