### PR TITLE
metrics: export nydus daemon memory usage (RSS)

### DIFF
--- a/pkg/metrics/collector/daemon.go
+++ b/pkg/metrics/collector/daemon.go
@@ -21,6 +21,11 @@ type DaemonInfoCollector struct {
 	value   float64
 }
 
+type DaemonResourceCollector struct {
+	DaemonID string
+	Value    float64
+}
+
 func (d *DaemonEventCollector) Collect() {
 	data.NydusdEventCount.WithLabelValues(string(d.event)).Inc()
 }
@@ -31,4 +36,8 @@ func (d *DaemonInfoCollector) Collect() {
 		return
 	}
 	data.NydusdCount.WithLabelValues(d.Version.PackageVer).Add(d.value)
+}
+
+func (d *DaemonResourceCollector) Collect() {
+	data.NydusdRSS.WithLabelValues(d.DaemonID).Set(d.Value)
 }

--- a/pkg/metrics/data/daemon.go
+++ b/pkg/metrics/data/daemon.go
@@ -6,11 +6,15 @@
 
 package data
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/containerd/nydus-snapshotter/pkg/metrics/types/ttl"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var (
 	nydusdEventLabel   = "nydusd_event"
 	nydusdVersionLabel = "version"
+	daemonIDLabel      = "daemon_id"
 )
 
 var (
@@ -27,5 +31,13 @@ var (
 			Help: "The counts of nydus daemon.",
 		},
 		[]string{nydusdVersionLabel},
+	)
+	NydusdRSS = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_rss_kilobytes",
+			Help: "Memory usage (RSS) of nydus daemon.",
+		},
+		[]string{daemonIDLabel},
+		ttl.DefaultTTL,
 	)
 )

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -23,6 +23,7 @@ func init() {
 		data.TotalHungIO,
 		data.NydusdEventCount,
 		data.NydusdCount,
+		data.NydusdRSS,
 		data.SnapshotEventElapsedHists,
 		data.CacheUsage,
 		data.CPUUsage,


### PR DESCRIPTION
Export nydus daemon memory usage (RSS) to prometheus metrics.