### PR TITLE
Fix override for log-to-stdout cmdline option

### DIFF
--- a/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -22,6 +22,7 @@ type Args struct {
 	DaemonMode            string
 	FsDriver              string
 	LogToStdout           bool
+	LogToStdoutCount      int
 	PrintVersion          bool
 }
 
@@ -77,6 +78,7 @@ func buildFlags(args *Args) []cli.Flag {
 			Name:        "log-to-stdout",
 			Usage:       "print log messages to STDOUT",
 			Destination: &args.LogToStdout,
+			Count:       &args.LogToStdoutCount,
 		},
 		&cli.StringFlag{
 			Name:        "nydus-image",

--- a/config/config.go
+++ b/config/config.go
@@ -304,7 +304,9 @@ func ParseParameters(args *command.Args, cfg *SnapshotterConfig) error {
 	if args.LogLevel != "" {
 		logConfig.LogLevel = args.LogLevel
 	}
-	logConfig.LogToStdout = args.LogToStdout
+	if args.LogToStdoutCount > 0 {
+		logConfig.LogToStdout = args.LogToStdout
+	}
 
 	// --- remote storage configuration
 	// empty

--- a/config/config.go
+++ b/config/config.go
@@ -109,7 +109,7 @@ type DaemonConfig struct {
 }
 
 type LoggingConfig struct {
-	LogToStdout         bool
+	LogToStdout         bool   `toml:"log_to_stdout"`
 	LogLevel            string `toml:"level"`
 	LogDir              string `toml:"dir"`
 	RotateLogMaxSize    int    `toml:"log_rotation_max_size"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -101,3 +101,63 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 
 	A.Equal(GetCacheGCPeriod(), time.Hour*24)
 }
+
+func TestSnapshotterConfig(t *testing.T) {
+	A := assert.New(t)
+
+	var cfg SnapshotterConfig
+	var args command.Args
+
+	// The log_to_stdout is false in toml file without --log-to-stdout flag.
+	// Expected false.
+	cfg.LoggingConfig.LogToStdout = false
+	args.LogToStdoutCount = 0
+	err := ParseParameters(&args, &cfg)
+	A.NoError(err)
+	A.EqualValues(cfg.LoggingConfig.LogToStdout, false)
+
+	// The log_to_stdout is true in toml file without --log-to-stdout flag.
+	// Expected true.
+	// This case is failed.
+	cfg.LoggingConfig.LogToStdout = true
+	args.LogToStdoutCount = 0
+	err = ParseParameters(&args, &cfg)
+	A.NoError(err)
+	A.EqualValues(cfg.LoggingConfig.LogToStdout, true)
+
+	// The log_to_stdout is false in toml file with --log-to-stdout=true.
+	// Expected true (command flag has higher priority).
+	args.LogToStdout = true
+	args.LogToStdoutCount = 1
+	cfg.LoggingConfig.LogToStdout = false
+	err = ParseParameters(&args, &cfg)
+	A.NoError(err)
+	A.EqualValues(cfg.LoggingConfig.LogToStdout, true)
+
+	// The log_to_stdout is true in toml file with --log-to-stdout=true.
+	// Expected true (command flag has higher priority).
+	args.LogToStdout = true
+	args.LogToStdoutCount = 1
+	cfg.LoggingConfig.LogToStdout = true
+	err = ParseParameters(&args, &cfg)
+	A.NoError(err)
+	A.EqualValues(cfg.LoggingConfig.LogToStdout, true)
+
+	// The log_to_stdout is false in toml file with --log-to-stdout=false.
+	// Expected false (command flag has higher priority).
+	args.LogToStdout = false
+	args.LogToStdoutCount = 1
+	cfg.LoggingConfig.LogToStdout = false
+	err = ParseParameters(&args, &cfg)
+	A.NoError(err)
+	A.EqualValues(cfg.LoggingConfig.LogToStdout, false)
+
+	// The log_to_stdout is true in toml file with --log-to-stdout=false.
+	// Expected false (command flag has higher priority).
+	args.LogToStdout = false
+	args.LogToStdoutCount = 1
+	cfg.LoggingConfig.LogToStdout = true
+	err = ParseParameters(&args, &cfg)
+	A.NoError(err)
+	A.EqualValues(cfg.LoggingConfig.LogToStdout, false)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -92,6 +92,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 	A.EqualValues(cfg.LoggingConfig.LogToStdout, false)
 
 	args.LogToStdout = true
+	args.LogToStdoutCount = 1
 	err = ParseParameters(&args, cfg)
 	A.NoError(err)
 	A.EqualValues(cfg.LoggingConfig.LogToStdout, true)

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/rs/xid v1.4.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
-	github.com/urfave/cli/v2 v2.3.0
+	github.com/urfave/cli/v2 v2.24.4
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/net v0.7.0
 	golang.org/x/sync v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
@@ -54,6 +53,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -41,7 +41,6 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
-github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/KarpelesLab/reflink v0.0.2 h1:PK0nDUsk2eEdIvMOUzh2TI35GY5KYmTdqdCCwd3BIz0=
 github.com/KarpelesLab/reflink v0.0.2/go.mod h1:mB+2afhyn+eZTMFSH1gXunrgArTsiUBzfoAy0X2fatA=
@@ -936,8 +935,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
-github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+github.com/urfave/cli/v2 v2.24.4 h1:0gyJJEBYtCV87zI/x2nZCPyDxD51K6xM8SkwjHFCNEU=
+github.com/urfave/cli/v2 v2.24.4/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
@@ -1457,7 +1456,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -954,6 +954,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -1456,6 +1458,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tests/e2e/k8s/snapshotter-cri.yaml
+++ b/tests/e2e/k8s/snapshotter-cri.yaml
@@ -158,6 +158,7 @@ data:
     log_rotation_max_backups = 5
     # In unit MB(megabytes)
     log_rotation_max_size = 1
+    log_to_stdout = false
 
     [remote]
     convert_vpc_registry = false

--- a/tests/e2e/k8s/snapshotter-kubeconf.yaml
+++ b/tests/e2e/k8s/snapshotter-kubeconf.yaml
@@ -181,6 +181,7 @@ data:
     log_rotation_max_backups = 5
     # In unit MB(megabytes)
     log_rotation_max_size = 1
+    log_to_stdout = false
 
     [remote]
     convert_vpc_registry = false


### PR DESCRIPTION
Updates github.com/urfave/cli/v2 to v.2.24.4 which allows the usage of the `Count` property for `BoolFlag`. This enables the detection of the cmdline flag being set or not and allows for correctly overriding the option from the toml config.
The corresponding tests have been added as well.

Signed-off-by: Philipp Kolberg <philipp.kolberg@t-online.de>