### PR TITLE
config: avoid to use default dir if root is valid

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -245,10 +245,6 @@ func ValidateConfig(c *SnapshotterConfig) error {
 			"\"enable_cri_keychain\" and \"enable_kubeconfig_keychain\" can't be set at the same time")
 	}
 
-	if !c.CacheManagerConfig.Disable && c.CacheManagerConfig.CacheDir == "" {
-		return errors.Wrapf(errdefs.ErrInvalidArgument, "cache directory is empty")
-	}
-
 	if c.RemoteConfig.MirrorsConfig.Dir != "" {
 		dirExisted, err := file.IsDirExisted(c.RemoteConfig.MirrorsConfig.Dir)
 		if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -161,4 +162,37 @@ func TestSnapshotterConfig(t *testing.T) {
 	err = ParseParameters(&args, &cfg)
 	A.NoError(err)
 	A.EqualValues(cfg.LoggingConfig.LogToStdout, false)
+}
+
+func TestMergeConfig(t *testing.T) {
+	A := assert.New(t)
+	var defaultSnapshotterConfig SnapshotterConfig
+	var snapshotterConfig1 SnapshotterConfig
+
+	defaultSnapshotterConfig.FillUpWithDefaults()
+
+	MergeConfig(&snapshotterConfig1, &defaultSnapshotterConfig)
+	A.Equal(snapshotterConfig1.Root, defaultRootDir)
+	A.Equal(snapshotterConfig1.LoggingConfig.LogDir, "")
+	A.Equal(snapshotterConfig1.CacheManagerConfig.CacheDir, "")
+
+	A.Equal(snapshotterConfig1.DaemonMode, DefaultDaemonMode)
+	A.Equal(snapshotterConfig1.SystemControllerConfig.Address, defaultSystemControllerAddress)
+	A.Equal(snapshotterConfig1.LoggingConfig.LogLevel, DefaultLogLevel)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxSize, defaultRotateLogMaxSize)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxBackups, defaultRotateLogMaxBackups)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxAge, defaultRotateLogMaxAge)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogCompress, defaultRotateLogCompress)
+
+	A.Equal(snapshotterConfig1.DaemonConfig.NydusdConfigPath, defaultNydusDaemonConfigPath)
+	A.Equal(snapshotterConfig1.DaemonConfig.RecoverPolicy, RecoverPolicyRestart.String())
+	A.Equal(snapshotterConfig1.CacheManagerConfig.GCPeriod, defaultGCPeriod)
+
+	var snapshotterConfig2 SnapshotterConfig
+	snapshotterConfig2.Root = "/snapshotter/root"
+
+	MergeConfig(&snapshotterConfig2, &defaultSnapshotterConfig)
+	A.Equal(snapshotterConfig2.Root, "/snapshotter/root")
+	A.Equal(snapshotterConfig2.LoggingConfig.LogDir, "")
+	A.Equal(snapshotterConfig2.CacheManagerConfig.CacheDir, "")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -196,3 +196,32 @@ func TestMergeConfig(t *testing.T) {
 	A.Equal(snapshotterConfig2.LoggingConfig.LogDir, "")
 	A.Equal(snapshotterConfig2.CacheManagerConfig.CacheDir, "")
 }
+
+func TestProcessConfigurations(t *testing.T) {
+	A := assert.New(t)
+	var defaultSnapshotterConfig SnapshotterConfig
+	var snapshotterConfig1 SnapshotterConfig
+
+	defaultSnapshotterConfig.FillUpWithDefaults()
+
+	MergeConfig(&snapshotterConfig1, &defaultSnapshotterConfig)
+	err := ValidateConfig(&snapshotterConfig1)
+	A.NoError(err)
+	err = ProcessConfigurations(&snapshotterConfig1)
+	A.NoError(err)
+
+	A.Equal(snapshotterConfig1.LoggingConfig.LogDir, filepath.Join(snapshotterConfig1.Root, "logs"))
+	A.Equal(snapshotterConfig1.CacheManagerConfig.CacheDir, filepath.Join(snapshotterConfig1.Root, "cache"))
+
+	var snapshotterConfig2 SnapshotterConfig
+	snapshotterConfig2.Root = "/snapshotter/root"
+
+	MergeConfig(&snapshotterConfig2, &defaultSnapshotterConfig)
+	err = ValidateConfig(&snapshotterConfig2)
+	A.NoError(err)
+	err = ProcessConfigurations(&snapshotterConfig2)
+	A.NoError(err)
+
+	A.Equal(snapshotterConfig2.LoggingConfig.LogDir, filepath.Join(snapshotterConfig2.Root, "logs"))
+	A.Equal(snapshotterConfig2.CacheManagerConfig.CacheDir, filepath.Join(snapshotterConfig2.Root, "cache"))
+}

--- a/config/default.go
+++ b/config/default.go
@@ -8,9 +8,6 @@ package config
 
 import (
 	"os/exec"
-	"path/filepath"
-
-	"github.com/containerd/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
 )
 
 const (
@@ -50,9 +47,6 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 	if logConfig.LogLevel == "" {
 		logConfig.LogLevel = DefaultLogLevel
 	}
-	if len(logConfig.LogDir) == 0 {
-		logConfig.LogDir = filepath.Join(c.Root, logging.DefaultLogDirName)
-	}
 	logConfig.RotateLogMaxSize = defaultRotateLogMaxSize
 	logConfig.RotateLogMaxBackups = defaultRotateLogMaxBackups
 	logConfig.RotateLogMaxAge = defaultRotateLogMaxAge
@@ -70,9 +64,6 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 	cacheConfig := &c.CacheManagerConfig
 	if cacheConfig.GCPeriod == "" {
 		cacheConfig.GCPeriod = defaultGCPeriod
-	}
-	if len(cacheConfig.CacheDir) == 0 {
-		cacheConfig.CacheDir = filepath.Join(c.Root, "cache")
 	}
 
 	return c.SetupNydusBinaryPaths()

--- a/config/global.go
+++ b/config/global.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
 	"github.com/pkg/errors"
 )
 
@@ -96,6 +97,13 @@ func GetDaemonProfileCPUDuration() int64 {
 }
 
 func ProcessConfigurations(c *SnapshotterConfig) error {
+	if c.LoggingConfig.LogDir == "" {
+		c.LoggingConfig.LogDir = filepath.Join(c.Root, logging.DefaultLogDirName)
+	}
+	if c.CacheManagerConfig.CacheDir == "" {
+		c.CacheManagerConfig.CacheDir = filepath.Join(c.Root, "cache")
+	}
+
 	globalConfig.origin = c
 
 	globalConfig.SnapshotsDir = filepath.Join(c.Root, "snapshots")


### PR DESCRIPTION
In the default configuration for snapshotter we fill the cacheDir and LogDir:
```go
    logConfig := &c.LoggingConfig
    if len(logConfig.LogDir) == 0 {
		logConfig.LogDir = filepath.Join(c.Root, logging.DefaultLogDirName)
	}
    cacheConfig := &c.CacheManagerConfig
	if len(cacheConfig.CacheDir) == 0 {
		cacheConfig.CacheDir = filepath.Join(c.Root, "cache")
	}
```
But we do not fill these elements after loading the configuration from the `toml' file and parsing the arguments. This results in cacheDir and LogDir not being in snapshotter's RootDir.