### PR TITLE
daemon: increase retry times to avoid premature returns

### DIFF
--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -173,7 +173,7 @@ func WaitUntilSocketExisted(sock string) error {
 
 		return nil
 	},
-		retry.Attempts(20), // totally wait for 2 seconds, should be enough
+		retry.Attempts(100), // totally wait for 10 seconds, should be enough
 		retry.LastErrorOnly(true),
 		retry.Delay(100*time.Millisecond))
 }


### PR DESCRIPTION
Currently, snapshotter retries for 2s while waiting for the nydus daemon's unix domain socket file to exist. This probably causes the nydusd_count metric to be incorrect because it returns prematurely.

This PR is addressing #392 