### PR TITLE
daemonconfig: only load mirrorsConfig for target host

### DIFF
--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -32,7 +32,7 @@ type DaemonConfig interface {
 	// Provide auth
 	FillAuth(kc *auth.PassKeyChain)
 	StorageBackendType() string
-	UpdateMirrors(mirrorsConfigDir string) error
+	UpdateMirrors(mirrorsConfigDir, registryHost string) error
 	DumpString() (string, error)
 	DumpFile(path string) error
 }
@@ -156,6 +156,10 @@ func SupplementDaemonConfig(c DaemonConfig, imageID, snapshotID string,
 		} else if registryHost == "docker.io" {
 			// For docker.io images, we should use index.docker.io
 			registryHost = "index.docker.io"
+		}
+
+		if err := c.UpdateMirrors(config.GetMirrorsConfigDir(), registryHost); err != nil {
+			return errors.Wrap(err, "update mirrors config")
 		}
 
 		// If no auth is provided, don't touch auth from provided nydusd configuration file.

--- a/config/daemonconfig/fscache.go
+++ b/config/daemonconfig/fscache.go
@@ -68,8 +68,8 @@ func LoadFscacheConfig(p string) (*FscacheDaemonConfig, error) {
 	return &cfg, nil
 }
 
-func (c *FscacheDaemonConfig) UpdateMirrors(mirrorsConfigDir string) error {
-	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir)
+func (c *FscacheDaemonConfig) UpdateMirrors(mirrorsConfigDir, registryHost string) error {
+	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	if err != nil {
 		return err
 	}

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -75,8 +75,8 @@ func (c *FuseDaemonConfig) FillAuth(kc *auth.PassKeyChain) {
 	}
 }
 
-func (c *FuseDaemonConfig) UpdateMirrors(mirrorsConfigDir string) error {
-	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir)
+func (c *FuseDaemonConfig) UpdateMirrors(mirrorsConfigDir, registryHost string) error {
+	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	if err != nil {
 		return err
 	}

--- a/config/daemonconfig/mirrors_test.go
+++ b/config/daemonconfig/mirrors_test.go
@@ -19,104 +19,63 @@ func TestLoadMirrorConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	defer os.RemoveAll(tmpDir)
 
+	registryHost := "registry.docker.io"
+
 	mirrorsConfigDir := filepath.Join(tmpDir, "certs.d")
-	mirrorsInvalidConfigDir := filepath.Join(tmpDir, "certs.d.file")
-	mirrorsConfigPath1 := filepath.Join(mirrorsConfigDir, "test1.toml")
-	mirrorsConfigPath2 := filepath.Join(mirrorsConfigDir, "test2.toml")
-	mirrorsConfigPath3 := filepath.Join(mirrorsConfigDir, "test3.toml")
-	mirrorsConfigPath4 := filepath.Join(mirrorsConfigDir, "test4.yaml")
-	mirrorsConfigPath5 := filepath.Join(mirrorsConfigDir, "test5.toml")
-	mirrorsInvalidConfigPath1 := filepath.Join(mirrorsConfigDir, "dir")
+	registryHostConfigDir := filepath.Join(mirrorsConfigDir, registryHost)
+	defaultHostConfigDir := filepath.Join(mirrorsConfigDir, "_default")
 
-	mirrors, err := LoadMirrorsConfig("")
-	require.Nil(t, err)
+	mirrors, err := LoadMirrorsConfig("", registryHost)
+	require.NoError(t, err)
 	require.Nil(t, mirrors)
 
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
-	require.Error(t, err)
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	require.NoError(t, err)
 	require.Nil(t, mirrors)
 
-	err = os.Mkdir(mirrorsConfigDir, os.ModePerm)
+	err = os.MkdirAll(defaultHostConfigDir, os.ModePerm)
 	assert.NoError(t, err)
 
-	err = os.WriteFile(mirrorsInvalidConfigDir, []byte(`""`), 0600)
-	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsInvalidConfigDir)
-	require.ErrorContains(t, err, "is not existed")
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	require.NoError(t, err)
 	require.Nil(t, mirrors)
 
-	buf1 := []byte(`server = "https://docker.hub.com"
-
+	buf1 := []byte(`server = "https://default-docker.hub.com"
 	[host]
-
-	  [host."http://p2p-mirror1:65001"]
-		auth_through = false
-
-		[host."http://p2p-mirror1:65001".header]
-		  X-Dragonfly-Registry = ["https://docker.hub.com"]`)
-	err = os.WriteFile(mirrorsConfigPath1, buf1, 0600)
+	  [host."http://default-p2p-mirror1:65001"]
+		auth_through = true
+		[host."http://default-p2p-mirror1:65001".header]
+		  X-Dragonfly-Registry = ["https://default-docker.hub.com"]
+	`)
+	err = os.WriteFile(filepath.Join(defaultHostConfigDir, "hosts.toml"), buf1, 0600)
 	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
-	require.Nil(t, err)
-	require.Equal(t, len(mirrors), 1)
-	require.Equal(t, mirrors[0].Host, "http://p2p-mirror1:65001")
-	require.Equal(t, mirrors[0].AuthThrough, false)
-	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	require.NoError(t, err)
+	require.Equal(t, len(mirrors), 2)
+	require.Equal(t, mirrors[0].Host, "http://default-p2p-mirror1:65001")
+	require.Equal(t, mirrors[0].AuthThrough, true)
+	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://default-docker.hub.com")
+	require.Equal(t, mirrors[1].Host, "https://default-docker.hub.com")
+	require.Equal(t, mirrors[1].AuthThrough, false)
 
-	err = os.Mkdir(mirrorsInvalidConfigPath1, os.ModePerm)
+	err = os.MkdirAll(registryHostConfigDir, os.ModePerm)
 	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
-	require.Nil(t, err)
-	require.Equal(t, len(mirrors), 1)
 
 	buf2 := []byte(`server = "https://docker.hub.com"
-
 	[host]
-
-	  [host."http://p2p-mirror2:65001"]
-		auth_through = false
-	
-		[host."http://p2p-mirror2:65001".header]
-		  X-Dragonfly-Registry = ["https://docker.hub.com"]`)
-	err = os.WriteFile(mirrorsConfigPath2, buf2, 0600)
+	  [host."http://p2p-mirror1:65001"]
+		auth_through = true
+		[host."http://p2p-mirror1:65001".header]
+		  X-Dragonfly-Registry = ["https://docker.hub.com"]
+	`)
+	err = os.WriteFile(filepath.Join(registryHostConfigDir, "hosts.toml"), buf2, 0600)
 	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
-	require.Nil(t, err)
+	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	require.NoError(t, err)
 	require.Equal(t, len(mirrors), 2)
-
-	buf3 := []byte(`server = "https://docker.hub.com"
-
-	[host]
-
-	  [host."http://127.0.0.1:65001"]
-	    capabilities = ["pull", "resolve"]
-	    auth_through = true
-
-	    [host."http://127.0.0.1:65001".header]
-	      X-Dragonfly-Registry = ["https://docker.hub.com"]`)
-	err = os.WriteFile(mirrorsConfigPath3, buf3, 0600)
-	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
-	require.Nil(t, err)
-	require.Equal(t, len(mirrors), 3)
-	require.Equal(t, mirrors[2].Host, "http://127.0.0.1:65001")
-	require.Equal(t, mirrors[2].AuthThrough, true)
-	require.Equal(t, mirrors[2].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
-
-	buf4 := []byte(`[test]`)
-	err = os.WriteFile(mirrorsConfigPath4, buf4, 0600)
-	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
-	require.ErrorContains(t, err, "invalid file path")
-	require.Equal(t, len(mirrors), 0)
-
-	buf5 := []byte(`}`)
-	err = os.MkdirAll(mirrorsConfigDir, os.ModePerm)
-	assert.NoError(t, err)
-	err = os.WriteFile(mirrorsConfigPath5, buf5, 0600)
-	assert.NoError(t, err)
-
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir)
-	require.ErrorContains(t, err, "invalid file path")
-	require.Equal(t, len(mirrors), 0)
+	require.Equal(t, mirrors[0].Host, "http://p2p-mirror1:65001")
+	require.Equal(t, mirrors[0].AuthThrough, true)
+	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
+	require.Equal(t, mirrors[1].Host, "https://docker.hub.com")
+	require.Equal(t, mirrors[1].AuthThrough, false)
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -243,10 +243,6 @@ func (fs *Filesystem) Mount(snapshotID string, labels map[string]string) (err er
 		daemonconfig.CacheDir: cacheDir}
 
 	cfg := deepcopy.Copy(fs.Manager.DaemonConfig).(daemonconfig.DaemonConfig)
-
-	if err := cfg.UpdateMirrors(config.GetMirrorsConfigDir()); err != nil {
-		return errors.Wrap(err, "update mirrors config")
-	}
 	err = daemonconfig.SupplementDaemonConfig(cfg, imageID, snapshotID, false, labels, params)
 	if err != nil {
 		return errors.Wrap(err, "supplement configuration")


### PR DESCRIPTION
Now, we load all the mirrorsConfig from directory. And the mirrorsConfig is available to all hosts. This is not compatible with containerd's mirror configuration. This PR tries to solve this issue.