### PR TITLE
converter: support parent bootstrap for merge

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -579,6 +579,7 @@ func Merge(ctx context.Context, layers []Layer, dest io.Writer, opt MergeOption)
 
 		TargetBootstrapPath: targetBootstrapPath,
 		ChunkDictPath:       opt.ChunkDictPath,
+		ParentBootstrapPath: opt.ParentBootstrapPath,
 		PrefetchPatterns:    opt.PrefetchPatterns,
 		OutputJSONPath:      filepath.Join(workDir, "merge-output.json"),
 		Timeout:             opt.Timeout,

--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -54,6 +54,7 @@ type MergeOption struct {
 
 	TargetBootstrapPath string
 	ChunkDictPath       string
+	ParentBootstrapPath string
 	PrefetchPatterns    string
 	OutputJSONPath      string
 	Timeout             *time.Duration
@@ -222,6 +223,9 @@ func Merge(option MergeOption) ([]digest.Digest, error) {
 	}
 	if option.ChunkDictPath != "" {
 		args = append(args, "--chunk-dict", fmt.Sprintf("bootstrap=%s", option.ChunkDictPath))
+	}
+	if option.ParentBootstrapPath != "" {
+		args = append(args, "--parent-bootstrap", option.ParentBootstrapPath)
 	}
 	if option.PrefetchPatterns == "" {
 		option.PrefetchPatterns = "/"

--- a/pkg/converter/types.go
+++ b/pkg/converter/types.go
@@ -91,6 +91,8 @@ type MergeOption struct {
 	FsVersion string
 	// ChunkDictPath holds the bootstrap path of chunk dict image.
 	ChunkDictPath string
+	// ParentBootstrapPath holds the bootstrap path of parent image.
+	ParentBootstrapPath string
 	// PrefetchPatterns holds file path pattern list want to prefetch.
 	PrefetchPatterns string
 	// WithTar puts bootstrap into a tar stream (no gzip).


### PR DESCRIPTION
Add `ParentBootstrapPath` option for `converter.Merge` method, the
option holds the bootstrap path of a parent image.

This option allows merging multiple bootstraps of upper layer with
the bootstrap of a parent image, so that we can implement container
commit operation for nydus image.