### PR TITLE
change oom score adj for nydus daemon

### DIFF
--- a/misc/snapshotter/nydus-snapshotter.fusedev.service
+++ b/misc/snapshotter/nydus-snapshotter.fusedev.service
@@ -10,9 +10,10 @@ ExecStart=/usr/local/bin/containerd-nydus-grpc --config /etc/nydus/config.toml
 Restart=always
 RestartSec=1
 KillMode=process
-OOMScoreAdjust=-999
+OOMScoreAdjust=-1000
 StandardOutput=journal
 StandardError=journal
+MemoryMax=2G
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
 	metrics "github.com/containerd/nydus-snapshotter/pkg/metrics/tool"
+	"github.com/containerd/nydus-snapshotter/pkg/utils/oom"
 )
 
 // Fork the nydusd daemon with the process PID decided
@@ -40,6 +41,10 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 	defer d.Unlock()
 
 	d.States.ProcessID = cmd.Process.Pid
+	err = oom.ChangeDaemonOOMScoreAdj(d.States.ProcessID, -999)
+	if err != nil {
+		return errors.Wrapf(err, "change oom score adj for %d", cmd.Process.Pid)
+	}
 
 	// Profile nydusd daemon CPU usage during its startup.
 	if config.GetDaemonProfileCPUDuration() > 0 {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/filesystem"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	metrics "github.com/containerd/nydus-snapshotter/pkg/metrics/tool"
+	"github.com/containerd/nydus-snapshotter/pkg/utils/oom"
 )
 
 const (
@@ -325,6 +326,10 @@ func (sc *Controller) upgradeNydusDaemon(d *daemon.Daemon, c upgradeRequest) err
 
 	if err := cmd.Start(); err != nil {
 		return errors.Wrap(err, "start process")
+	}
+	err = oom.ChangeDaemonOOMScoreAdj(cmd.Process.Pid, -999)
+	if err != nil {
+		return errors.Wrapf(err, "change oom score adj for %d", cmd.Process.Pid)
 	}
 
 	if err := new.WaitUntilState(types.DaemonStateInit); err != nil {

--- a/pkg/utils/oom/oom.go
+++ b/pkg/utils/oom/oom.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package oom
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	OOMScoreAdjMin = -1000
+	OOMScoreAdjMax = 1000
+)
+
+func ReadOOMScoreAdj(path string) (int, error) {
+	oomBuf, err := os.ReadFile(path)
+	if err != nil {
+		return 0, errors.Wrapf(err, "read file %s", path)
+	}
+
+	oom, err := strconv.Atoi(strings.ReplaceAll(string(oomBuf), "\n", ""))
+	if err != nil {
+		return 0, errors.Wrapf(err, "convert %s to integer", string(oomBuf))
+	}
+	return oom, nil
+}
+
+func WriteOOMScoreAdj(path string, oomScoreAdj int) error {
+	return os.WriteFile(path, []byte(fmt.Sprint(oomScoreAdj)), 0644)
+}
+
+// Change the oom_score_adj of target process if the oom_score_adj of
+// current process is equal to OOM_SCORE_ADJ_MIN.
+// If the target's oom_score_adj is already greater than OOM_SCORE_ADJ_MIN, skip it.
+func ChangeDaemonOOMScoreAdj(pid, scodeAdj int) error {
+	currentOOMPath := "/proc/self/oom_score_adj"
+	currentOOM, err := ReadOOMScoreAdj(currentOOMPath)
+	if err != nil {
+		return errors.Wrapf(err, "read oom_score_adj file %s", currentOOMPath)
+	}
+	if currentOOM > OOMScoreAdjMin {
+		return nil
+	}
+
+	daemonOOMPath := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	daemonOOM, err := ReadOOMScoreAdj(currentOOMPath)
+	if err != nil {
+		return errors.Wrapf(err, "read oom_score_adj file %s", daemonOOMPath)
+	}
+	if daemonOOM > OOMScoreAdjMin {
+		return nil
+	}
+
+	return WriteOOMScoreAdj(daemonOOMPath, scodeAdj)
+}


### PR DESCRIPTION
Nydus-snapshotter does not have a maximum memory limit by default. This can result in host invalidity. We can fix this problem by adding MemoryMax to nydus-snapshotter.service. We can set OOMScoreAdjust=-1000 to prevent killing nydus-snapshotter on OOM.