### PR TITLE
fix custom nydusd paths don't work

### DIFF
--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -45,7 +45,7 @@ func main() {
 			var snapshotterConfig config.SnapshotterConfig
 
 			if err := defaultSnapshotterConfig.FillUpWithDefaults(); err != nil {
-				return errors.New("failed to fill up nydus configuration with defaults")
+				return errors.Wrap(err, "failed to fill up nydus configuration with defaults")
 			}
 
 			// Once snapshotter's configuration file is provided, parse it and let command line parameters override it.

--- a/config/config.go
+++ b/config/config.go
@@ -228,6 +228,10 @@ func ValidateConfig(c *SnapshotterConfig) error {
 		return errors.Wrapf(errdefs.ErrInvalidArgument, "configuration is none")
 	}
 
+	if err := c.ValidateNydusBinaryPaths(); err != nil {
+		return errors.Wrapf(err, "failed to validate nydusd path.")
+	}
+
 	if c.ImageConfig.ValidateSignature {
 		if c.ImageConfig.PublicKeyFile == "" {
 			return errors.New("public key file for signature validation is not provided")

--- a/config/default.go
+++ b/config/default.go
@@ -65,6 +65,9 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 		daemonConfig.NydusdConfigPath = defaultNydusDaemonConfigPath
 	}
 	daemonConfig.RecoverPolicy = RecoverPolicyRestart.String()
+	daemonConfig.NydusdPath = nydusdBinaryName
+	daemonConfig.NydusImagePath = nydusImageBinaryName
+	daemonConfig.FsDriver = FsDriverFusedev
 
 	// cache configuration
 	cacheConfig := &c.CacheManagerConfig
@@ -75,24 +78,24 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 		cacheConfig.CacheDir = filepath.Join(c.Root, "cache")
 	}
 
-	return c.SetupNydusBinaryPaths()
+	return nil
 }
 
-func (c *SnapshotterConfig) SetupNydusBinaryPaths() error {
+func (c *SnapshotterConfig) ValidateNydusBinaryPaths() error {
 	// when using DaemonMode = none, nydusd and nydus-image binaries are not required
 	if c.DaemonMode == string(DaemonModeNone) {
 		return nil
 	}
 
 	// resolve nydusd path
-	path, err := exec.LookPath(nydusdBinaryName)
+	path, err := exec.LookPath(c.DaemonConfig.NydusdPath)
 	if err != nil {
 		return err
 	}
 	c.DaemonConfig.NydusdPath = path
 
 	// resolve nydus-image path
-	path, err = exec.LookPath(nydusImageBinaryName)
+	path, err = exec.LookPath(c.DaemonConfig.NydusImagePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
By default, nydusd is searched in the $PATH. When I want to use a custom path in the command line parameter, it doesn't work.