### PR TITLE
fix containerd mount failed when root is a relative path

### DIFF
--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -76,6 +76,10 @@ func main() {
 				return errors.Wrap(err, "process configurations")
 			}
 
+			if err := config.SetupEnvironment(&snapshotterConfig); err != nil {
+				return errors.Wrap(err, "setup environment failed")
+			}
+
 			ctx := logging.WithContext()
 			logConfig := &snapshotterConfig.LoggingConfig
 			logRotateArgs := &logging.RotateLogArgs{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -86,6 +86,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 	var args = flags.Args{}
 	args.RootDir = "/var/lib/containerd/nydus"
 	exampleConfig.Root = "/var/lib/containerd/nydus"
+
 	err = ParseParameters(&args, cfg)
 	A.NoError(err)
 	A.EqualValues(cfg, &exampleConfig)
@@ -211,6 +212,7 @@ func TestProcessConfigurations(t *testing.T) {
 	A.NoError(err)
 	err = ValidateConfig(&snapshotterConfig1)
 	A.NoError(err)
+
 	err = ProcessConfigurations(&snapshotterConfig1)
 	A.NoError(err)
 
@@ -224,9 +226,21 @@ func TestProcessConfigurations(t *testing.T) {
 	A.NoError(err)
 	err = ValidateConfig(&snapshotterConfig2)
 	A.NoError(err)
+
 	err = ProcessConfigurations(&snapshotterConfig2)
 	A.NoError(err)
 
 	A.Equal(snapshotterConfig2.LoggingConfig.LogDir, filepath.Join(snapshotterConfig2.Root, "logs"))
 	A.Equal(snapshotterConfig2.CacheManagerConfig.CacheDir, filepath.Join(snapshotterConfig2.Root, "cache"))
+
+	var snapshotterConfig3 SnapshotterConfig
+	snapshotterConfig3.Root = "./snapshotter/root"
+
+	err = MergeConfig(&snapshotterConfig3, &defaultSnapshotterConfig)
+	A.NoError(err)
+	err = ValidateConfig(&snapshotterConfig3)
+	A.NoError(err)
+
+	err = ProcessConfigurations(&snapshotterConfig3)
+	A.NoError(err)
 }

--- a/config/global.go
+++ b/config/global.go
@@ -10,11 +10,13 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/nydus-snapshotter/internal/logging"
+	"github.com/containerd/nydus-snapshotter/pkg/utils/mount"
 	"github.com/pkg/errors"
 )
 
@@ -132,5 +134,18 @@ func ProcessConfigurations(c *SnapshotterConfig) error {
 
 	globalConfig.DaemonMode = m
 
+	return nil
+}
+
+func SetupEnvironment(c *SnapshotterConfig) error {
+	if err := os.MkdirAll(c.Root, 0700); err != nil {
+		return errors.Wrapf(err, "create root dir %s", c.Root)
+	}
+
+	realPath, err := mount.NormalizePath(c.Root)
+	if err != nil {
+		return errors.Wrapf(err, "root path invalid")
+	}
+	c.Root = realPath
 	return nil
 }

--- a/pkg/utils/mount/mount.go
+++ b/pkg/utils/mount/mount.go
@@ -39,7 +39,7 @@ func (m *Mounter) Umount(target string) error {
 	return syscall.Unmount(target, 0)
 }
 
-func normalizePath(path string) (realPath string, err error) {
+func NormalizePath(path string) (realPath string, err error) {
 	if realPath, err = filepath.Abs(path); err != nil {
 		return "", errors.Wrapf(err, "get absolute path for %s", path)
 	}
@@ -54,7 +54,7 @@ func normalizePath(path string) (realPath string, err error) {
 
 // return value `true` means the path is mounted
 func IsMountpoint(path string) (bool, error) {
-	realPath, err := normalizePath(path)
+	realPath, err := NormalizePath(path)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
When the Root path is set as a relative path, Prepare return a relative path, the containerd will fail to mount.