### PR TITLE
[backport] remove not frequently used CLI parameters

### DIFF
--- a/misc/snapshotter/entrypoint.sh
+++ b/misc/snapshotter/entrypoint.sh
@@ -17,10 +17,7 @@ if [ "$#" -eq 0 ]; then
 		--root ${NYDUS_LIB} \
 		--address ${NYDUS_RUN}/containerd-nydus-grpc.sock \
 		--log-level ${LEVEL} \
-		--enable-metrics=${ENABLE_METRICS} \
-		--enable-nydus-overlayfs=${ENABLE_NYDUS_OVERLAY} \
 		--daemon-mode ${NYDUSD_DAEMON_MODE} \
-		--enable-stargz \
 		--log-to-stdout
 fi
 


### PR DESCRIPTION
Fix the nydus snapshotter image not starting properly in v0.5.x because it would exit with wrong args in entrypoint.sh.

> $ sudo nerdctl run -d ghcr.io/containerd/nydus-snapshotter:v0.5.1
> 
> time="2023-03-16T03:29:02Z" level=fatal msg="failed to start nydus-snapshotter" error="flag provided but not defined: -enable-metrics"