### PR TITLE
[backport] misc: update stable nydusd version v2.1.5 in Dockerfile and docs

### DIFF
--- a/docs/optimize_nydus_image.md
+++ b/docs/optimize_nydus_image.md
@@ -106,7 +106,7 @@ Nydus provides a [nydusify](https://github.com/dragonflyoss/image-service/blob/m
 We can install the `nydusify` cli tool from the nydus package.
 
 ```console
-VERSION=v2.1.4
+VERSION=v2.1.5
 
 wget https://github.com/dragonflyoss/image-service/releases/download/$VERSION/nydus-static-$VERSION-linux-amd64.tgz
 tar -zxvf nydus-static-$VERSION-linux-amd64.tgz

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17.0 AS sourcer
 
-ARG NYDUS_VER=v2.1.2
+ARG NYDUS_VER=v2.1.5
 
 RUN apk add --no-cache curl
 RUN apk add --no-cache --upgrade grep


### PR DESCRIPTION
We should upgrade the version of nydus to v2.1.5 to fix known issues.