### PR TITLE
set default value for fsdriver

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -179,7 +179,7 @@ func TestMergeConfig(t *testing.T) {
 	A.Equal(snapshotterConfig1.LoggingConfig.LogDir, "")
 	A.Equal(snapshotterConfig1.CacheManagerConfig.CacheDir, "")
 
-	A.Equal(snapshotterConfig1.DaemonMode, DefaultDaemonMode)
+	A.Equal(snapshotterConfig1.DaemonMode, defaultDaemonMode)
 	A.Equal(snapshotterConfig1.SystemControllerConfig.Address, defaultSystemControllerAddress)
 	A.Equal(snapshotterConfig1.LoggingConfig.LogLevel, DefaultLogLevel)
 	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxSize, defaultRotateLogMaxSize)

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -53,7 +53,7 @@ func NewDaemonConfig(fsDriver, path string) (DaemonConfig, error) {
 		}
 		return cfg, nil
 	default:
-		return nil, errors.Errorf("unsupported, fs driver %s", fsDriver)
+		return nil, errors.Errorf("unsupported, fs driver %q", fsDriver)
 	}
 }
 

--- a/config/default.go
+++ b/config/default.go
@@ -11,7 +11,9 @@ import (
 )
 
 const (
-	DefaultDaemonMode string = string(DaemonModeMultiple)
+	defaultDaemonMode string = string(DaemonModeMultiple)
+
+	defaultFsDriver string = FsDriverFusedev
 
 	DefaultLogLevel string = "info"
 	defaultGCPeriod string = "24h"
@@ -36,7 +38,7 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 
 	// essential configuration
 	if c.DaemonMode == "" {
-		c.DaemonMode = DefaultDaemonMode
+		c.DaemonMode = defaultDaemonMode
 	}
 
 	// system controller configuration
@@ -59,6 +61,7 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 		daemonConfig.NydusdConfigPath = defaultNydusDaemonConfigPath
 	}
 	daemonConfig.RecoverPolicy = RecoverPolicyRestart.String()
+	daemonConfig.FsDriver = defaultFsDriver
 
 	// cache configuration
 	cacheConfig := &c.CacheManagerConfig


### PR DESCRIPTION
So we can start nydus-snapshotter witout its toml config file with minimal parameters