### PR TITLE
workflow: fix incorrect files number for optimizer test

### DIFF
--- a/.github/workflows/optimizer.yml
+++ b/.github/workflows/optimizer.yml
@@ -76,15 +76,16 @@ jobs:
           sudo systemctl restart containerd
       - name: Generate accessed files list
         run: |
-          sudo crictl run misc/optimizer/nginx.yaml misc/optimizer/sandbox.yaml
+          sudo crictl run misc/optimizer/ubuntu.yaml misc/optimizer/sandbox.yaml
           sleep 20
           sudo crictl rmp  -f --all
           tree /opt/nri/optimizer/results/
-          count=$(cat /opt/nri/optimizer/results/library/nginx:1.23.3 | wc -l)
+          cat /opt/nri/optimizer/results/library/ubuntu:22.04
+          count=$(cat /opt/nri/optimizer/results/library/ubuntu:22.04 | wc -l)
           echo $count
-          if [ "$count" != 44 ]; then
-            echo "failed to generate accessed files list for nginx:1.23.3"
+          if [ "$count" != 4 ]; then
+            echo "failed to generate accessed files list for ubuntu:22.04"
             exit 1
           fi
-          cat /opt/nri/optimizer/results/library/nginx:1.23.3.csv
+          cat /opt/nri/optimizer/results/library/ubuntu:22.04.csv
     

--- a/misc/optimizer/nginx.yaml
+++ b/misc/optimizer/nginx.yaml
@@ -1,8 +1,0 @@
-metadata:
-  name: nginx
-
-image:
-  image: nginx:1.23.3
-
-log_path: nginx.0.log
-linux: {}

--- a/misc/optimizer/sandbox.yaml
+++ b/misc/optimizer/sandbox.yaml
@@ -1,5 +1,5 @@
 metadata:
-  name: nginx-sandbox
+  name: ubuntu-sandbox
   namespace: default
   attempt: 1
   uid: hdishd83djaidwnduwk28bcsb

--- a/misc/optimizer/ubuntu.yaml
+++ b/misc/optimizer/ubuntu.yaml
@@ -1,0 +1,13 @@
+metadata:
+  name: ubuntu
+
+image:
+  image: ubuntu:22.04
+
+command:
+  - /bin/sh
+  - -c
+  - echo hello
+
+log_path: ubuntu.0.log
+linux: {}


### PR DESCRIPTION
We use `nginx:1.23.3` to test the optimizer, but sometimes the number of files accessed is not equal to 44. Normally, the optimizer works fine if the number of files accessed is greater than 0.