### PR TITLE
converter: return null feature set when failed to detect version

### DIFF
--- a/pkg/converter/tool/feature.go
+++ b/pkg/converter/tool/feature.go
@@ -86,7 +86,7 @@ func DetectFeatures(builder string, required Features) Features {
 	})
 
 	if currentVersion == "" {
-		return required
+		return Features{}
 	}
 
 	detectedFeatures := Features{}


### PR DESCRIPTION
Return null feature set for safety when failed to detect nydus-image version.