### PR TITLE
Avoid optimizer to use too much memory and improve error handling processes

### DIFF
--- a/.github/workflows/optimizer.yml
+++ b/.github/workflows/optimizer.yml
@@ -86,5 +86,5 @@ jobs:
             echo "failed to generate accessed files list for nginx:1.23.3"
             exit 1
           fi
-          cat /opt/nri/optimizer/results/library/nginx:1.23.3.json
+          cat /opt/nri/optimizer/results/library/nginx:1.23.3.csv
     

--- a/cmd/optimizer-nri-plugin/main.go
+++ b/cmd/optimizer-nri-plugin/main.go
@@ -40,6 +40,7 @@ type PluginConfig struct {
 
 	ServerPath string `toml:"server_path"`
 	PersistDir string `toml:"persist_dir"`
+	Readable   bool   `toml:"readable"`
 	Timeout    int    `toml:"timeout"`
 	Overwrite  bool   `toml:"overwrite"`
 }
@@ -85,6 +86,12 @@ func buildFlags(args *PluginArgs) []cli.Flag {
 			Value:       defaultPersistDir,
 			Usage:       "the directory to persist accessed files list for container",
 			Destination: &args.Config.PersistDir,
+		},
+		&cli.BoolFlag{
+			Name:        "readable",
+			Value:       false,
+			Usage:       "whether to make the csv file human readable",
+			Destination: &args.Config.Readable,
 		},
 		&cli.IntFlag{
 			Name:        "timeout",
@@ -165,7 +172,7 @@ func (p *plugin) StartContainer(_ *api.PodSandbox, container *api.Container) err
 		persistFile = fmt.Sprintf("%s.timeout%ds", persistFile, cfg.Timeout)
 	}
 
-	fanotifyServer := fanotify.NewServer(cfg.ServerPath, container.Pid, imageName, persistFile, cfg.Overwrite, time.Duration(cfg.Timeout)*time.Second, logWriter)
+	fanotifyServer := fanotify.NewServer(cfg.ServerPath, container.Pid, imageName, persistFile, cfg.Readable, cfg.Overwrite, time.Duration(cfg.Timeout)*time.Second, logWriter)
 
 	if err := fanotifyServer.RunServer(); err != nil {
 		return err

--- a/docs/optimize_nydus_image.md
+++ b/docs/optimize_nydus_image.md
@@ -30,6 +30,8 @@ This command installs the optimizer's default toml configuration file in `/etc/n
 ```toml
 # The directory to persist accessed files list for container.
 persist_dir = "/opt/nri/optimizer/results"
+# Whether to make the csv file human readable.
+readable = false
 # The path of optimizer server binary.
 server_path = "/usr/local/bin/optimizer-server"
 # The timeout to kill optimizer server, 0 to disable it.

--- a/misc/example/optimizer-nri-plugin.conf
+++ b/misc/example/optimizer-nri-plugin.conf
@@ -1,5 +1,7 @@
 # The directory to persist accessed files list for container.
 persist_dir = "/opt/nri/optimizer/results"
+# Whether to make the csv file human readable.
+readable = false
 # The path of optimizer server binary.
 server_path = "/usr/local/bin/optimizer-server"
 # The timeout to kill optimizer server, 0 to disable it.

--- a/pkg/fanotify/conn/conn.go
+++ b/pkg/fanotify/conn/conn.go
@@ -21,13 +21,16 @@ type EventInfo struct {
 	Elapsed uint64 `json:"elapsed"`
 }
 
-func (c *Client) GetEventInfo() ([]EventInfo, error) {
-	eventInfo := []EventInfo{}
+func (c *Client) GetEventInfo() (*EventInfo, error) {
+	eventInfo := EventInfo{}
 
-	err := json.NewDecoder(c.Reader).Decode(&eventInfo)
+	eventByte, err := c.Reader.ReadBytes('\n')
 	if err != nil {
 		return nil, err
 	}
+	if err := json.Unmarshal(eventByte, &eventInfo); err != nil {
+		return nil, err
+	}
 
-	return eventInfo, nil
+	return &eventInfo, nil
 }

--- a/pkg/fanotify/fanotify.go
+++ b/pkg/fanotify/fanotify.go
@@ -8,8 +8,9 @@ package fanotify
 
 import (
 	"bufio"
-	"encoding/json"
+	"encoding/csv"
 	"fmt"
+	"io"
 	"log/syslog"
 	"os"
 	"os/exec"
@@ -74,6 +75,12 @@ func (fserver *Server) RunServer() error {
 	}
 	fserver.Cmd = cmd
 
+	go func() {
+		if err := fserver.RunReceiver(); err != nil {
+			logrus.WithError(err).Errorf("Failed to receive event information from server")
+		}
+	}()
+
 	if fserver.Timeout > 0 {
 		go func() {
 			time.Sleep(fserver.Timeout)
@@ -84,29 +91,45 @@ func (fserver *Server) RunServer() error {
 	return nil
 }
 
-func (fserver *Server) ReceiveEventInfo() error {
-	eventInfo, err := fserver.Client.GetEventInfo()
-	if err != nil {
-		return fmt.Errorf("failed to get event information: %v", err)
-	}
-
+func (fserver *Server) RunReceiver() error {
 	f, err := os.OpenFile(fserver.PersistFile, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open persist file %q", fserver.PersistFile)
+		return errors.Wrapf(err, "failed to open file %q", fserver.PersistFile)
 	}
 	defer f.Close()
 
-	for _, event := range eventInfo {
-		fmt.Fprintln(f, event.Path)
-	}
-
-	persistJSONFile := fmt.Sprintf("%s.json", fserver.PersistFile)
-	data, err := json.MarshalIndent(eventInfo, "", "      ")
+	persistCsvFile := fmt.Sprintf("%s.csv", fserver.PersistFile)
+	fCsv, err := os.Create(persistCsvFile)
 	if err != nil {
-		return errors.Wrapf(err, "failed to encode event information %v", eventInfo)
+		return errors.Wrapf(err, "failed to create file %q", persistCsvFile)
 	}
-	if err := os.WriteFile(persistJSONFile, data, 0644); err != nil {
-		return errors.Wrapf(err, "failed to write file %s", persistJSONFile)
+	defer fCsv.Close()
+
+	csvWriter := csv.NewWriter(fCsv)
+	if err := csvWriter.Write([]string{"path", "size", "elapsed"}); err != nil {
+		return errors.Wrapf(err, "failed to write csv header")
+	}
+	csvWriter.Flush()
+
+	for {
+		eventInfo, err := fserver.Client.GetEventInfo()
+		if err != nil {
+			if err == io.EOF {
+				logrus.Infoln("Get EOF from fanotify server, break event receiver")
+				break
+			}
+			return fmt.Errorf("failed to get event information: %v", err)
+		}
+
+		if eventInfo != nil {
+			fmt.Fprintln(f, eventInfo.Path)
+
+			var line = []string{eventInfo.Path, fmt.Sprint(eventInfo.Size), fmt.Sprint(eventInfo.Elapsed)}
+			if err := csvWriter.Write(line); err != nil {
+				return errors.Wrapf(err, "failed to write csv")
+			}
+			csvWriter.Flush()
+		}
 	}
 
 	return nil
@@ -117,9 +140,6 @@ func (fserver *Server) StopServer() {
 		logrus.Infof("Send SIGTERM signal to process group %d", fserver.Cmd.Process.Pid)
 		if err := syscall.Kill(-fserver.Cmd.Process.Pid, syscall.SIGTERM); err != nil {
 			logrus.WithError(err).Errorf("Stop process group %d failed!", fserver.Cmd.Process.Pid)
-		}
-		if err := fserver.ReceiveEventInfo(); err != nil {
-			logrus.WithError(err).Errorf("Failed to receive event information")
 		}
 		if _, err := fserver.Cmd.Process.Wait(); err != nil {
 			logrus.WithError(err).Errorf("Failed to wait for fanotify server")

--- a/pkg/utils/display/display.go
+++ b/pkg/utils/display/display.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package display
+
+import "fmt"
+
+func ByteToReadableIEC(b uint32) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB",
+		float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func MicroSecondToReadable(b uint64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d us", b)
+	}
+
+	if b < unit*unit {
+		return fmt.Sprintf("%.3f ms", float64(b)/float64(unit))
+	}
+
+	return fmt.Sprintf("%.3f s", float64(b)/float64(unit*unit))
+}

--- a/tools/optimizer-server/src/main.rs
+++ b/tools/optimizer-server/src/main.rs
@@ -8,13 +8,9 @@ use std::{
     env, ffi, fs, io,
     io::Write,
     mem,
-    os::unix::io::AsRawFd,
+    os::unix::{io::AsRawFd, net::UnixStream},
     path::{Path, PathBuf},
     slice,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
 };
 
 use lazy_static::lazy_static;
@@ -28,6 +24,7 @@ use nix::{
     },
 };
 use serde::Serialize;
+use signal_hook::{consts::SIGTERM, low_level::pipe};
 use std::time::Instant;
 
 #[derive(Debug, Clone, Copy)]
@@ -164,31 +161,44 @@ fn generate_event_info(path: &Path) -> Result<EventInfo, io::Error> {
     })
 }
 
-fn send_event_info(event_info: &EventInfo) -> Result<(), SendError> {
+fn send_event(event: &EventInfo) -> Result<(), SendError> {
     let mut writer = io::stdout();
-    let event_string = serde_json::to_string(event_info).map_err(SendError::Serde)?;
+    let event_string = serde_json::to_string(event).map_err(SendError::Serde)?;
     writer
         .write_all(format!("{event_string}\n").as_bytes())
         .map_err(SendError::IO)?;
     writer.flush().map_err(SendError::IO)
 }
 
-fn handle_fanotify_event(fd: i32) {
-    let mut fds = [PollFd::new(fd.as_raw_fd(), PollFlags::POLLIN)];
-    let mut event_duplicate = Vec::new();
+fn handle_event(event: &FanotifyEvent, event_duplicate: &mut Vec<String>) -> Result<(), SendError> {
+    let path = get_fd_path(event.fd).map_err(SendError::IO)?;
+    let info = generate_event_info(&path).map_err(SendError::IO)?;
+    if !event_duplicate.contains(&info.path) {
+        send_event(&info)?;
+        event_duplicate.push(info.path);
+    }
+    Ok(())
+}
 
-    let term = Arc::new(AtomicBool::new(false));
-    if let Err(e) = signal_hook::flag::register(signal_hook::consts::SIGTERM, Arc::clone(&term)) {
+fn handle_fanotify_event(fd: i32) {
+    let mut event_duplicate = Vec::new();
+    let (reader, writer) = match UnixStream::pair() {
+        Ok((reader, writer)) => (reader, writer),
+        Err(e) => {
+            eprintln!("failed to create a pair of sockets: {e:?}");
+            return;
+        }
+    };
+    if let Err(e) = pipe::register(SIGTERM, writer) {
         eprintln!("failed to set SIGTERM signal handler {e:?}");
         return;
     }
+    let mut fds = [
+        PollFd::new(fd.as_raw_fd(), PollFlags::POLLIN),
+        PollFd::new(reader.as_raw_fd(), PollFlags::POLLIN),
+    ];
 
     loop {
-        if term.load(Ordering::Relaxed) {
-            eprintln!("received SIGTERM signal, break fanotify event handler");
-            break;
-        }
-
         match poll(&mut fds, -1) {
             Ok(polled_num) => {
                 if polled_num <= 0 {
@@ -200,25 +210,19 @@ fn handle_fanotify_event(fd: i32) {
                     if flag.contains(PollFlags::POLLIN) {
                         let events = read_fanotify(fd);
                         for event in events {
-                            if let Ok(path) = get_fd_path(event.fd) {
-                                if let Err(e) = generate_event_info(&path).map(|info| {
-                                    if !event_duplicate.contains(&info.path) {
-                                        if let Err(e) = send_event_info(&info) {
-                                            eprintln!(
-                                                "failed to send event information {info:?} {e:?}"
-                                            );
-                                        }
-                                        event_duplicate.push(info.path)
-                                    }
-                                }) {
-                                    eprintln!(
-                                        "failed to generate event information for {path:?} {e:?}"
-                                    )
-                                };
-                            }
+                            if let Err(e) = handle_event(&event, &mut event_duplicate) {
+                                eprintln!("failed to handle event {event:?} {e:?}")
+                            };
                             // No matter the target path is valid or not, we should close the fd
                             close_fd(event.fd);
                         }
+                    }
+                }
+
+                if let Some(flag) = fds[1].revents() {
+                    if flag.contains(PollFlags::POLLIN) {
+                        println!("received SIGTERM signal");
+                        break;
                     }
                 }
             }
@@ -233,11 +237,22 @@ fn handle_fanotify_event(fd: i32) {
     }
 }
 
+fn start_fanotify() -> Result<(), io::Error> {
+    let fd = init_fanotify()?;
+    mark_fanotify(fd, get_target().as_str())?;
+    handle_fanotify_event(fd);
+    Ok(())
+}
+
+fn join_namespace(pid: String) -> Result<(), SetnsError> {
+    set_ns(format!("/proc/{pid}/ns/pid"), CloneFlags::CLONE_NEWPID)?;
+    set_ns(format!("/proc/{pid}/ns/mnt"), CloneFlags::CLONE_NEWNS)?;
+    Ok(())
+}
+
 fn main() {
     if let Some(pid) = get_pid() {
-        if let Err(e) = set_ns(format!("/proc/{pid}/ns/pid"), CloneFlags::CLONE_NEWPID)
-            .map(|_| set_ns(format!("/proc/{pid}/ns/mnt"), CloneFlags::CLONE_NEWNS))
-        {
+        if let Err(e) = join_namespace(pid) {
             eprintln!("join namespace failed {e:?}");
             return;
         }
@@ -245,9 +260,7 @@ fn main() {
     let pid = unsafe { fork() };
     match pid.expect("fork failed: unable to create child process") {
         Child => {
-            if let Err(e) = init_fanotify().map(|fd| {
-                mark_fanotify(fd, get_target().as_str()).map(|_| handle_fanotify_event(fd))
-            }) {
+            if let Err(e) = start_fanotify() {
                 eprintln!("failed to start fanotify server {e:?}");
             }
         }


### PR DESCRIPTION
1. To avoid using too much memory in the `containerd` cgroup, we should send event information one by one.
2. Add an option to make the result human-readable.
3. Refine the code to better handle errors on the optimizer server.