### PR TITLE
Support using nydus-snapshotter as Builkdit's oci-woker-snapshotter to gain lazyload when building images

### DIFF
--- a/pkg/referrer/manager.go
+++ b/pkg/referrer/manager.go
@@ -57,7 +57,7 @@ func (manager *Manager) CheckReferrer(ctx context.Context, ref string, manifestD
 			return nil, errors.Wrap(err, "check referrer")
 		}
 
-		// FIXME: how invalidating the LRU cache if referrers update?
+		// FIXME: how to invalidate the LRU cache if referrers update?
 		manager.cache.Add(manifestDigest, *metaLayer)
 
 		return metaLayer, nil

--- a/pkg/referrer/referrer.go
+++ b/pkg/referrer/referrer.go
@@ -34,7 +34,7 @@ func newReferrer(keyChain *auth.PassKeyChain, insecure bool) *referrer {
 	}
 }
 
-// checkReferrer fetches the referrers and parse out the nydus
+// checkReferrer fetches the referrers and parses out the nydus
 // image by specified manifest digest.
 // it's using distribution list referrers API.
 func (r *referrer) checkReferrer(ctx context.Context, ref string, manifestDigest digest.Digest) (*ocispec.Descriptor, error) {

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -68,7 +68,7 @@ func IterateParentSnapshots(ctx context.Context, ms *storage.MetaStore, key stri
 
 	defer func() {
 		if err := t.Rollback(); err != nil {
-			log.L.WithError(err).Errorf("Rollback traction %s", key)
+			log.L.WithError(err).Errorf("Rollback transaction %s", key)
 		}
 	}()
 

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -92,13 +92,15 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 			handler = remoteHandler(id, info.Labels)
 		}
 
-		if id, info, err := sn.findReferrerLayer(ctx, key); err == nil {
-			logger.Infof("found referenced nydus manifest for image: %s", info.Labels[snpkg.TargetRefLabel])
-			metaPath := path.Join(sn.snapshotDir(id), "fs", "image.boot")
-			if err := sn.fs.TryFetchMetadata(ctx, info.Labels, metaPath); err != nil {
-				return nil, "", errors.Wrap(err, "try fetch metadata")
+		if sn.fs.ReferrerDetectEnabled() {
+			if id, info, err := sn.findReferrerLayer(ctx, key); err == nil {
+				logger.Infof("found referenced nydus manifest for image: %s", info.Labels[snpkg.TargetRefLabel])
+				metaPath := path.Join(sn.snapshotDir(id), "fs", "image.boot")
+				if err := sn.fs.TryFetchMetadata(ctx, info.Labels, metaPath); err != nil {
+					return nil, "", errors.Wrap(err, "try fetch metadata")
+				}
+				handler = remoteHandler(id, info.Labels)
 			}
-			handler = remoteHandler(id, info.Labels)
 		}
 
 		if sn.fs.StargzEnabled() {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -313,10 +313,11 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 		}
 	}
 
-	// TODO: Skip this ? Directly map OCI layer to nydus layer ?
-	if id, _, err := o.findReferrerLayer(ctx, key); err == nil {
-		needRemoteMounts = true
-		metaSnapshotID = id
+	if o.fs.ReferrerDetectEnabled() {
+		if id, _, err := o.findReferrerLayer(ctx, key); err == nil {
+			needRemoteMounts = true
+			metaSnapshotID = id
+		}
 	}
 
 	snap, err := snapshot.GetSnapshot(ctx, o.ms, key)


### PR DESCRIPTION
Currently, Buildkit only supports using stargz as the base image remote snapshotter to build container images with lazy-load capability.  This PR is the precondition of adding such capability to Buildkit for nydus-snapshotter, majorly including bugfixes and enhancements.