### PR TITLE
cmd: improve user interface for help message by add default text

### DIFF
--- a/cmd/containerd-nydus-grpc/main.go
+++ b/cmd/containerd-nydus-grpc/main.go
@@ -94,8 +94,8 @@ func main() {
 				return errors.Wrap(err, "failed to setup logger")
 			}
 
-			log.L.Infof("Start nydus-snapshotter. PID %d Version %s FsDriver %s DaemonMode %s",
-				os.Getpid(), version.Version, config.GetFsDriver(), snapshotterConfig.DaemonMode)
+			log.L.Infof("Start nydus-snapshotter. Version: %s, PID: %d, FsDriver: %s, DaemonMode: %s",
+				version.Version, os.Getpid(), config.GetFsDriver(), snapshotterConfig.DaemonMode)
 
 			return Start(ctx, &snapshotterConfig)
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 
+	"github.com/containerd/nydus-snapshotter/internal/constant"
 	"github.com/containerd/nydus-snapshotter/internal/flags"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/file"
@@ -31,14 +32,14 @@ type DaemonMode string
 
 const (
 	// One nydusd, one rafs instance
-	DaemonModeMultiple DaemonMode = "multiple"
+	DaemonModeMultiple DaemonMode = DaemonMode(constant.DaemonModeMultiple)
 	// One nydusd serves multiple rafs instances
-	DaemonModeShared DaemonMode = "shared"
+	DaemonModeShared DaemonMode = DaemonMode(constant.DaemonModeShared)
 	// No nydusd daemon is needed to be started. Snapshotter does not start any nydusd
 	// and only interacts with containerd with mount slice to pass necessary configuration
 	// to container runtime
-	DaemonModeNone    DaemonMode = "none"
-	DaemonModeInvalid DaemonMode = ""
+	DaemonModeNone    DaemonMode = DaemonMode(constant.DaemonModeNone)
+	DaemonModeInvalid DaemonMode = DaemonMode(constant.DaemonModeInvalid)
 )
 
 func parseDaemonMode(m string) (DaemonMode, error) {
@@ -90,8 +91,8 @@ func ParseRecoverPolicy(p string) (DaemonRecoverPolicy, error) {
 }
 
 const (
-	FsDriverFusedev string = "fusedev"
-	FsDriverFscache string = "fscache"
+	FsDriverFusedev string = constant.FsDriverFusedev
+	FsDriverFscache string = constant.FsDriverFscache
 )
 
 type Experimental struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/nydus-snapshotter/internal/constant"
 	"github.com/containerd/nydus-snapshotter/internal/flags"
 	"github.com/stretchr/testify/assert"
 )
@@ -178,21 +179,21 @@ func TestMergeConfig(t *testing.T) {
 
 	err = MergeConfig(&snapshotterConfig1, &defaultSnapshotterConfig)
 	A.NoError(err)
-	A.Equal(snapshotterConfig1.Root, defaultRootDir)
+	A.Equal(snapshotterConfig1.Root, constant.DefaultRootDir)
 	A.Equal(snapshotterConfig1.LoggingConfig.LogDir, "")
 	A.Equal(snapshotterConfig1.CacheManagerConfig.CacheDir, "")
 
-	A.Equal(snapshotterConfig1.DaemonMode, defaultDaemonMode)
-	A.Equal(snapshotterConfig1.SystemControllerConfig.Address, defaultSystemControllerAddress)
-	A.Equal(snapshotterConfig1.LoggingConfig.LogLevel, DefaultLogLevel)
-	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxSize, defaultRotateLogMaxSize)
-	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxBackups, defaultRotateLogMaxBackups)
-	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxAge, defaultRotateLogMaxAge)
-	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogCompress, defaultRotateLogCompress)
+	A.Equal(snapshotterConfig1.DaemonMode, constant.DefaultDaemonMode)
+	A.Equal(snapshotterConfig1.SystemControllerConfig.Address, constant.DefaultSystemControllerAddress)
+	A.Equal(snapshotterConfig1.LoggingConfig.LogLevel, constant.DefaultLogLevel)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxSize, constant.DefaultRotateLogMaxSize)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxBackups, constant.DefaultRotateLogMaxBackups)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogMaxAge, constant.DefaultRotateLogMaxAge)
+	A.Equal(snapshotterConfig1.LoggingConfig.RotateLogCompress, constant.DefaultRotateLogCompress)
 
-	A.Equal(snapshotterConfig1.DaemonConfig.NydusdConfigPath, defaultNydusDaemonConfigPath)
+	A.Equal(snapshotterConfig1.DaemonConfig.NydusdConfigPath, constant.DefaultNydusDaemonConfigPath)
 	A.Equal(snapshotterConfig1.DaemonConfig.RecoverPolicy, RecoverPolicyRestart.String())
-	A.Equal(snapshotterConfig1.CacheManagerConfig.GCPeriod, defaultGCPeriod)
+	A.Equal(snapshotterConfig1.CacheManagerConfig.GCPeriod, constant.DefaultGCPeriod)
 
 	var snapshotterConfig2 SnapshotterConfig
 	snapshotterConfig2.Root = "/snapshotter/root"

--- a/config/default.go
+++ b/config/default.go
@@ -8,68 +8,46 @@ package config
 
 import (
 	"os/exec"
-)
 
-const (
-	defaultDaemonMode string = string(DaemonModeMultiple)
-
-	defaultFsDriver string = FsDriverFusedev
-
-	DefaultLogLevel string = "info"
-	defaultGCPeriod string = "24h"
-
-	defaultNydusDaemonConfigPath string = "/etc/nydus/nydusd-config.json"
-	nydusdBinaryName             string = "nydusd"
-	nydusImageBinaryName         string = "nydus-image"
-
-	defaultRootDir                 = "/var/lib/containerd-nydus"
-	defaultAddress                 = "/run/containerd-nydus/containerd-nydus-grpc.sock"
-	defaultSystemControllerAddress = "/run/containerd-nydus/system.sock"
-
-	// Log rotation
-	defaultRotateLogMaxSize    = 200 // 200 megabytes
-	defaultRotateLogMaxBackups = 10
-	defaultRotateLogMaxAge     = 0 // days
-	defaultRotateLogLocalTime  = true
-	defaultRotateLogCompress   = true
+	"github.com/containerd/nydus-snapshotter/internal/constant"
 )
 
 func (c *SnapshotterConfig) FillUpWithDefaults() error {
 	c.Version = 1
-	c.Root = defaultRootDir
-	c.Address = defaultAddress
+	c.Root = constant.DefaultRootDir
+	c.Address = constant.DefaultAddress
 
 	// essential configuration
 	if c.DaemonMode == "" {
-		c.DaemonMode = defaultDaemonMode
+		c.DaemonMode = constant.DefaultDaemonMode
 	}
 
 	// system controller configuration
-	c.SystemControllerConfig.Address = defaultSystemControllerAddress
+	c.SystemControllerConfig.Address = constant.DefaultSystemControllerAddress
 
 	// logging configuration
 	logConfig := &c.LoggingConfig
 	if logConfig.LogLevel == "" {
-		logConfig.LogLevel = DefaultLogLevel
+		logConfig.LogLevel = constant.DefaultLogLevel
 	}
-	logConfig.RotateLogMaxSize = defaultRotateLogMaxSize
-	logConfig.RotateLogMaxBackups = defaultRotateLogMaxBackups
-	logConfig.RotateLogMaxAge = defaultRotateLogMaxAge
-	logConfig.RotateLogLocalTime = defaultRotateLogLocalTime
-	logConfig.RotateLogCompress = defaultRotateLogCompress
+	logConfig.RotateLogMaxSize = constant.DefaultRotateLogMaxSize
+	logConfig.RotateLogMaxBackups = constant.DefaultRotateLogMaxBackups
+	logConfig.RotateLogMaxAge = constant.DefaultRotateLogMaxAge
+	logConfig.RotateLogLocalTime = constant.DefaultRotateLogLocalTime
+	logConfig.RotateLogCompress = constant.DefaultRotateLogCompress
 
 	// daemon configuration
 	daemonConfig := &c.DaemonConfig
 	if daemonConfig.NydusdConfigPath == "" {
-		daemonConfig.NydusdConfigPath = defaultNydusDaemonConfigPath
+		daemonConfig.NydusdConfigPath = constant.DefaultNydusDaemonConfigPath
 	}
 	daemonConfig.RecoverPolicy = RecoverPolicyRestart.String()
-	daemonConfig.FsDriver = defaultFsDriver
+	daemonConfig.FsDriver = constant.DefaultFsDriver
 
 	// cache configuration
 	cacheConfig := &c.CacheManagerConfig
 	if cacheConfig.GCPeriod == "" {
-		cacheConfig.GCPeriod = defaultGCPeriod
+		cacheConfig.GCPeriod = constant.DefaultGCPeriod
 	}
 
 	return c.SetupNydusBinaryPaths()
@@ -82,12 +60,12 @@ func (c *SnapshotterConfig) SetupNydusBinaryPaths() error {
 	}
 
 	// resolve nydusd path
-	if path, err := exec.LookPath(nydusdBinaryName); err == nil {
+	if path, err := exec.LookPath(constant.NydusdBinaryName); err == nil {
 		c.DaemonConfig.NydusdPath = path
 	}
 
 	// resolve nydus-image path
-	if path, err := exec.LookPath(nydusImageBinaryName); err == nil {
+	if path, err := exec.LookPath(constant.NydusImageBinaryName); err == nil {
 		c.DaemonConfig.NydusImagePath = path
 	}
 

--- a/internal/constant/values.go
+++ b/internal/constant/values.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// constants of nydus snapshotter CLI config
+
+package constant
+
+const (
+	DaemonModeMultiple string = "multiple"
+	DaemonModeShared   string = "shared"
+	DaemonModeNone     string = "none"
+	DaemonModeInvalid  string = ""
+)
+
+const (
+	FsDriverFusedev string = "fusedev"
+	FsDriverFscache string = "fscache"
+)
+
+const (
+	DefaultDaemonMode string = DaemonModeMultiple
+
+	DefaultFsDriver string = FsDriverFusedev
+
+	DefaultLogLevel string = "info"
+	DefaultGCPeriod string = "24h"
+
+	DefaultNydusDaemonConfigPath string = "/etc/nydus/nydusd-config.json"
+	NydusdBinaryName             string = "nydusd"
+	NydusImageBinaryName         string = "nydus-image"
+
+	DefaultRootDir                 = "/var/lib/containerd-nydus"
+	DefaultAddress                 = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+	DefaultSystemControllerAddress = "/run/containerd-nydus/system.sock"
+
+	// Log rotation
+	DefaultRotateLogMaxSize    = 200 // 200 megabytes
+	DefaultRotateLogMaxBackups = 10
+	DefaultRotateLogMaxAge     = 0 // days
+	DefaultRotateLogLocalTime  = true
+	DefaultRotateLogCompress   = true
+)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -8,6 +8,7 @@
 package flags
 
 import (
+	"github.com/containerd/nydus-snapshotter/internal/constant"
 	"github.com/urfave/cli/v2"
 )
 
@@ -37,51 +38,57 @@ func buildFlags(args *Args) []cli.Flag {
 			Name:        "root",
 			Usage:       "directory to store snapshotter data and working states",
 			Destination: &args.RootDir,
+			DefaultText: constant.DefaultRootDir,
 		},
 		&cli.StringFlag{
 			Name:        "address",
 			Usage:       "remote snapshotter gRPC socket path",
 			Destination: &args.Address,
+			DefaultText: constant.DefaultAddress,
 		},
 		&cli.StringFlag{
 			Name:        "config",
-			Usage:       "path to nydus-snapshotter configuration file",
+			Usage:       "path to nydus-snapshotter configuration (such as: config.toml)",
 			Destination: &args.SnapshotterConfigPath,
 		},
 		&cli.StringFlag{
 			Name:        "nydus-image",
-			Usage:       "path to `nydus-image` binary, default to search in $PATH",
+			Usage:       "path to `nydus-image` binary, default to search in $PATH (such as: /usr/local/bin/nydus-image)",
 			Destination: &args.NydusImagePath,
 		},
 		&cli.StringFlag{
 			Name:        "nydusd",
-			Usage:       "path to `nydusd` binary, default to search in $PATH",
+			Usage:       "path to `nydusd` binary, default to search in $PATH (such as: /usr/local/bin/nydusd)",
 			Destination: &args.NydusdPath,
 		},
 		&cli.StringFlag{
 			Name:        "nydusd-config",
 			Aliases:     []string{"config-path"},
-			Usage:       "path to nydusd configuration file",
+			Usage:       "path to nydusd configuration (such as: nydusd-config.json or nydusd-config-v2.toml)",
 			Destination: &args.NydusdConfigPath,
+			DefaultText: constant.DefaultNydusDaemonConfigPath,
 		},
 		&cli.StringFlag{
 			Name:        "daemon-mode",
 			Usage:       "nydusd daemon working mode, possible values: \"multiple\", \"shared\" or \"none\"",
 			Destination: &args.DaemonMode,
+			DefaultText: constant.DaemonModeMultiple,
 		},
 		&cli.StringFlag{
 			Name:        "fs-driver",
 			Usage:       "driver to mount RAFS filesystem, possible values: \"fusedev\", \"fscache\"",
 			Destination: &args.FsDriver,
+			DefaultText: constant.FsDriverFusedev,
 		},
 		&cli.StringFlag{
 			Name:        "log-level",
 			Usage:       "logging level, possible values: \"trace\", \"debug\", \"info\", \"warn\", \"error\"",
 			Destination: &args.LogLevel,
+			DefaultText: constant.DefaultLogLevel,
 		},
 		&cli.BoolFlag{
 			Name:        "log-to-stdout",
-			Usage:       "print log messages to STDOUT",
+			Usage:       "print log messages to standard output",
 			Destination: &args.LogToStdout,
 			Count:       &args.LogToStdoutCount,
 		},

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -12,7 +12,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/internal/constant"
 	"github.com/pkg/errors"
 )
 
@@ -53,7 +53,7 @@ func WithLogToStdout(logToStdout bool) NewDaemonOpt {
 func WithLogLevel(logLevel string) NewDaemonOpt {
 	return func(d *Daemon) error {
 		if logLevel == "" {
-			d.States.LogLevel = config.DefaultLogLevel
+			d.States.LogLevel = constant.DefaultLogLevel
 		} else {
 			d.States.LogLevel = logLevel
 		}


### PR DESCRIPTION
- pkg: introduce internal/constant package 
- cmd: improve user interface for help message by add default text

Current help message:
``` 
NAME:
   containerd-nydus-grpc - Nydus remote snapshotter for containerd

USAGE:
   containerd-nydus-grpc [global options] command [command options] [arguments...]

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --root value                                directory to store snapshotter data and working states (default: /var/lib/containerd-nydus)
   --address value                             remote snapshotter gRPC socket path (default: /run/containerd-nydus/containerd-nydus-grpc.sock)
   --config value                              path to nydus-snapshotter configuration (such as: config.toml)
   --nydus-image nydus-image                   path to nydus-image binary, default to search in $PATH (such as: /usr/local/bin/nydus-image)
   --nydusd nydusd                             path to nydusd binary, default to search in $PATH (such as: /usr/local/bin/nydusd)
   --nydusd-config value, --config-path value  path to nydusd configuration (such as: nydusd-config.json or nydusd-config-v2.toml) (default: /etc/nydus/nydusd-config.json)
   --daemon-mode value                         nydusd daemon working mode, possible values: "multiple", "shared" or "none" (default: multiple)
   --fs-driver value                           driver to mount RAFS filesystem, possible values: "fusedev", "fscache" (default: fusedev)
   --log-level value                           logging level, possible values: "trace", "debug", "info", "warn", "error" (default: info)
   --log-to-stdout                             print log messages to standard output (default: false)
   --version                                   print version and build information (default: false)
   --help, -h                                  show help
```