### PR TITLE
action: update workflow to block low unit test coverage code

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto  # auto compares coverage to the previous base commit
+        # adjust accordingly based on how flaky your tests are
+        # this allows a 0.5% drop from the previous base commit coverage
+        threshold: 0.5%
+    patch:
+      default:
+        target: 75%   # the required coverage value in each patch
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false # if true: only post the comment if coverage changes
+
+codecov:
+  require_ci_to_pass: false
+  notify:
+    wait_for_ci: false
+
+# When modifying this file, please validate using
+
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate


### PR DESCRIPTION
In order to improve the code quality of this project, we have introduced a test coverage check in CI to prevent code with low unit test coverage from being merged. Although there is no perfect code coverage value, we can still make a stab at such a value. 3 years ago, Google posted a [blog post](https://testing.googleblog.com/2020/08/code-coverage-best-practices.html) on their best practices:

> We offer the general guidelines of 60% as “acceptable”, 75% as “commendable” and 90% as “exemplary.”

Therefore, in order to increase the overall code coverage of this project to 60% mentioned in #334, we set the coverage of each patch to 75% and above.

Patch details:
1. The project's unit test coverage cannot be reduced by more than 0.5%.
2. The unit test coverage of each patch must be higher than 75%.

Reference: https://about.codecov.io/blog/the-case-against-100-code-coverage/