### PR TITLE
cache: simplify cache manager by removing FsDriver

### DIFF
--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -27,18 +27,17 @@ const (
 	dataFileSuffix = ".blob.data"
 )
 
+// Disk cache manager for fusedev.
 type Manager struct {
 	cacheDir string
 	period   time.Duration
 	eventCh  chan struct{}
-	fsDriver string
 }
 
 type Opt struct {
 	CacheDir string
 	Period   time.Duration
 	Database *store.Database
-	FsDriver string
 }
 
 func NewManager(opt Opt) (*Manager, error) {
@@ -52,7 +51,6 @@ func NewManager(opt Opt) (*Manager, error) {
 		cacheDir: opt.CacheDir,
 		period:   opt.Period,
 		eventCh:  eventCh,
-		fsDriver: opt.FsDriver,
 	}
 
 	return m, nil

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -135,7 +135,6 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 			Database: db,
 			Period:   config.GetCacheGCPeriod(),
 			CacheDir: cacheConfig.CacheDir,
-			FsDriver: config.GetFsDriver(),
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "create cache manager")


### PR DESCRIPTION
The FsDriver field is never used, so remove it.