### PR TITLE
Prepare to support multiple running modes and tarfs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,8 +97,10 @@ func ParseRecoverPolicy(p string) (DaemonRecoverPolicy, error) {
 }
 
 const (
-	FsDriverFusedev string = constant.FsDriverFusedev
-	FsDriverFscache string = constant.FsDriverFscache
+	FsDriverBlockdev string = constant.FsDriverBlockdev
+	FsDriverFusedev  string = constant.FsDriverFusedev
+	FsDriverFscache  string = constant.FsDriverFscache
+	FsDriverNodev    string = constant.FsDriverNodev
 )
 
 type Experimental struct {

--- a/config/default.go
+++ b/config/default.go
@@ -54,11 +54,6 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 }
 
 func (c *SnapshotterConfig) SetupNydusBinaryPaths() error {
-	// when using DaemonMode = none, nydusd and nydus-image binaries are not required
-	if c.DaemonMode == string(DaemonModeNone) {
-		return nil
-	}
-
 	// resolve nydusd path
 	if path, err := exec.LookPath(constant.NydusdBinaryName); err == nil {
 		c.DaemonConfig.NydusdPath = path

--- a/config/global.go
+++ b/config/global.go
@@ -39,6 +39,10 @@ type GlobalConfig struct {
 	MirrorsConfig    MirrorsConfig
 }
 
+func IsFusedevSharedModeEnabled() bool {
+	return globalConfig.DaemonMode == DaemonModeShared
+}
+
 func GetDaemonMode() DaemonMode {
 	return globalConfig.DaemonMode
 }

--- a/internal/constant/values.go
+++ b/internal/constant/values.go
@@ -17,8 +17,14 @@ const (
 )
 
 const (
+	// Mount RAFS filesystem by using EROFS over block devices.
+	FsDriverBlockdev string = "blockdev"
+	// Mount RAFS filesystem by using FUSE subsystem
 	FsDriverFusedev string = "fusedev"
+	// Mount RAFS filesystem by using fscache/EROFS.
 	FsDriverFscache string = "fscache"
+	// Only prepare/supply meta/data blobs, do not mount RAFS filesystem.
+	FsDriverNodev string = "nodev"
 )
 
 const (

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -39,6 +39,9 @@ func WithRef(ref int32) NewDaemonOpt {
 
 func WithLogDir(dir string) NewDaemonOpt {
 	return func(d *Daemon) error {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return errors.Wrapf(err, "create logging dir %s", dir)
+		}
 		d.States.LogDir = filepath.Join(dir, d.ID())
 		return nil
 	}

--- a/pkg/daemon/rafs.go
+++ b/pkg/daemon/rafs.go
@@ -114,9 +114,10 @@ type Rafs struct {
 	Annotations map[string]string
 }
 
-func NewRafs(snapshotID, imageID string) (*Rafs, error) {
+func NewRafs(snapshotID, imageID, fsDriver string) (*Rafs, error) {
 	snapshotDir := path.Join(config.GetSnapshotsRootDir(), snapshotID)
 	rafs := &Rafs{
+		FsDriver:    fsDriver,
 		ImageID:     imageID,
 		SnapshotID:  snapshotID,
 		SnapshotDir: snapshotDir,
@@ -143,9 +144,9 @@ func (r *Rafs) GetSnapshotDir() string {
 func (r *Rafs) GetFsDriver() string {
 	if r.FsDriver != "" {
 		return r.FsDriver
-	} else {
-		return config.GetFsDriver()
 	}
+
+	return config.GetFsDriver()
 }
 
 // Blob caches' chunk bitmap and meta headers are stored here.

--- a/pkg/daemon/rafs.go
+++ b/pkg/daemon/rafs.go
@@ -104,6 +104,7 @@ type Rafs struct {
 	// Usually is the image reference
 	ImageID  string
 	DaemonID string
+	FsDriver string
 	// Given by containerd
 	SnapshotID  string
 	SnapshotDir string
@@ -137,6 +138,14 @@ func (r *Rafs) AddAnnotation(k, v string) {
 
 func (r *Rafs) GetSnapshotDir() string {
 	return r.SnapshotDir
+}
+
+func (r *Rafs) GetFsDriver() string {
+	if r.FsDriver != "" {
+		return r.FsDriver
+	} else {
+		return config.GetFsDriver()
+	}
 }
 
 // Blob caches' chunk bitmap and meta headers are stored here.

--- a/pkg/filesystem/config.go
+++ b/pkg/filesystem/config.go
@@ -8,6 +8,7 @@
 package filesystem
 
 import (
+	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
@@ -31,7 +32,14 @@ func WithManager(pm *manager.Manager) NewFSOpt {
 			return errors.New("process manager cannot be nil")
 		}
 
-		fs.Manager = pm
+		if pm.FsDriver == config.FsDriverFusedev {
+			fs.fusedevManager = pm
+		} else if pm.FsDriver == config.FsDriverFscache {
+			fs.fscacheManager = pm
+		}
+
+		fs.enabledManagers = append(fs.enabledManagers, pm)
+
 		return nil
 	}
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -458,24 +458,17 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 // 1. Don't erase ever written record
 // 2. Just recover nydusd daemon states to manager's memory part.
 // 3. Manager in SharedDaemon mode should starts a nydusd when recovering
-func (m *Manager) Recover(ctx context.Context) (map[string]*daemon.Daemon, map[string]*daemon.Daemon, error) {
-	// Collected deserialized daemons that need to be recovered.
-	recoveringDaemons := make(map[string]*daemon.Daemon, 0)
-	liveDaemons := make(map[string]*daemon.Daemon, 0)
-
+func (m *Manager) Recover(ctx context.Context,
+	recoveringDaemons *map[string]*daemon.Daemon, liveDaemons *map[string]*daemon.Daemon) error {
 	if err := m.store.WalkDaemons(ctx, func(s *daemon.States) error {
-		log.L.Debugf("found daemon states %#v", s)
+		if s.FsDriver != m.FsDriver {
+			return nil
+		}
 
+		log.L.Debugf("found daemon states %#v", s)
 		opt := make([]daemon.NewDaemonOpt, 0)
 		var d, _ = daemon.NewDaemon(opt...)
 		d.States = *s
-
-		// It can't change snapshotter's fs driver to a different one from a daemon that ever created in the past.
-		if d.States.FsDriver != m.FsDriver {
-			return errors.Wrapf(errdefs.ErrInvalidArgument,
-				"can't recover from the last restart, the specified fs-driver=%s mismatches with the last fs-driver=%s",
-				m.FsDriver, d.States.FsDriver)
-		}
 
 		m.daemonStates.RecoverDaemonState(d)
 
@@ -500,7 +493,7 @@ func (m *Manager) Recover(ctx context.Context) (map[string]*daemon.Daemon, map[s
 		state, err := d.GetState()
 		if err != nil {
 			log.L.Warnf("Daemon %s died somehow. Clean up its vestige!, %s", d.ID(), err)
-			recoveringDaemons[d.ID()] = d
+			(*recoveringDaemons)[d.ID()] = d
 			//nolint:nilerr
 			return nil
 		}
@@ -512,7 +505,7 @@ func (m *Manager) Recover(ctx context.Context) (map[string]*daemon.Daemon, map[s
 
 		// FIXME: Should put the a daemon back file system shared damon field.
 		log.L.Infof("found RUNNING daemon %s during reconnecting", d.ID())
-		liveDaemons[d.ID()] = d
+		(*liveDaemons)[d.ID()] = d
 
 		d.Lock()
 		collector.NewDaemonInfoCollector(&d.Version, 1).Collect()
@@ -535,32 +528,31 @@ func (m *Manager) Recover(ctx context.Context) (map[string]*daemon.Daemon, map[s
 
 		return nil
 	}); err != nil {
-		return nil, nil, errors.Wrapf(err, "walk daemons to reconnect")
+		return errors.Wrapf(err, "walk daemons to reconnect")
 	}
 
 	if err := m.store.WalkInstances(ctx, func(r *daemon.Rafs) error {
-		log.L.Debugf("found instance %#v", r)
-
-		d := recoveringDaemons[r.DaemonID]
-		if d != nil {
-			d.AddInstance(r)
+		if r.GetFsDriver() == m.FsDriver {
+			log.L.Debugf("found instance %#v", r)
+			if r.GetFsDriver() == config.FsDriverFscache || r.GetFsDriver() == config.FsDriverFusedev {
+				d := (*recoveringDaemons)[r.DaemonID]
+				if d != nil {
+					d.AddInstance(r)
+				}
+				d = (*liveDaemons)[r.DaemonID]
+				if d != nil {
+					d.AddInstance(r)
+				}
+				daemon.RafsSet.Add(r)
+			} else if r.GetFsDriver() == config.FsDriverBlockdev {
+				daemon.RafsSet.Add(r)
+				// TODO: check and remount tarfs
+			}
 		}
-
-		d = liveDaemons[r.DaemonID]
-		if d != nil {
-			d.AddInstance(r)
-		}
-
-		daemon.RafsSet.Add(r)
-
 		return nil
 	}); err != nil {
-		return nil, nil, errors.Wrapf(err, "walk instances to reconnect")
+		return errors.Wrapf(err, "walk instances to reconnect")
 	}
 
-	for _, d := range recoveringDaemons {
-		d.ClearVestige()
-	}
-
-	return recoveringDaemons, liveDaemons, nil
+	return nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -51,7 +51,7 @@ func (s *DaemonStates) Add(daemon *daemon.Daemon) *daemon.Daemon {
 	return old
 }
 
-func (s *DaemonStates) removeUnlocked(d *daemon.Daemon) *daemon.Daemon {
+func (s *DaemonStates) removeLocked(d *daemon.Daemon) *daemon.Daemon {
 	old := s.idxByDaemonID[d.ID()]
 	delete(s.idxByDaemonID, d.ID())
 	return old
@@ -59,14 +59,14 @@ func (s *DaemonStates) removeUnlocked(d *daemon.Daemon) *daemon.Daemon {
 
 func (s *DaemonStates) Remove(d *daemon.Daemon) *daemon.Daemon {
 	s.mu.Lock()
-	old := s.removeUnlocked(d)
+	old := s.removeLocked(d)
 	s.mu.Unlock()
 
 	return old
 }
 
 func (s *DaemonStates) RemoveByDaemonID(id string) *daemon.Daemon {
-	return s.GetByDaemonID(id, func(d *daemon.Daemon) { s.removeUnlocked(d) })
+	return s.GetByDaemonID(id, func(d *daemon.Daemon) { s.removeLocked(d) })
 }
 
 // Also recover daemon runtime state here

--- a/pkg/manager/monitor.go
+++ b/pkg/manager/monitor.go
@@ -82,7 +82,7 @@ func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deat
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if s, ok := m.subscribers[id]; ok && s.id == path {
+	if s, ok := m.subscribers[id]; ok && s.path == path {
 		log.L.Warnf("Daemon %s is already subscribed!", id)
 		return errdefs.ErrAlreadyExists
 	}

--- a/pkg/manager/monitor_test.go
+++ b/pkg/manager/monitor_test.go
@@ -70,6 +70,8 @@ func TestLivenessMonitor(t *testing.T) {
 
 	e1 := monitor.Subscribe("daemon_1", s1.Name(), notifier)
 	assert.Nil(t, e1)
+	e1 = monitor.Subscribe("daemon_1", s1.Name(), notifier)
+	assert.NotNil(t, e1)
 	e2 := monitor.Subscribe("daemon_2", s2.Name(), notifier)
 	assert.Nil(t, e2)
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -750,7 +750,10 @@ func (o *snapshotter) remoteMountWithExtraOptions(ctx context.Context, s storage
 	}
 
 	instance := daemon.RafsSet.Get(id)
-	daemon := o.fs.Manager.GetByDaemonID(instance.DaemonID)
+	daemon, err := o.fs.GetDaemonByID(instance.DaemonID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get daemon with ID %s", instance.DaemonID)
+	}
 
 	var c daemonconfig.DaemonConfig
 	if daemon.IsSharedDaemon() {


### PR DESCRIPTION
Enhance the snapshotter to prepare for
- running nydusd daemon on multiple modes concurrently: fusedev shared, fusedev dedicated, fscache
- support tarfs