### PR TITLE
converter: do not append batch size if non is provided

### DIFF
--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -133,7 +133,7 @@ func buildPackArgs(option PackOption) []string {
 	if option.ChunkSize != "" {
 		args = append(args, "--chunk-size", option.ChunkSize)
 	}
-	if option.BatchSize != "" {
+	if option.BatchSize != "" && option.BatchSize != "0" {
 		args = append(args, "--batch-size", option.BatchSize)
 	}
 	args = append(args, option.SourcePath)


### PR DESCRIPTION
It actually creates an incompatibility between nydusify and nydus-image. Let's keep the default (0) working at least.