### PR TITLE
converter: ignore nonexistent blob data for unpack

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -140,6 +140,11 @@ func unpackNydusBlob(bootDst, blobDst string, ra content.ReaderAt, unpackBlob bo
 		defer blob.Close()
 
 		if _, err = UnpackEntry(ra, EntryBlob, blob); err != nil {
+			if errors.Is(err, ErrNotFound) {
+				// The nydus layer may contain only bootstrap and no blob
+				// data, which should be ignored.
+				return nil
+			}
 			return errors.Wrap(err, "unpack blob from nydus")
 		}
 	}


### PR DESCRIPTION
When we convert nydus with empty blob data to gzip
(or other compression types) layer, will encounter the error:

```
unpack nydus blob: unpack nydus tar: unpack blob from nydus:
can't find target image.blob by seeking tar: data not found
```

The nydus layer may contain only bootstrap and no blob
data, which should be ignored.