### PR TITLE
action: remove patch coverage check in workflow

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,11 +5,8 @@ coverage:
         enabled: yes
         target: auto  # auto compares coverage to the previous base commit
         # adjust accordingly based on how flaky your tests are
-        # this allows a 0.5% drop from the previous base commit coverage
-        threshold: 0.5%
-    patch:
-      default:
-        target: 75%   # the required coverage value in each patch
+        # this allows a 0.3% drop from the previous base commit coverage
+        threshold: 0.3%
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
In the recent PR #482, the patch coverage requirement seems to be too strict. So we temporarily remove this check and focus on project coverage.