### PR TITLE
Minor improvements for image optimizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,12 @@ debug:
 .PHONY: build-optimizer
 build-optimizer:
 	GOOS=${GOOS} GOARCH=${GOARCH} ${PROXY} go build -ldflags "$(LDFLAGS)" -v -o bin/optimizer-nri-plugin ./cmd/optimizer-nri-plugin
-	${CARGO} fmt --manifest-path ${OPTIMIZER_SERVER_TOML} -- --check
-	${CARGO} build --release --manifest-path ${OPTIMIZER_SERVER_TOML} && cp ${OPTIMIZER_SERVER_BIN} ./bin
-	${CARGO} clippy --manifest-path ${OPTIMIZER_SERVER_TOML} --bins -- -Dwarnings
+	make -C tools/optimizer-server release && cp ${OPTIMIZER_SERVER_BIN} ./bin
 
 static-release:
 	CGO_ENABLED=0 ${PROXY} GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags "$(LDFLAGS) -extldflags -static" -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
 	CGO_ENABLED=0 ${PROXY} GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags "$(LDFLAGS) -extldflags -static" -v -o bin/optimizer-nri-plugin ./cmd/optimizer-nri-plugin
-	RUSTFLAGS="-C target-feature=+crt-static" ${CARGO} build --release --manifest-path ${OPTIMIZER_SERVER_TOML} --target x86_64-unknown-linux-gnu && cp ${STATIC_OPTIMIZER_SERVER_BIN} ./bin
+	make -C tools/optimizer-server static-release && cp ${STATIC_OPTIMIZER_SERVER_BIN} ./bin
 
 # Majorly for cross build for converter package since it is imported by other projects
 converter:
@@ -81,9 +79,8 @@ clean:
 
 .PHONY: clean-optimizer
 clean-optimizer:
-	rm -rf bin/optimizer-nri-plugin
-	rm -rf bin/optimizer-server
-	${CARGO} clean --manifest-path ${OPTIMIZER_SERVER_TOML}
+	rm -rf bin/optimizer-nri-plugin bin/optimizer-server
+	make -C tools/optimizer-server clean
 
 .PHONY: install
 install:

--- a/tools/optimizer-server/Makefile
+++ b/tools/optimizer-server/Makefile
@@ -1,0 +1,22 @@
+all: build
+
+.PHONY: .release_version .format build release
+
+.release_version:
+	$(eval CARGO_BUILD_FLAGS += --release)
+
+.format:
+	cargo fmt -- --check
+
+build: .format
+	cargo build $(CARGO_BUILD_FLAGS)
+	cargo clippy $(CARGO_BUILD_FLAGS) -- -Dwarnings
+
+release: .format .release_version build
+
+static-release: .format 
+	cargo clippy $(CARGO_BUILD_FLAGS) -- -Dwarnings
+	RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu
+
+clean:
+	cargo clean

--- a/tools/optimizer-server/src/main.rs
+++ b/tools/optimizer-server/src/main.rs
@@ -11,10 +11,9 @@ use std::{
     os::unix::{io::AsRawFd, net::UnixStream},
     path::{Path, PathBuf},
     slice,
+    time::Instant,
 };
 
-use lazy_static::lazy_static;
-use libc::{__s32, __u16, __u32, __u64, __u8};
 use nix::{
     poll::{poll, PollFd, PollFlags},
     sched::{setns, CloneFlags},
@@ -24,19 +23,20 @@ use nix::{
     },
 };
 use serde::Serialize;
+
+use lazy_static::lazy_static;
 use signal_hook::{consts::SIGTERM, low_level::pipe};
-use std::time::Instant;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 struct FanotifyEvent {
-    event_len: __u32,
-    vers: __u8,
-    reserved: __u8,
-    metadata_len: __u16,
-    mask: __u64,
-    fd: __s32,
-    pid: __s32,
+    event_len: u32,
+    vers: u8,
+    reserved: u8,
+    metadata_len: u16,
+    mask: u64,
+    fd: i32,
+    pid: i32,
 }
 
 #[derive(Serialize, Debug)]


### PR DESCRIPTION
1. Add its own makefile and invokes the makefile from the project root makefile
2. No need to use libc integer types, the standard integer types meet our reuqiurements