### PR TITLE
add Bin Tang as a reviewer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,3 +12,5 @@ imeoer, Yan Song, yansong.ys@antgroup.com
 #
 # REVIEWERS
 # GitHub ID, Name, Email address
+sctb512, Bin Tang, tangbin.bin@bytedance.com
+


### PR DESCRIPTION
Bin Tang @sctb512 has worked as a nydus-snapshotter developer for almost one year. He has contributed valuable features to the project and mastered the core design philosophy and essential working process. Those features include:
1. logger builder
2. metrics collector
3. mirror registry support
4. maintenance infrastructure
5. nydus image optimizer and related containerd NRI plugin
6. nydusd daemon resources manager
7. other misc test works

The features help a lot for the project to grow. Thanks for his remarkable work

I'd like to invite him as a nydus-snapshotter reviewer if he would approve :)

Needs explicit LGTM from @sctb512 and 1/3 of the nydus-snapshotter committers:

- [x] @changweige 
- [x] @imeoer 
- [ ] @eryugey 
- [ ] @sctb512 