### PR TITLE
Prefetchfiles snapshotter

### DIFF
--- a/cmd/prefetchfiles-nri-plugin/main.go
+++ b/cmd/prefetchfiles-nri-plugin/main.go
@@ -1,0 +1,216 @@
+/*
+* Copyright (c) 2023. Nydus Developers. All rights reserved.
+*
+* SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"log/syslog"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/nri/pkg/api"
+	"github.com/containerd/nri/pkg/stub"
+	"github.com/containerd/nydus-snapshotter/version"
+	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+)
+
+const (
+	endpointPL      = "/api/v1/daemons/prefetch" //////////todo
+	defaultEvents   = "RunPodSandbox"
+	defaulthttp     = "http://system.sock"
+	defaultsockaddr = "/run/containerd-nydus/system.sock"
+)
+
+type PluginArgs struct {
+	PluginName   string
+	PluginIdx    string
+	PluginEvents string
+	Sockaddr     string
+}
+
+type Flags struct {
+	Args *PluginArgs
+	F    []cli.Flag
+}
+
+func buildFlags(args *PluginArgs) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "name",
+			Usage:       "plugin name to register to NRI",
+			Destination: &args.PluginName,
+		},
+		&cli.StringFlag{
+			Name:        "idx",
+			Usage:       "plugin index to register to NRI",
+			Destination: &args.PluginIdx,
+		},
+		&cli.StringFlag{
+			Name:        "sockaddr",
+			Value:       defaultsockaddr,
+			Usage:       "default unix domain socket address",
+			Destination: &args.Sockaddr,
+		},
+		&cli.StringFlag{
+			Name:        "events",
+			Value:       defaultEvents,
+			Usage:       "the events that containerd subscribes to. DO NOT CHANGE THIS.",
+			Destination: &args.PluginEvents,
+		},
+	}
+}
+
+func NewPluginFlags() *Flags {
+	var args PluginArgs
+	return &Flags{
+		Args: &args,
+		F:    buildFlags(&args),
+	}
+}
+
+type plugin struct {
+	stub stub.Stub
+	mask stub.EventMask
+}
+
+var (
+	globalsock string
+	log        *logrus.Logger
+	logWriter  *syslog.Writer
+)
+
+func sendDataOverHTTP(data string, endpoint string, sock string) error {
+	url := defaulthttp + endpoint
+	req, err := http.NewRequest("POST",
+		url, bytes.NewBufferString(data))
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return conn, nil
+			},
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func (p *plugin) RunPodSandbox(pod *api.PodSandbox) error {
+	name := pod.Name
+	parts := strings.Split(name, "-")
+	name = parts[0]
+	if pod.Annotations == nil {
+		log.Printf("error: Pod annotations is nil")
+		return errors.New("Pod annotations is nil")
+	}
+
+	prefetchList, ok := pod.Annotations["prefetch_list"]
+	if !ok {
+		errMsg := "Pod.yaml annotations don't have prefetch list."
+		log.Printf("error: %s", errMsg)
+		return errors.New(errMsg)
+	}
+
+	msg := fmt.Sprintf("%s : %s", name, prefetchList)
+	err := sendDataOverHTTP(msg, endpointPL, globalsock)
+	if err != nil {
+		log.Printf("Failed to send data: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func (p *plugin) onClose() {
+	os.Exit(0)
+}
+
+func main() {
+
+	flags := NewPluginFlags()
+	app := &cli.App{
+		Name:        "prefetchfiles-nri-plugin",
+		Usage:       "NRI plugin for obtaining and transmitting prefetch files path",
+		Version:     version.Version,
+		Flags:       flags.F,
+		HideVersion: true,
+		Action: func(c *cli.Context) error {
+			var (
+				opts []stub.Option
+				err  error
+			)
+
+			flags.Args.Sockaddr = c.String("sockaddr")
+			globalsock = flags.Args.Sockaddr
+
+			log = logrus.StandardLogger()
+			log.SetFormatter(&logrus.TextFormatter{
+				PadLevelText: true,
+			})
+			logWriter, err = syslog.New(syslog.LOG_INFO, "prefetchfiles-nri-plugin")
+
+			if err == nil {
+				log.SetOutput(io.MultiWriter(os.Stdout, logWriter))
+			}
+
+			if flags.Args.PluginName != "" {
+				opts = append(opts, stub.WithPluginName(flags.Args.PluginName))
+			}
+			if flags.Args.PluginIdx != "" {
+				opts = append(opts, stub.WithPluginIdx(flags.Args.PluginIdx))
+			}
+
+			p := &plugin{}
+
+			if p.mask, err = api.ParseEventMask(flags.Args.PluginEvents); err != nil {
+				log.Fatalf("failed to parse events: %v", err)
+			}
+
+			if p.stub, err = stub.New(p, append(opts, stub.WithOnClose(p.onClose))...); err != nil {
+				log.Fatalf("failed to create plugin stub: %v", err)
+			}
+
+			err = p.stub.Run(context.Background())
+			if err != nil {
+				log.Errorf("plugin exited with error %v", err)
+				os.Exit(1)
+			}
+
+			return nil
+		},
+	}
+	if err := app.Run(os.Args); err != nil {
+
+		if errdefs.IsConnectionClosed(err) {
+			log.Info("prefetchfiles NRI plugin exited")
+		} else {
+			log.WithError(err).Fatal("failed to start prefetchfiles NRI plugin")
+		}
+	}
+}

--- a/pkg/daemon/command/command.go
+++ b/pkg/daemon/command/command.go
@@ -34,6 +34,9 @@ type DaemonCommand struct {
 	LogLevel   string `type:"param" name:"log-level"`
 	Supervisor string `type:"param" name:"supervisor"`
 	LogFile    string `type:"param" name:"log-file"`
+	//add prefetch list
+	PrefetchList string `type:"param" name:"prefetch-files"`
+
 }
 
 // Build exec style command line
@@ -96,6 +99,12 @@ func BuildCommand(opts []Opt) ([]string, error) {
 	}
 
 	return args, nil
+}
+
+func WithPrefetchList(p string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.PrefetchList = p
+	}
 }
 
 func WithMode(m string) Opt {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -101,3 +101,9 @@ func WithDaemonMode(daemonMode config.DaemonMode) NewDaemonOpt {
 		return nil
 	}
 }
+func WithNydusdPrefetchList(PrefetchList string) NewDaemonOpt {
+	return func(d *Daemon) error {
+		d.States.PrefetchList = PrefetchList
+		return nil
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -53,6 +53,7 @@ type States struct {
 	// Where the configuration file resides, all rafs instances share the same configuration template
 	ConfigDir      string
 	SupervisorPath string
+	PrefetchList string
 }
 
 // TODO: Record queried nydusd state

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/containerd/nydus-snapshotter/pkg/globalvar"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
@@ -497,6 +498,10 @@ func (fs *Filesystem) createDaemon(mountpoint string, ref int32) (d *daemon.Daem
 
 	if mountpoint != "" {
 		opts = append(opts, daemon.WithMountpoint(mountpoint))
+	}
+
+	if globalvar.PlPath != "" {
+		opts = append(opts, daemon.WithNydusdPrefetchList(globalvar.PlPath))
 	}
 
 	d, err = daemon.NewDaemon(opts...)

--- a/pkg/globalvar/globalvar.go
+++ b/pkg/globalvar/globalvar.go
@@ -1,0 +1,4 @@
+package globalvar
+
+var PlPath string
+//var PldataDict = make(map[string]string)

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -153,6 +153,10 @@ func (m *Manager) BuildDaemonCommand(d *daemon.Daemon, bin string, upgrade bool)
 			command.WithID(d.ID()))
 	}
 
+	if d.States.PrefetchList != ""{
+		cmdOpts = append(cmdOpts, command.WithPrefetchList(d.States.PrefetchList))
+	}
+
 	cmdOpts = append(cmdOpts,
 		command.WithLogLevel(d.States.LogLevel),
 		command.WithAPISock(d.GetAPISock()))


### PR DESCRIPTION
Hello, in order to complete the transmitting and persistence of the prefetch-files param in the nydusd command(persistence means restoring the correct nydusd command when accidentally restarting the snapshotter) , the following modifications are made to the nydus-snapshotter. Those modifications can achieve prefetch-files transmitting when creating a single container, but it is not flexible. For example, when executing commands in the following order:
1. crictl runp busybox-sandbox.yaml
2. crictl runp wordpress-sandbox.yaml
3. crictl create <pod_id> busybox.yaml busybox-sandbox.yaml
At this point, the busybox container is created, but the prefetch-files is the path of wordpress. To solve this problem,  I attempted to define PrefetchList in the States structure as a dictionary and add each prefetch-files parameter to the dictionary. Then, monitor the create container event though NRI plugin and obtain the image name of the comtainer being created, and find the corresponding image name in PrefetchList dictionary to build nydusd cmd. However, this method did not achieve the effect I wanted, because the corresponding image name will transmit from NRI only after the nydusd command is completed, which results in the failure to correctly add the prefetch-files parameter. So currently, I haven't come up with a better way to optimize the code. What should I do next? Please give me some suggestions. Thanks.