### PR TITLE
Refine tarfs overall design and implementation details

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,10 +107,11 @@ const (
 )
 
 type Experimental struct {
-	EnableStargz         bool `toml:"enable_stargz"`
-	EnableReferrerDetect bool `toml:"enable_referrer_detect"`
-	EnableTarfs          bool `toml:"enable_tarfs"`
-	TarfsHint            bool `toml:"tarfs_hint"`
+	EnableStargz           bool `toml:"enable_stargz"`
+	EnableReferrerDetect   bool `toml:"enable_referrer_detect"`
+	EnableTarfs            bool `toml:"enable_tarfs"`
+	TarfsHint              bool `toml:"tarfs_hint"`
+	TarfsMaxConcurrentProc int  `toml:"tarfs_max_concurrent_proc"`
 }
 
 type CgroupConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -107,11 +107,16 @@ const (
 )
 
 type Experimental struct {
-	EnableStargz           bool `toml:"enable_stargz"`
-	EnableReferrerDetect   bool `toml:"enable_referrer_detect"`
-	EnableTarfs            bool `toml:"enable_tarfs"`
-	TarfsHint              bool `toml:"tarfs_hint"`
-	TarfsMaxConcurrentProc int  `toml:"tarfs_max_concurrent_proc"`
+	EnableStargz         bool        `toml:"enable_stargz"`
+	EnableReferrerDetect bool        `toml:"enable_referrer_detect"`
+	TarfsConfig          TarfsConfig `toml:"tarfs"`
+}
+
+type TarfsConfig struct {
+	EnableTarfs       bool   `toml:"enable_tarfs"`
+	TarfsHint         bool   `toml:"tarfs_hint"`
+	MaxConcurrentProc int    `toml:"max_concurrent_proc"`
+	ExportMode        string `toml:"export_mode"`
 }
 
 type CgroupConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -109,6 +109,8 @@ const (
 type Experimental struct {
 	EnableStargz         bool `toml:"enable_stargz"`
 	EnableReferrerDetect bool `toml:"enable_referrer_detect"`
+	EnableTarfs          bool `toml:"enable_tarfs"`
+	TarfsHint            bool `toml:"tarfs_hint"`
 }
 
 type CgroupConfig struct {

--- a/config/global.go
+++ b/config/global.go
@@ -112,6 +112,49 @@ func GetDaemonProfileCPUDuration() int64 {
 	return globalConfig.origin.SystemControllerConfig.DebugConfig.ProfileDuration
 }
 
+const (
+	TarfsLayerVerityOnly      string = "layer_verity_only"
+	TarfsImageVerityOnly      string = "image_verity_only"
+	TarfsLayerBlockDevice     string = "layer_block"
+	TarfsImageBlockDevice     string = "image_block"
+	TarfsLayerBlockWithVerity string = "layer_block_with_verity"
+	TarfsImageBlockWithVerity string = "image_block_with_verity"
+)
+
+func GetTarfsExportEnabled() bool {
+	switch globalConfig.origin.Experimental.TarfsConfig.ExportMode {
+	case TarfsLayerVerityOnly, TarfsLayerBlockDevice, TarfsLayerBlockWithVerity:
+		return true
+	case TarfsImageVerityOnly, TarfsImageBlockDevice, TarfsImageBlockWithVerity:
+		return true
+	default:
+		return false
+	}
+}
+
+// Returns (wholeImage, generateBlockImage, withVerityInfo)
+// wholeImage: generate tarfs for the whole image instead of of a specific layer.
+// generateBlockImage: generate a block image file.
+// withVerityInfo: generate disk verity information.
+func GetTarfsExportFlags() (bool, bool, bool) {
+	switch globalConfig.origin.Experimental.TarfsConfig.ExportMode {
+	case "layer_verity_only":
+		return false, false, true
+	case "image_verity_only":
+		return true, false, true
+	case "layer_block":
+		return false, true, false
+	case "image_block":
+		return true, true, false
+	case "layer_block_with_verity":
+		return false, true, true
+	case "image_block_with_verity":
+		return true, true, true
+	default:
+		return false, false, false
+	}
+}
+
 func ProcessConfigurations(c *SnapshotterConfig) error {
 	if c.LoggingConfig.LogDir == "" {
 		c.LoggingConfig.LogDir = filepath.Join(c.Root, logging.DefaultLogDirName)

--- a/docs/tarfs.md
+++ b/docs/tarfs.md
@@ -1,0 +1,175 @@
+# Nydus Tarfs Mode
+
+`Nydus Tarfs Mode` or `Tarfs` is a working mode for Nydus Image, which uses tar files as Nydus data blobs instead of generating native Nydus data blobs.
+
+### Enable Tarfs
+`Nydus Tarfs Mode` is still an experiment feature, please edit the snapshotter configuration file to enable the feature:
+```
+[experimental.tarfs]
+enable_tarfs = true
+```
+
+### Generate Raw Disk Image for Each Layer of a Container Image
+`Tarfs` supports generating a raw disk image for each layer of a container image, which can be directly mounted as EROFS filesystem through loopdev. Please edit the snapshotter configuration file to enable this submode:
+```
+[experimental.tarfs]
+enable_tarfs = true
+export_mode = "layer_block"
+```
+
+This is an example to generate and verify raw disk image for each layer of a container image:
+```
+$ containerd-nydus-grpc --config /etc/nydus/config.toml &
+$ nerdctl run --snapshotter nydus --rm nginx
+
+# Show mounted rootfs a container
+$ mount
+/dev/loop17 on /var/lib/containerd-nydus/snapshots/7/mnt type erofs (ro,relatime,user_xattr,acl,cache_strategy=readaround)
+
+# Show loop devices used to mount layers and bootstrap for a container image
+$ losetup 
+NAME SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE                                                                       DIO LOG-SEC
+/dev/loop11 0      0         0  0 /var/lib/containerd-nydus/cache/fd9f026c631046113bd492f69761c3ba6042c791c35a60e7c7f3b8f254592daa 0     512
+/dev/loop12 0      0         0  0 /var/lib/containerd-nydus/cache/055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3 0     512
+/dev/loop13 0      0         0  0 /var/lib/containerd-nydus/cache/96576293dd2954ff84251aa0455687c8643358ba1b190ea1818f56b41884bdbd 0     512
+/dev/loop14 0      0         0  0 /var/lib/containerd-nydus/cache/a7c4092be9044bd4eef78f27c95785ef3a9f345d01fd4512bc94ddaaefc359f4 0     512
+/dev/loop15 0      0         0  0 /var/lib/containerd-nydus/cache/e3b6889c89547ec9ba653ab44ed32a99370940d51df956968c0d578dd61ab665 0     512
+/dev/loop16 0      0         0  0 /var/lib/containerd-nydus/cache/da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75 0     512
+/dev/loop17 0      0         0  0 /var/lib/containerd-nydus/snapshots/7/fs/image/image.boot                         0     512
+
+# Files without suffix are tar files, files with suffix `layer.disk` are raw disk image for container image layers
+$ ls -l /var/lib/containerd-nydus/cache/
+total 376800
+-rw-r--r-- 1 root root      3584 Aug 30 23:18 055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3
+-rw-r--r-- 1 root root    527872 Aug 30 23:18 055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3.layer.disk
+-rw-r--r-- 1 root root  77814784 Aug 30 23:18 52d2b7f179e32b4cbd579ee3c4958027988f9a8274850ab0c7c24661e3adaac5
+-rw-r--r-- 1 root root  78863360 Aug 30 23:18 52d2b7f179e32b4cbd579ee3c4958027988f9a8274850ab0c7c24661e3adaac5.layer.disk
+-rw-r--r-- 1 root root      4608 Aug 30 23:18 96576293dd2954ff84251aa0455687c8643358ba1b190ea1818f56b41884bdbd
+-rw-r--r-- 1 root root    528896 Aug 30 23:18 96576293dd2954ff84251aa0455687c8643358ba1b190ea1818f56b41884bdbd.layer.disk
+-rw-r--r-- 1 root root      2560 Aug 30 23:18 a7c4092be9044bd4eef78f27c95785ef3a9f345d01fd4512bc94ddaaefc359f4
+-rw-r--r-- 1 root root    526848 Aug 30 23:18 a7c4092be9044bd4eef78f27c95785ef3a9f345d01fd4512bc94ddaaefc359f4.layer.disk
+-rw-r--r-- 1 root root      7168 Aug 30 23:18 da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75
+-rw-r--r-- 1 root root    531456 Aug 30 23:18 da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75.layer.disk
+-rw-r--r-- 1 root root      5120 Aug 30 23:18 e3b6889c89547ec9ba653ab44ed32a99370940d51df956968c0d578dd61ab665
+-rw-r--r-- 1 root root    529408 Aug 30 23:18 e3b6889c89547ec9ba653ab44ed32a99370940d51df956968c0d578dd61ab665.layer.disk
+-rw-r--r-- 1 root root 112968704 Aug 30 23:18 fd9f026c631046113bd492f69761c3ba6042c791c35a60e7c7f3b8f254592daa
+-rw-r--r-- 1 root root 113492992 Aug 30 23:18 fd9f026c631046113bd492f69761c3ba6042c791c35a60e7c7f3b8f254592daa.layer.disk
+$ file /var/lib/containerd-nydus/cache/055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3
+/var/lib/containerd-nydus/cache/055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3: POSIX tar archive
+
+# Mount the raw disk image for a container image layer
+$ losetup /dev/loop100 /var/lib/containerd-nydus/cache/055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3.layer.disk 
+$ mount -t erofs /dev/loop100 ./mnt/
+$ mount
+tmpfs on /run/user/0 type tmpfs (rw,nosuid,nodev,relatime,size=1544836k,nr_inodes=386209,mode=700,inode64)
+/dev/loop17 on /var/lib/containerd-nydus/snapshots/7/mnt type erofs (ro,relatime,user_xattr,acl,cache_strategy=readaround)
+/dev/loop100 on /root/ws/nydus-snapshotter.git/mnt type erofs (ro,relatime,user_xattr,acl,cache_strategy=readaround)
+
+```
+
+### Generate Raw Disk Image for a Container Image
+`Tarfs` supports generating a raw disk image a container image, which can be directly mounted as EROFS filesystem through loopdev. Please edit the snapshotter configuration file to enable this submode:
+```
+[experimental.tarfs]
+enable_tarfs = true
+export_mode = "image_block"
+```
+
+This is an example to generate and verify raw disk image for a container image:
+```
+$ containerd-nydus-grpc --config /etc/nydus/config.toml &
+$ nerdctl run --snapshotter nydus --rm nginx
+
+# Files without suffix are tar files, files with suffix `image.disk` are raw disk image for a container image
+$ ls -l /var/lib/containerd-nydus/cache/
+total 376320
+-rw-r--r-- 1 root root      3584 Aug 30 23:35 055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3
+-rw-r--r-- 1 root root  77814784 Aug 30 23:35 52d2b7f179e32b4cbd579ee3c4958027988f9a8274850ab0c7c24661e3adaac5
+-rw-r--r-- 1 root root      4608 Aug 30 23:35 96576293dd2954ff84251aa0455687c8643358ba1b190ea1818f56b41884bdbd
+-rw-r--r-- 1 root root      2560 Aug 30 23:35 a7c4092be9044bd4eef78f27c95785ef3a9f345d01fd4512bc94ddaaefc359f4
+-rw-r--r-- 1 root root      7168 Aug 30 23:35 da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75
+-rw-r--r-- 1 root root 194518016 Aug 30 23:36 da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75.image.disk
+-rw-r--r-- 1 root root      5120 Aug 30 23:35 e3b6889c89547ec9ba653ab44ed32a99370940d51df956968c0d578dd61ab665
+-rw-r--r-- 1 root root 112968704 Aug 30 23:36 fd9f026c631046113bd492f69761c3ba6042c791c35a60e7c7f3b8f254592daa
+
+```
+
+### Generate Raw Disk Image with dm-verity Information
+`Tarfs` supports generating raw disk images with dm-verity information, to enable runtime data integrity validation. Please change `export_mode` in snapshotter configuration file to `layer_block_with_verity` or `image_block_with_verity`.
+
+```
+[experimental.tarfs]
+enable_tarfs = true
+export_mode = "image_block_with_verity"
+```
+
+This is an example to generate and verify raw disk image for a container image with dm-verity information:
+```
+$ containerd-nydus-grpc --config /etc/nydus/config.toml &
+$ nerdctl run --snapshotter nydus --rm nginx
+
+# Files without suffix are tar files, files with suffix `image.disk` are raw disk image for a container image
+$ ls -l /var/lib/containerd-nydus/cache/
+total 388296
+-rw-r--r-- 1 root root      3584 Aug 30 23:45 055fa98b43638b67d10c58d41094d99c8696cc34b7a960c7a0cc5d9d152d12b3
+-rw-r--r-- 1 root root  77814784 Aug 30 23:46 52d2b7f179e32b4cbd579ee3c4958027988f9a8274850ab0c7c24661e3adaac5
+-rw-r--r-- 1 root root      4608 Aug 30 23:45 96576293dd2954ff84251aa0455687c8643358ba1b190ea1818f56b41884bdbd
+-rw-r--r-- 1 root root      2560 Aug 30 23:45 a7c4092be9044bd4eef78f27c95785ef3a9f345d01fd4512bc94ddaaefc359f4
+-rw-r--r-- 1 root root      7168 Aug 30 23:45 da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75
+-rw-r--r-- 1 root root 206782464 Aug 30 23:46 da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75.image.disk
+-rw-r--r-- 1 root root      5120 Aug 30 23:45 e3b6889c89547ec9ba653ab44ed32a99370940d51df956968c0d578dd61ab665
+-rw-r--r-- 1 root root 112968704 Aug 30 23:46 fd9f026c631046113bd492f69761c3ba6042c791c35a60e7c7f3b8f254592daa
+
+$ losetup /dev/loop100 /var/lib/containerd-nydus/cache/da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75.image.disk
+$  veritysetup open --no-superblock --format=1 -s "" --hash=sha256 --data-block-size=512 --hash-block-size=4096 --data-blocks 379918 --hash-offset 194519040 /dev/loop100 image1 /dev/loop100 8113799aaf9a5d14feca1eadc3b7e6ea98bdaf61e3a2e4a8ef8c24e26a551efd
+$ lsblk
+loop100   7:100  0 197.2M  0 loop  
+└─dm-0  252:0    0 185.5M  1 crypt 
+
+$ veritysetup status dm-0
+/dev/mapper/dm-0 is active and is in use.
+  type:        VERITY
+  status:      verified
+  hash type:   1
+  data block:  512
+  hash block:  4096
+  hash name:   sha256
+  salt:        -
+  data device: /dev/loop100
+  data loop:   /var/lib/containerd-nydus/cache/da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75.image.disk
+  size:        379918 sectors
+  mode:        readonly
+  hash device: /dev/loop100
+  hash loop:   /var/lib/containerd-nydus/cache/da761d9a302b21dc50767b67d46f737f5072fb4490c525b4a7ae6f18e1dbbf75.image.disk
+  hash offset: 379920 sectors
+  root hash:   8113799aaf9a5d14feca1eadc3b7e6ea98bdaf61e3a2e4a8ef8c24e26a551efd
+
+$ mount -t erofs /dev/dm-0 ./mnt/
+mount: /root/ws/nydus-snapshotter.git/mnt: WARNING: source write-protected, mounted read-only.
+$ ls -l mnt/
+total 14
+lrwxrwxrwx  1 root root    7 Aug 14 08:00 bin -> usr/bin
+drwxr-xr-x  2 root root   27 Jul 15 00:00 boot
+drwxr-xr-x  2 root root   27 Aug 14 08:00 dev
+drwxr-xr-x  2 root root  184 Aug 16 17:50 docker-entrypoint.d
+-rwxrwxr-x  1 root root 1620 Aug 16 17:50 docker-entrypoint.sh
+drwxr-xr-x 34 root root 1524 Aug 16 17:50 etc
+drwxr-xr-x  2 root root   27 Jul 15 00:00 home
+lrwxrwxrwx  1 root root    7 Aug 14 08:00 lib -> usr/lib
+lrwxrwxrwx  1 root root    9 Aug 14 08:00 lib32 -> usr/lib32
+lrwxrwxrwx  1 root root    9 Aug 14 08:00 lib64 -> usr/lib64
+lrwxrwxrwx  1 root root   10 Aug 14 08:00 libx32 -> usr/libx32
+drwxr-xr-x  2 root root   27 Aug 14 08:00 media
+drwxr-xr-x  2 root root   27 Aug 14 08:00 mnt
+drwxr-xr-x  2 root root   27 Aug 14 08:00 opt
+drwxr-xr-x  2 root root   27 Jul 15 00:00 proc
+drwx------  2 root root   66 Aug 14 08:00 root
+drwxr-xr-x  3 root root   43 Aug 14 08:00 run
+lrwxrwxrwx  1 root root    8 Aug 14 08:00 sbin -> usr/sbin
+drwxr-xr-x  2 root root   27 Aug 14 08:00 srv
+drwxr-xr-x  2 root root   27 Jul 15 00:00 sys
+drwxrwxrwt  2 root root   27 Aug 16 17:50 tmp
+drwxr-xr-x 14 root root  229 Aug 14 08:00 usr
+drwxr-xr-x 11 root root  204 Aug 14 08:00 var
+
+```

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,8 @@ require (
 	k8s.io/cri-api v0.27.0-alpha.3
 )
 
+require github.com/freddierice/go-losetup v0.0.0-20220711213114-2a14873012db // indirect
+
 require (
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,10 @@ github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/freddierice/go-losetup v0.0.0-20220711213114-2a14873012db h1:StM6A9LvaVrFS2chAGcfRVDoBB6rHYPIGJ3GknpB25c=
+github.com/freddierice/go-losetup v0.0.0-20220711213114-2a14873012db/go.mod h1:pwuQfHWn6j2Fpl2AWw/bPLlKfojHxIIEa5TeKIgDFW4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -104,3 +104,21 @@ enable_stargz = false
 # The option enables trying to fetch the Nydus image associated with the OCI image and run it.
 # Also see https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
 enable_referrer_detect = false
+[experimental.tarfs]
+# Whether to enable nydus tarfs mode. Tarfs is supported by:
+# - The EROFS filesystem driver since Linux 6.4
+# - Nydus Image Service release v2.3
+enable_tarfs = false
+# Only enable nydus tarfs mode for images with `tarfs hint` label when true
+tarfs_hint = false
+# Maximum of concurrence to converting OCIv1 images to tarfs, 0 means default
+max_concurrent_proc = 0
+# Mode to export tarfs images:
+# - "none" or "": do not export tarfs
+# - "layer_verity_only": only generate disk verity information for a layer blob
+# - "image_verity_only": only generate disk verity information for all blobs of an image
+# - "layer_block": generate a raw block disk image with tarfs for a layer
+# - "image_block": generate a raw block disk image with tarfs for an image
+# - "layer_block_with_verity": generate a raw block disk image with tarfs for a layer with dm-verity info
+# - "image_block_with_verity": generate a raw block disk image with tarfs for an image with dm-verity info
+export_mode = ""

--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
-	chunkMapFileSuffix = ".chunk_map"
-	metaFileSuffix     = ".blob.meta"
+	imageDiskFileSuffix = ".image.disk"
+	layerDiskFileSuffix = ".layer.disk"
+	chunkMapFileSuffix  = ".chunk_map"
+	metaFileSuffix      = ".blob.meta"
 	// Blob cache is suffixed after nydus v2.1
 	dataFileSuffix = ".blob.data"
 )
@@ -72,8 +74,10 @@ func (m *Manager) CacheUsage(ctx context.Context, blobID string) (snapshots.Usag
 	blobCacheSuffixedPath := path.Join(m.cacheDir, blobID+dataFileSuffix)
 	blobChunkMap := path.Join(m.cacheDir, blobID+chunkMapFileSuffix)
 	blobMeta := path.Join(m.cacheDir, blobID+metaFileSuffix)
+	imageDisk := path.Join(m.cacheDir, blobID+imageDiskFileSuffix)
+	layerDisk := path.Join(m.cacheDir, blobID+layerDiskFileSuffix)
 
-	stuffs := []string{blobCachePath, blobCacheSuffixedPath, blobChunkMap, blobMeta}
+	stuffs := []string{blobCachePath, blobCacheSuffixedPath, blobChunkMap, blobMeta, imageDisk, layerDisk}
 
 	for _, f := range stuffs {
 		du, err := fs.DiskUsage(ctx, f)
@@ -95,9 +99,11 @@ func (m *Manager) RemoveBlobCache(blobID string) error {
 	blobCacheSuffixedPath := path.Join(m.cacheDir, blobID+dataFileSuffix)
 	blobChunkMap := path.Join(m.cacheDir, blobID+chunkMapFileSuffix)
 	blobMeta := path.Join(m.cacheDir, blobID+metaFileSuffix)
+	imageDisk := path.Join(m.cacheDir, blobID+imageDiskFileSuffix)
+	layerDisk := path.Join(m.cacheDir, blobID+layerDiskFileSuffix)
 
 	// NOTE: Delete chunk bitmap file before data blob
-	stuffs := []string{blobChunkMap, blobMeta, blobCachePath, blobCacheSuffixedPath}
+	stuffs := []string{blobChunkMap, blobMeta, blobCachePath, blobCacheSuffixedPath, imageDisk, layerDisk}
 
 	for _, f := range stuffs {
 		err := os.Remove(f)

--- a/pkg/filesystem/config.go
+++ b/pkg/filesystem/config.go
@@ -29,17 +29,17 @@ func WithNydusImageBinaryPath(p string) NewFSOpt {
 
 func WithManager(pm *manager.Manager) NewFSOpt {
 	return func(fs *Filesystem) error {
-		if pm == nil {
-			return errors.New("process manager cannot be nil")
+		if pm != nil {
+			switch pm.FsDriver {
+			case config.FsDriverBlockdev:
+				fs.blockdevManager = pm
+			case config.FsDriverFscache:
+				fs.fscacheManager = pm
+			case config.FsDriverFusedev:
+				fs.fusedevManager = pm
+			}
+			fs.enabledManagers = append(fs.enabledManagers, pm)
 		}
-
-		if pm.FsDriver == config.FsDriverFusedev {
-			fs.fusedevManager = pm
-		} else if pm.FsDriver == config.FsDriverFscache {
-			fs.fscacheManager = pm
-		}
-
-		fs.enabledManagers = append(fs.enabledManagers, pm)
 
 		return nil
 	}

--- a/pkg/filesystem/config.go
+++ b/pkg/filesystem/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
 	"github.com/containerd/nydus-snapshotter/pkg/stargz"
+	"github.com/containerd/nydus-snapshotter/pkg/tarfs"
 	"github.com/pkg/errors"
 )
 
@@ -62,6 +63,16 @@ func WithReferrerManager(rm *referrer.Manager) NewFSOpt {
 		}
 
 		fs.referrerMgr = rm
+		return nil
+	}
+}
+
+func WithTarfsManager(tm *tarfs.Manager) NewFSOpt {
+	return func(fs *Filesystem) error {
+		if tm == nil {
+			return errors.New("tarfs manager cannot be nil")
+		}
+		fs.tarfsMgr = tm
 		return nil
 	}
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -600,7 +600,6 @@ func (fs *Filesystem) initSharedDaemon(fsManager *manager.Manager) (err error) {
 }
 
 // createDaemon create new nydus daemon by snapshotID and imageID
-// For fscache driver, no need to provide mountpoint to nydusd daemon.
 func (fs *Filesystem) createDaemon(fsManager *manager.Manager, daemonMode config.DaemonMode,
 	mountpoint string, ref int32) (d *daemon.Daemon, err error) {
 	opts := []daemon.NewDaemonOpt{
@@ -616,6 +615,7 @@ func (fs *Filesystem) createDaemon(fsManager *manager.Manager, daemonMode config
 		daemon.WithDaemonMode(daemonMode),
 	}
 
+	// For fscache driver, no need to provide mountpoint to nydusd daemon.
 	if mountpoint != "" {
 		opts = append(opts, daemon.WithMountpoint(mountpoint))
 	}

--- a/pkg/filesystem/tarfs_adaptor.go
+++ b/pkg/filesystem/tarfs_adaptor.go
@@ -59,11 +59,6 @@ func (fs *Filesystem) PrepareTarfsLayer(ctx context.Context, labels map[string]s
 	return nil
 }
 
-func (fs *Filesystem) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[string]string,
-	storageLocater func(string) string) ([]string, error) {
-	return fs.tarfsMgr.ExportBlockData(s, perLayer, labels, storageLocater)
-}
-
 func (fs *Filesystem) MergeTarfsLayers(s storage.Snapshot, storageLocater func(string) string) error {
 	return fs.tarfsMgr.MergeLayers(s, storageLocater)
 }
@@ -72,10 +67,7 @@ func (fs *Filesystem) DetachTarfsLayer(snapshotID string) error {
 	return fs.tarfsMgr.DetachLayer(snapshotID)
 }
 
-func (fs *Filesystem) IsTarfsLayer(snapshotID string) bool {
-	return fs.tarfsMgr.IsTarfsLayer(snapshotID)
-}
-
-func (fs *Filesystem) IsMountedTarfsLayer(snapshotID string) bool {
-	return fs.tarfsMgr.IsMountedTarfsLayer(snapshotID)
+func (fs *Filesystem) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[string]string,
+	storageLocater func(string) string) ([]string, error) {
+	return fs.tarfsMgr.ExportBlockData(s, perLayer, labels, storageLocater)
 }

--- a/pkg/filesystem/tarfs_adaptor.go
+++ b/pkg/filesystem/tarfs_adaptor.go
@@ -20,7 +20,7 @@ func (fs *Filesystem) TarfsEnabled() bool {
 	return fs.tarfsMgr != nil
 }
 
-func (fs *Filesystem) PrepareTarfsLayer(ctx context.Context, labels map[string]string, snapshotID, storagePath string) error {
+func (fs *Filesystem) PrepareTarfsLayer(ctx context.Context, labels map[string]string, snapshotID, upperDirPath string) error {
 	ref, ok := labels[snpkg.TargetRefLabel]
 	if !ok {
 		return errors.Errorf("not found image reference label")
@@ -50,8 +50,8 @@ func (fs *Filesystem) PrepareTarfsLayer(ctx context.Context, labels map[string]s
 	}
 
 	go func() {
-		if err := fs.tarfsMgr.PrepareLayer(snapshotID, ref, manifestDigest, layerDigest, storagePath); err != nil {
-			log.L.WithError(err).Errorf("async prepare Tarfs layer of snapshot ID %s", snapshotID)
+		if err := fs.tarfsMgr.PrepareLayer(snapshotID, ref, manifestDigest, layerDigest, upperDirPath); err != nil {
+			log.L.WithError(err).Errorf("async prepare tarfs layer of snapshot ID %s", snapshotID)
 		}
 		if limiter != nil {
 			limiter.Release(1)
@@ -70,9 +70,9 @@ func (fs *Filesystem) DetachTarfsLayer(snapshotID string) error {
 }
 
 func (fs *Filesystem) IsTarfsLayer(snapshotID string) bool {
-	return fs.tarfsMgr.CheckTarfsLayer(snapshotID, false)
+	return fs.tarfsMgr.IsTarfsLayer(snapshotID)
 }
 
-func (fs *Filesystem) IsMergedTarfsLayer(snapshotID string) bool {
-	return fs.tarfsMgr.CheckTarfsLayer(snapshotID, true)
+func (fs *Filesystem) IsMountedTarfsLayer(snapshotID string) bool {
+	return fs.tarfsMgr.IsMountedTarfsLayer(snapshotID)
 }

--- a/pkg/filesystem/tarfs_adaptor.go
+++ b/pkg/filesystem/tarfs_adaptor.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package filesystem
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/log"
+	snpkg "github.com/containerd/containerd/pkg/snapshotters"
+	"github.com/containerd/containerd/snapshots/storage"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+func (fs *Filesystem) TarfsEnabled() bool {
+	return fs.tarfsMgr != nil
+}
+
+func (fs *Filesystem) PrepareTarfsLayer(ctx context.Context, labels map[string]string, snapshotID, storagePath string) error {
+	ref, ok := labels[snpkg.TargetRefLabel]
+	if !ok {
+		return errors.Errorf("not found image reference lable")
+	}
+	layerDigest := digest.Digest(labels[snpkg.TargetLayerDigestLabel])
+	if layerDigest.Validate() != nil {
+		return errors.Errorf("not found manifest digest lable")
+	}
+	manifest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
+	if manifest.Validate() != nil {
+		return errors.Errorf("not found manifest digest lable")
+	}
+
+	ok, err := fs.tarfsMgr.CheckTarfsHintAnnotation(ctx, ref, manifest)
+	if err != nil {
+		return errors.Wrapf(err, "check tarfs hint annotaion")
+	}
+	if !ok {
+		return errors.Errorf("this image is not recommended for tarfs")
+	}
+
+	go func() {
+		// TODO concurrency control
+		if err := fs.tarfsMgr.PrepareLayer(snapshotID, ref, manifest, layerDigest, storagePath); err != nil {
+			log.L.WithError(err).Errorf("async prepare Tarfs layer of snapshot ID %s", snapshotID)
+		}
+	}()
+	return nil
+}
+
+func (fs *Filesystem) MergeTarfsLayers(s storage.Snapshot, storageLocater func(string) string) error {
+	return fs.tarfsMgr.MergeLayers(s, storageLocater)
+}
+
+func (fs *Filesystem) DetachTarfsLayer(snapshotID string) error {
+	return fs.tarfsMgr.DetachLayer(snapshotID)
+}
+
+func (fs *Filesystem) IsTarfsLayer(snapshotID string) bool {
+	return fs.tarfsMgr.CheckTarfsLayer(snapshotID, false)
+}
+
+func (fs *Filesystem) IsMergedTarfsLayer(snapshotID string) bool {
+	return fs.tarfsMgr.CheckTarfsLayer(snapshotID, true)
+}

--- a/pkg/filesystem/tarfs_adaptor.go
+++ b/pkg/filesystem/tarfs_adaptor.go
@@ -49,16 +49,19 @@ func (fs *Filesystem) PrepareTarfsLayer(ctx context.Context, labels map[string]s
 		}
 	}
 
-	go func() {
-		if err := fs.tarfsMgr.PrepareLayer(snapshotID, ref, manifestDigest, layerDigest, upperDirPath); err != nil {
-			log.L.WithError(err).Errorf("async prepare tarfs layer of snapshot ID %s", snapshotID)
-		}
-		if limiter != nil {
-			limiter.Release(1)
-		}
-	}()
+	if err := fs.tarfsMgr.PrepareLayer(snapshotID, ref, manifestDigest, layerDigest, upperDirPath); err != nil {
+		log.L.WithError(err).Errorf("async prepare tarfs layer of snapshot ID %s", snapshotID)
+	}
+	if limiter != nil {
+		limiter.Release(1)
+	}
 
 	return nil
+}
+
+func (fs *Filesystem) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[string]string,
+	storageLocater func(string) string) ([]string, error) {
+	return fs.tarfsMgr.ExportBlockData(s, perLayer, labels, storageLocater)
 }
 
 func (fs *Filesystem) MergeTarfsLayers(s storage.Snapshot, storageLocater func(string) string) error {

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -42,6 +42,10 @@ const (
 	NydusImagePullUsername = "containerd.io/snapshot/pullusername"
 	// A bool flag to enable integrity verification of meta data blob
 	NydusSignature = "containerd.io/snapshot/nydus-signature"
+	// Information for image block device
+	NydusImageBlockInfo = "containerd.io/snapshot/nydus-image-block"
+	// Information for layer block device
+	NydusLayerBlockInfo = "containerd.io/snapshot/nydus-layer-block"
 
 	// A bool flag to mark the blob as a estargz data blob, set by the snapshotter.
 	StargzLayer = "containerd.io/snapshot/stargz"

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -34,6 +34,8 @@ const (
 	NydusMetaLayer = "containerd.io/snapshot/nydus-bootstrap"
 	// The referenced blob sha256 in format of `sha256:xxx`, set by image builders.
 	NydusRefLayer = "containerd.io/snapshot/nydus-ref"
+	// A bool flag to mark the layer as a nydus tarfs, set by the snapshotter
+	NydusTarfsLayer = "containerd.io/snapshot/nydus-tarfs"
 	// Annotation containing secret to pull images from registry, set by the snapshotter.
 	NydusImagePullSecret = "containerd.io/snapshot/pullsecret"
 	// Annotation containing username to pull images from registry, set by the snapshotter.
@@ -60,17 +62,16 @@ func IsNydusDataLayer(labels map[string]string) bool {
 }
 
 func IsNydusMetaLayer(labels map[string]string) bool {
-	if labels == nil {
-		return false
-	}
 	_, ok := labels[NydusMetaLayer]
 	return ok
 }
 
-func IsTarfsHint(labels map[string]string) bool {
-	if labels == nil {
-		return false
-	}
+func IsTarfsDataLayer(labels map[string]string) bool {
+	_, ok := labels[NydusTarfsLayer]
+	return ok
+}
+
+func HasTarfsHint(labels map[string]string) bool {
 	_, ok := labels[TarfsHint]
 	return ok
 }

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -48,6 +48,10 @@ const (
 	// If this optional label of a snapshot is specified, when mounted to rootdir
 	// this snapshot will include volatile option
 	OverlayfsVolatileOpt = "containerd.io/snapshot/overlay.volatile"
+
+	// A bool flag to mark it is recommended to run this image with tarfs mode, set by image builders.
+	// runtime can decide whether to rely on this annotation
+	TarfsHint = "containerd.io/snapshot/tarfs-hint"
 )
 
 func IsNydusDataLayer(labels map[string]string) bool {
@@ -60,5 +64,13 @@ func IsNydusMetaLayer(labels map[string]string) bool {
 		return false
 	}
 	_, ok := labels[NydusMetaLayer]
+	return ok
+}
+
+func IsTarfsHint(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+	_, ok := labels[TarfsHint]
 	return ok
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -127,9 +127,8 @@ type Manager struct {
 	// supposed to refilled when nydus-snapshotter restarting.
 	daemonStates *DaemonStates
 
-	monitor LivenessMonitor
-	// TODO: Close me
-	LivenessNotifier chan deathEvent
+	monitor          LivenessMonitor
+	LivenessNotifier chan deathEvent // TODO: Close me
 	RecoverPolicy    config.DaemonRecoverPolicy
 	SupervisorSet    *supervisor.SupervisorsSet
 
@@ -151,12 +150,10 @@ type Opt struct {
 	Database         *store.Database
 	CacheDir         string
 	RecoverPolicy    config.DaemonRecoverPolicy
-	// Nydus-snapshotter work directory
-	RootDir      string
-	DaemonConfig daemonconfig.DaemonConfig
-	CgroupMgr    *cgroup.Manager
-	// In order to validate daemon fs driver is consistent with the latest snapshotter boot
-	FsDriver string
+	RootDir          string // Nydus-snapshotter work directory
+	DaemonConfig     daemonconfig.DaemonConfig
+	CgroupMgr        *cgroup.Manager
+	FsDriver         string // In order to validate daemon fs driver is consistent with the latest snapshotter boot
 }
 
 func (m *Manager) doDaemonFailover(d *daemon.Daemon) {
@@ -328,6 +325,10 @@ func (m *Manager) NewInstance(r *daemon.Rafs) error {
 	return m.store.AddInstance(r)
 }
 
+func (m *Manager) RemoveInstance(snapshotID string) error {
+	return m.store.DeleteInstance(snapshotID)
+}
+
 func (m *Manager) Lock() {
 	m.mu.Lock()
 }
@@ -351,10 +352,6 @@ func (m *Manager) UnsubscribeDaemonEvent(d *daemon.Daemon) error {
 		return errors.Wrapf(err, "unsubscribe daemon %s", d.ID())
 	}
 	return nil
-}
-
-func (m *Manager) RemoveInstance(snapshotID string) error {
-	return m.store.DeleteInstance(snapshotID)
 }
 
 func (m *Manager) UpdateDaemon(daemon *daemon.Daemon) error {

--- a/pkg/metrics/serve.go
+++ b/pkg/metrics/serve.go
@@ -36,7 +36,9 @@ type Server struct {
 
 func WithProcessManager(pm *manager.Manager) ServerOpt {
 	return func(s *Server) error {
-		s.managers = append(s.managers, pm)
+		if pm != nil {
+			s.managers = append(s.managers, pm)
+		}
 		return nil
 	}
 }

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -83,8 +83,6 @@ func IterateParentSnapshots(ctx context.Context, ms *storage.MetaStore, key stri
 			return id, info, nil
 		}
 
-		log.L.Debugf("continue to check snapshot %s parent", id)
-
 		cKey = info.Parent
 	}
 

--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -1,0 +1,538 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package tarfs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/snapshots/storage"
+	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
+	"github.com/containerd/nydus-snapshotter/pkg/remote"
+	"github.com/containerd/nydus-snapshotter/pkg/remote/remotes"
+	losetup "github.com/freddierice/go-losetup"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
+	"golang.org/x/sys/unix"
+	"k8s.io/utils/lru"
+)
+
+type Manager struct {
+	snapshotMap    map[string]*snapshotStatus // tarfs snapshots status, indexed by snapshot ID
+	mutex          sync.Mutex
+	insecure       bool
+	checkTarfsHint bool       // whether to rely on tarfs hint annotation
+	tarfsHintCache *lru.Cache // cache oci image raf and tarfs hint annotation
+	nydusImagePath string
+	diffIDCache    *lru.Cache // cache oci blob digest and diffID
+	sg             singleflight.Group
+}
+
+const (
+	TarfsStatusInit       = 0
+	TarfsStatusFormatting = 1
+	TarfsStatusReady      = 2
+	TarfsStatusFailed     = 3
+)
+
+const (
+	TarfsBlobName            = "blob.tar"
+	TarfsLayerBootstapName   = "layer_bootstrap"
+	TarfsMeragedBootstapName = "merged_bootstrap"
+)
+
+var ErrEmptyBlob = errors.New("empty blob")
+
+type snapshotStatus struct {
+	status          int
+	layerBsLoopdev  *losetup.Device
+	mergedBsLoopdev *losetup.Device
+	erofsMountPoint string
+	erofsMountOpts  string
+	wg              *sync.WaitGroup
+	cancel          context.CancelFunc
+}
+
+func NewManager(insecure, checkTarfsHint bool, nydusImagePath string) *Manager {
+	return &Manager{
+		snapshotMap:    map[string]*snapshotStatus{},
+		nydusImagePath: nydusImagePath,
+		insecure:       insecure,
+		checkTarfsHint: checkTarfsHint,
+		tarfsHintCache: lru.New(50),
+		diffIDCache:    lru.New(1000),
+		sg:             singleflight.Group{},
+	}
+}
+
+// fetch image form manifest and config, then cache them in lru
+// FIXME need an update policy
+func (t *Manager) fetchImageInfo(ctx context.Context, remote *remote.Remote, ref string, manifest digest.Digest) error {
+	// fetch the manifest find config digest and layers digest
+	rc, err := t.getBlobStream(ctx, remote, ref, manifest)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	var manifestOCI ocispec.Manifest
+	bytes, err := io.ReadAll(rc)
+	if err != nil {
+		return errors.Wrap(err, "read manifest")
+	}
+	if err := json.Unmarshal(bytes, &manifestOCI); err != nil {
+		return errors.Wrap(err, "unmarshal manifest")
+	}
+	if len(manifestOCI.Layers) < 1 {
+		return errors.Errorf("invalid manifest")
+	}
+
+	// fetch the config and find diff ids
+	rc, err = t.getBlobStream(ctx, remote, ref, manifestOCI.Config.Digest)
+	if err != nil {
+		return errors.Wrap(err, "fetch referrers")
+	}
+	defer rc.Close()
+	var config ocispec.Image
+	bytes, err = io.ReadAll(rc)
+	if err != nil {
+		return errors.Wrap(err, "read config")
+	}
+	if err := json.Unmarshal(bytes, &config); err != nil {
+		return errors.Wrap(err, "unmarshal config")
+	}
+	if len(config.RootFS.DiffIDs) != len(manifestOCI.Layers) {
+		return errors.Errorf("number of diff ids unmatch manifest layers")
+	}
+	// cache ref & tarfs hint annotation
+	t.tarfsHintCache.Add(ref, label.IsTarfsHint(manifestOCI.Annotations))
+	// cache OCI blob digest & diff id
+	for i := range manifestOCI.Layers {
+		t.diffIDCache.Add(manifestOCI.Layers[i].Digest, config.RootFS.DiffIDs[i])
+	}
+	return nil
+}
+
+func (t *Manager) getBlobDiffID(ctx context.Context, remote *remote.Remote, ref string, manifest, layerDigest digest.Digest) (digest.Digest, error) {
+	if diffid, ok := t.diffIDCache.Get(layerDigest); ok {
+		return diffid.(digest.Digest), nil
+	}
+
+	if _, err, _ := t.sg.Do(ref, func() (interface{}, error) {
+		err := t.fetchImageInfo(ctx, remote, ref, manifest)
+		return nil, err
+	}); err != nil {
+		return "", err
+	}
+
+	if diffid, ok := t.diffIDCache.Get(layerDigest); ok {
+		return diffid.(digest.Digest), nil
+	}
+
+	return "", errors.Errorf("get blob diff id failed")
+}
+
+func (t *Manager) getBlobStream(ctx context.Context, remote *remote.Remote, ref string, layerDigest digest.Digest) (io.ReadCloser, error) {
+	fetcher, err := remote.Fetcher(ctx, ref)
+	if err != nil {
+		return nil, errors.Wrap(err, "get remote fetcher")
+	}
+
+	fetcherByDigest, ok := fetcher.(remotes.FetcherByDigest)
+	if !ok {
+		return nil, errors.Errorf("fetcher %T does not implement remotes.FetcherByDigest", fetcher)
+	}
+
+	rc, _, err := fetcherByDigest.FetchByDigest(ctx, layerDigest)
+	return rc, err
+}
+
+// generate tar file and layer bootstrap, return if this blob is an empty blob
+func (t *Manager) generateBootstrap(tarReader io.Reader, storagePath, snapshotID string) (emptyBlob bool, err error) {
+	layerBootstrap := filepath.Join(storagePath, TarfsLayerBootstapName)
+	blob := filepath.Join(storagePath, "layer_"+snapshotID+"_"+TarfsBlobName)
+
+	tarFile, err := os.Create(blob)
+	if err != nil {
+		return false, err
+	}
+	defer tarFile.Close()
+
+	fifoName := filepath.Join(storagePath, "layer_"+snapshotID+"_"+"tar.fifo")
+	if err = syscall.Mkfifo(fifoName, 0644); err != nil {
+		return false, err
+	}
+	defer os.Remove(fifoName)
+
+	go func() {
+		fifoFile, err := os.OpenFile(fifoName, os.O_WRONLY, os.ModeNamedPipe)
+		if err != nil {
+			log.L.Warnf("can not open fifo file,  err %v", err)
+			return
+		}
+		defer fifoFile.Close()
+		if _, err := io.Copy(fifoFile, io.TeeReader(tarReader, tarFile)); err != nil {
+			log.L.Warnf("tar stream copy err %v", err)
+		}
+	}()
+
+	options := []string{
+		"create",
+		"--type", "tar-tarfs",
+		"--bootstrap", layerBootstrap,
+		"--blob-id", "layer_" + snapshotID + "_" + TarfsBlobName,
+		"--blob-dir", storagePath,
+		fifoName,
+	}
+	cmd := exec.Command(t.nydusImagePath, options...)
+	var errb, outb bytes.Buffer
+	cmd.Stderr = &errb
+	cmd.Stdout = &outb
+	log.L.Debugf("nydus image command %v", options)
+	err = cmd.Run()
+	if err != nil {
+		log.L.Warnf("nydus image exec failed, %s", errb.String())
+		return false, errors.Wrap(err, "converting tarfs layer failed")
+	}
+	log.L.Debugf("nydus image output %s", outb.String())
+	log.L.Debugf("nydus image err %s", errb.String())
+
+	// TODO need a more reliable way to check if this is an empty blob
+	if strings.Contains(outb.String(), "data blob size: 0x0") ||
+		strings.Contains(errb.String(), "data blob size: 0x0") {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (t *Manager) attachLoopdev(blob string) (*losetup.Device, error) {
+	// losetup.Attach() is not thread-safe hold lock here
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	dev, err := losetup.Attach(blob, 0, false)
+	return &dev, err
+}
+
+// download & uncompress oci blob, generate tarfs bootstrap
+func (t *Manager) blobProcess(ctx context.Context, snapshotID, ref string, manifest, layerDigest digest.Digest, storagePath string) (*losetup.Device, error) {
+	keyChain, err := auth.GetKeyChainByRef(ref, nil)
+	if err != nil {
+		return nil, err
+	}
+	remote := remote.New(keyChain, t.insecure)
+
+	handle := func() (bool, error) {
+		diffID, err := t.getBlobDiffID(ctx, remote, ref, manifest, layerDigest)
+		if err != nil {
+			return false, err
+		}
+
+		rc, err := t.getBlobStream(ctx, remote, ref, layerDigest)
+		if err != nil {
+			return false, err
+		}
+		defer rc.Close()
+
+		ds, err := compression.DecompressStream(rc)
+		if err != nil {
+			return false, errors.Wrap(err, "unpack stream")
+		}
+		defer ds.Close()
+
+		digester := digest.Canonical.Digester()
+		dr := io.TeeReader(ds, digester.Hash())
+
+		emptyBlob, err := t.generateBootstrap(dr, storagePath, snapshotID)
+		if err != nil {
+			return false, err
+		}
+		log.L.Infof("prepare tarfs Layer generateBootstrap done layer %s, digest %s", snapshotID, digester.Digest())
+		if digester.Digest() != diffID {
+			return false, errors.Errorf("diff id %s not match", diffID)
+		}
+		return emptyBlob, nil
+	}
+
+	var emptyBlob bool
+	emptyBlob, err = handle()
+	if err != nil && remote.RetryWithPlainHTTP(ref, err) {
+		emptyBlob, err = handle()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// for empty blob do not need a loop device
+	if emptyBlob {
+		return nil, ErrEmptyBlob
+	}
+
+	return t.attachLoopdev(filepath.Join(storagePath, "layer_"+snapshotID+"_"+TarfsBlobName))
+}
+
+func (t *Manager) PrepareLayer(snapshotID, ref string, manifest, layerDigest digest.Digest, storagePath string) error {
+	t.mutex.Lock()
+	if _, ok := t.snapshotMap[snapshotID]; ok {
+		t.mutex.Unlock()
+		return errors.Errorf("snapshot %s already prapared", snapshotID)
+	}
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	defer wg.Done()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	t.snapshotMap[snapshotID] = &snapshotStatus{
+		status: TarfsStatusFormatting,
+		wg:     wg,
+		cancel: cancel,
+	}
+	t.mutex.Unlock()
+
+	loopdev, err := t.blobProcess(ctx, snapshotID, ref, manifest, layerDigest, storagePath)
+
+	st, err1 := t.getSnapshotStatus(snapshotID)
+	if err1 != nil {
+		return errors.Errorf("can not found snapshot status after prepare")
+	}
+	if err != nil {
+		if errors.Is(err, ErrEmptyBlob) {
+			st.status = TarfsStatusReady
+			err = nil
+		} else {
+			st.status = TarfsStatusFailed
+		}
+	} else {
+		st.status = TarfsStatusReady
+		st.layerBsLoopdev = loopdev
+	}
+	return err
+}
+
+func (t *Manager) MergeLayers(s storage.Snapshot, storageLocater func(string) string) error {
+	mergedBootstrap := filepath.Join(storageLocater(s.ParentIDs[0]), TarfsMeragedBootstapName)
+	if _, err := os.Stat(mergedBootstrap); err == nil {
+		log.L.Infof("tarfs snapshot %s already has merged bootstrap %s", s.ParentIDs[0], mergedBootstrap)
+		return nil
+	}
+
+	var mountOpts string
+	bootstraps := []string{}
+	// When merging bootstrap, we need to arrange layer bootstrap in order from low to high
+	for idx := len(s.ParentIDs) - 1; idx >= 0; idx-- {
+		snapshotID := s.ParentIDs[idx]
+		err := t.waitLayerFormating(snapshotID)
+		if err != nil {
+			return errors.Wrapf(err, "wait layer formating err")
+		}
+
+		st, err := t.getSnapshotStatus(snapshotID)
+		if err != nil {
+			return err
+		}
+		if st.status != TarfsStatusReady {
+			return errors.Errorf("snapshot %s tarfs format error %d", snapshotID, st.status)
+		}
+		bootstraps = append(bootstraps, filepath.Join(storageLocater(snapshotID), TarfsLayerBootstapName))
+
+		// mount opt skip empty blob
+		if st.layerBsLoopdev != nil {
+			mountOpts += "device=" + st.layerBsLoopdev.Path() + ","
+		}
+	}
+
+	options := []string{
+		"merge",
+		"--bootstrap", mergedBootstrap,
+	}
+	options = append(options, bootstraps...)
+	cmd := exec.Command(t.nydusImagePath, options...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	log.L.Debugf("nydus image command %v", options)
+	err := cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "merging tarfs layers")
+	}
+
+	loopdev, err := t.attachLoopdev(mergedBootstrap)
+	if err != nil {
+		return errors.Wrap(err, "attach bootstrap to loop error")
+	}
+
+	st, err := t.getSnapshotStatus(s.ParentIDs[0])
+	if err != nil {
+		return errors.Errorf("snapshot %s not found", s.ParentIDs[0])
+	}
+	st.mergedBsLoopdev = loopdev
+	st.erofsMountOpts = mountOpts
+
+	return nil
+}
+
+func (t *Manager) MountTarErofs(snapshotID string, mountPoint string) error {
+	var devName string
+
+	st, err := t.getSnapshotStatus(snapshotID)
+	if err != nil {
+		return err
+	}
+	if len(st.erofsMountPoint) > 0 {
+		if st.erofsMountPoint == mountPoint {
+			log.L.Debugf("erofs tarfs %s already mounted", mountPoint)
+			return nil
+		}
+		return errors.Errorf("erofs snapshot %s already mounted at %s", snapshotID, st.erofsMountPoint)
+	}
+
+	if err = os.MkdirAll(mountPoint, 0755); err != nil {
+		return errors.Wrapf(err, "failed to create tarfs mount dir %s", mountPoint)
+	}
+
+	if st.mergedBsLoopdev != nil {
+		devName = st.mergedBsLoopdev.Path()
+	} else {
+		return errors.Errorf("snapshot %s not found boostrap loopdev error %d", snapshotID, st.status)
+	}
+
+	err = unix.Mount(devName, mountPoint, "erofs", 0, st.erofsMountOpts)
+	if err != nil {
+		return errors.Wrapf(err, "mount erofs at %s with opts %s", mountPoint, st.erofsMountOpts)
+	}
+	st.erofsMountPoint = mountPoint
+	return nil
+}
+
+func (t *Manager) UmountTarErofs(snapshotID string) error {
+	st, err := t.getSnapshotStatus(snapshotID)
+	if err != nil {
+		return errors.Wrapf(err, "umount a tarfs snapshot %s which is already removed", snapshotID)
+	}
+
+	if len(st.erofsMountPoint) > 0 {
+		err := unix.Unmount(st.erofsMountPoint, 0)
+		if err != nil {
+			return errors.Wrapf(err, "umount erofs tarfs %s failed", st.erofsMountPoint)
+		}
+	}
+	st.erofsMountPoint = ""
+	return nil
+}
+
+func (t *Manager) waitLayerFormating(snapshotID string) error {
+	log.L.Debugf("wait for tarfs formating snapshot %s", snapshotID)
+	st, err := t.getSnapshotStatus(snapshotID)
+	if err != nil {
+		return err
+	}
+	st.wg.Wait()
+	return nil
+}
+
+// check if a snapshot is tarfs layer and if mounted a erofs tarfs
+func (t *Manager) CheckTarfsLayer(snapshotID string, merged bool) bool {
+	st, err := t.getSnapshotStatus(snapshotID)
+	if err != nil {
+		return false
+	}
+	if merged && len(st.erofsMountPoint) == 0 {
+		return false
+	}
+	return true
+}
+
+func (t *Manager) DetachLayer(snapshotID string) error {
+	st, err := t.getSnapshotStatus(snapshotID)
+	if err != nil {
+		return os.ErrNotExist
+	}
+
+	if len(st.erofsMountPoint) > 0 {
+		err := unix.Unmount(st.erofsMountPoint, 0)
+		if err != nil {
+			return errors.Wrapf(err, "umount erofs tarfs %s failed", st.erofsMountPoint)
+		}
+	}
+
+	if st.mergedBsLoopdev != nil {
+		err := st.mergedBsLoopdev.Detach()
+		if err != nil {
+			return errors.Wrapf(err, "detach merged bootstrap loopdev for tarfs snapshot %s failed", snapshotID)
+		}
+	}
+
+	if st.layerBsLoopdev != nil {
+		err := st.layerBsLoopdev.Detach()
+		if err != nil {
+			return errors.Wrapf(err, "detach layer bootstrap loopdev for tarfs snapshot %s failed", snapshotID)
+		}
+	}
+	st.cancel()
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	delete(t.snapshotMap, snapshotID)
+	return nil
+}
+
+func (t *Manager) getSnapshotStatus(snapshotID string) (*snapshotStatus, error) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	st, ok := t.snapshotMap[snapshotID]
+	if ok {
+		return st, nil
+	}
+	return nil, errors.Errorf("not found snapshot %s", snapshotID)
+}
+
+func (t *Manager) CheckTarfsHintAnnotation(ctx context.Context, ref string, manifest digest.Digest) (bool, error) {
+	if !t.checkTarfsHint {
+		return true, nil
+	}
+
+	keyChain, err := auth.GetKeyChainByRef(ref, nil)
+	if err != nil {
+		return false, err
+	}
+	remote := remote.New(keyChain, t.insecure)
+
+	handle := func() (bool, error) {
+		if tarfsHint, ok := t.tarfsHintCache.Get(ref); ok {
+			return tarfsHint.(bool), nil
+		}
+
+		if _, err, _ := t.sg.Do(ref, func() (interface{}, error) {
+			err := t.fetchImageInfo(ctx, remote, ref, manifest)
+			return nil, err
+		}); err != nil {
+			return false, err
+		}
+
+		if tarfsHint, ok := t.tarfsHintCache.Get(ref); ok {
+			return tarfsHint.(bool), nil
+		}
+
+		return false, errors.Errorf("get tarfs hint annotation failed")
+	}
+
+	tarfsHint, err := handle()
+	if err != nil && remote.RetryWithPlainHTTP(ref, err) {
+		return handle()
+	}
+	return tarfsHint, err
+}

--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -533,10 +533,12 @@ func (t *Manager) UmountTarErofs(snapshotID string) error {
 }
 
 func (t *Manager) waitLayerReady(snapshotID string) error {
-	log.L.Debugf("wait tarfs conversion task for snapshot %s", snapshotID)
 	st, err := t.getSnapshotStatus(snapshotID, false)
 	if err != nil {
 		return err
+	}
+	if st.status != TarfsStatusReady {
+		log.L.Debugf("wait tarfs conversion task for snapshot %s", snapshotID)
 	}
 	st.wg.Wait()
 	return nil
@@ -651,7 +653,7 @@ func (t *Manager) CheckTarfsHintAnnotation(ctx context.Context, ref string, mani
 }
 
 func (t *Manager) GetConcurrentLimiter(ref string) *semaphore.Weighted {
-	if t.maxConcurrentProcess == 0 {
+	if t.maxConcurrentProcess <= 0 {
 		return nil
 	}
 

--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -302,7 +302,7 @@ func (t *Manager) getImageBlobInfo(metaFilePath string) (string, error) {
 		return "", errors.Wrap(err, "converting OCIv1 layer blob to tarfs")
 	}
 
-	return string(outb.Bytes()), nil
+	return outb.String(), nil
 }
 
 // download & uncompress an oci/docker blob, and then generate the tarfs bootstrap

--- a/snapshot/mount_option.go
+++ b/snapshot/mount_option.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package snapshot
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots/storage"
+	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/containerd/nydus-snapshotter/pkg/layout"
+	"github.com/pkg/errors"
+)
+
+type ExtraOption struct {
+	Source      string `json:"source"`
+	Config      string `json:"config"`
+	Snapshotdir string `json:"snapshotdir"`
+	Version     string `json:"fs_version"`
+}
+
+func (o *snapshotter) remoteMountWithExtraOptions(ctx context.Context, s storage.Snapshot, id string, overlayOptions []string) ([]mount.Mount, error) {
+	source, err := o.fs.BootstrapFile(id)
+	if err != nil {
+		return nil, err
+	}
+
+	instance := daemon.RafsSet.Get(id)
+	daemon, err := o.fs.GetDaemonByID(instance.DaemonID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get daemon with ID %s", instance.DaemonID)
+	}
+
+	var c daemonconfig.DaemonConfig
+	if daemon.IsSharedDaemon() {
+		c, err = daemonconfig.NewDaemonConfig(daemon.States.FsDriver, daemon.ConfigFile(instance.SnapshotID))
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to load instance configuration %s",
+				daemon.ConfigFile(instance.SnapshotID))
+		}
+	} else {
+		c = daemon.Config
+	}
+	configContent, err := c.DumpString()
+	if err != nil {
+		return nil, errors.Wrapf(err, "remoteMounts: failed to marshal config")
+	}
+
+	// get version from bootstrap
+	f, err := os.Open(source)
+	if err != nil {
+		return nil, errors.Wrapf(err, "remoteMounts: check bootstrap version: failed to open bootstrap")
+	}
+	defer f.Close()
+	header := make([]byte, 4096)
+	sz, err := f.Read(header)
+	if err != nil {
+		return nil, errors.Wrapf(err, "remoteMounts: check bootstrap version: failed to read bootstrap")
+	}
+	version, err := layout.DetectFsVersion(header[0:sz])
+	if err != nil {
+		return nil, errors.Wrapf(err, "remoteMounts: failed to detect filesystem version")
+	}
+
+	// when enable nydus-overlayfs, return unified mount slice for runc and kata
+	extraOption := &ExtraOption{
+		Source:      source,
+		Config:      configContent,
+		Snapshotdir: o.snapshotDir(s.ID),
+		Version:     version,
+	}
+	no, err := json.Marshal(extraOption)
+	if err != nil {
+		return nil, errors.Wrapf(err, "remoteMounts: failed to marshal NydusOption")
+	}
+	// XXX: Log options without extraoptions as it might contain secrets.
+	log.G(ctx).Debugf("fuse.nydus-overlayfs mount options %v", overlayOptions)
+	// base64 to filter easily in `nydus-overlayfs`
+	opt := fmt.Sprintf("extraoption=%s", base64.StdEncoding.EncodeToString(no))
+	overlayOptions = append(overlayOptions, opt)
+
+	return []mount.Mount{
+		{
+			Type:    "fuse.nydus-overlayfs",
+			Source:  "overlay",
+			Options: overlayOptions,
+		},
+	}, nil
+}

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -58,9 +58,9 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 	}
 
 	// OCI image is also marked with "containerd.io/snapshot.ref" by Containerd
-	target, is_ro_layer := labels[label.TargetSnapshotRef]
+	target, isRoLayer := labels[label.TargetSnapshotRef]
 
-	if is_ro_layer {
+	if isRoLayer {
 		// Containerd won't consume mount slice for below snapshots
 		switch {
 		case label.IsNydusMetaLayer(labels):

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -41,7 +41,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 	remoteHandler := func(id string, labels map[string]string) func() (bool, []mount.Mount, error) {
 		return func() (bool, []mount.Mount, error) {
 			logger.Debugf("Prepare remote snapshot %s", id)
-			if err := sn.prepareRemoteSnapshot(id, labels, s); err != nil {
+			if err := sn.fs.Mount(id, labels, &s); err != nil {
 				return false, nil, err
 			}
 
@@ -51,7 +51,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 			}
 
 			logger.Infof("Nydus remote snapshot %s is ready", id)
-			mounts, err := sn.remoteMounts(ctx, s, id)
+			mounts, err := sn.remoteMounts(ctx, labels, s, id)
 			return false, mounts, err
 		}
 	}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -799,16 +799,19 @@ func overlayMount(options []string) []mount.Mount {
 // `s` and `id` can represent a different layer, it's useful when View an image
 func (o *snapshotter) remoteMounts(ctx context.Context, labels map[string]string, s storage.Snapshot, id string) ([]mount.Mount, error) {
 	var overlayOptions []string
-	lowerPaths := make([]string, 0, 8)
 	if s.Kind == snapshots.KindActive {
 		overlayOptions = append(overlayOptions,
 			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
 			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
 		)
+		if _, ok := labels[label.OverlayfsVolatileOpt]; ok {
+			overlayOptions = append(overlayOptions, "volatile")
+		}
 	} else if len(s.ParentIDs) == 1 {
 		return bindMount(o.upperPath(s.ParentIDs[0]), "ro"), nil
 	}
 
+	lowerPaths := make([]string, 0, 8)
 	lowerPathNydus, err := o.lowerPath(id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to locate overlay lowerdir")

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -418,7 +418,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 	}
 
 	if needRemoteMounts {
-		return o.remoteMounts(ctx, *snap, metaSnapshotID)
+		return o.remoteMounts(ctx, info.Labels, *snap, metaSnapshotID)
 	}
 
 	return o.mounts(ctx, info.Labels, *snap)
@@ -516,7 +516,7 @@ func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 	log.L.Infof("[View] snapshot with key %s parent %s", key, parent)
 
 	if needRemoteMounts {
-		return o.remoteMounts(ctx, s, metaSnapshotID)
+		return o.remoteMounts(ctx, base.Labels, s, metaSnapshotID)
 	}
 
 	return o.mounts(ctx, base.Labels, s)
@@ -795,13 +795,9 @@ func overlayMount(options []string) []mount.Mount {
 	}
 }
 
-func (o *snapshotter) prepareRemoteSnapshot(id string, labels map[string]string, s storage.Snapshot) error {
-	return o.fs.Mount(id, labels, &s)
-}
-
 // `s` is the upmost snapshot and `id` refers to the nydus meta snapshot
 // `s` and `id` can represent a different layer, it's useful when View an image
-func (o *snapshotter) remoteMounts(ctx context.Context, s storage.Snapshot, id string) ([]mount.Mount, error) {
+func (o *snapshotter) remoteMounts(ctx context.Context, labels map[string]string, s storage.Snapshot, id string) ([]mount.Mount, error) {
 	var overlayOptions []string
 	lowerPaths := make([]string, 0, 8)
 	if s.Kind == snapshots.KindActive {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -53,12 +53,11 @@ import (
 var _ snapshots.Snapshotter = &snapshotter{}
 
 type snapshotter struct {
-	root       string
-	nydusdPath string
-	// Storing snapshots' state, parentage and other metadata
-	ms                   *storage.MetaStore
+	root                 string
+	nydusdPath           string
+	ms                   *storage.MetaStore // Storing snapshots' state, parentage and other metadata
 	fs                   *filesystem.Filesystem
-	manager              *mgr.Manager
+	cgroupManager        *cgroup.Manager
 	enableNydusOverlayFS bool
 	syncRemove           bool
 	cleanupOnClose       bool
@@ -102,23 +101,61 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 		}
 	}
 
-	manager, err := mgr.NewManager(mgr.Opt{
-		NydusdBinaryPath: cfg.DaemonConfig.NydusdPath,
+	blockdevManager, err := mgr.NewManager(mgr.Opt{
+		NydusdBinaryPath: "",
 		Database:         db,
 		CacheDir:         cfg.CacheManagerConfig.CacheDir,
 		RootDir:          cfg.Root,
 		RecoverPolicy:    rp,
-		FsDriver:         config.GetFsDriver(),
+		FsDriver:         config.FsDriverBlockdev,
 		DaemonConfig:     daemonConfig,
 		CgroupMgr:        cgroupMgr,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "create daemons manager")
+		return nil, errors.Wrap(err, "create blockdevice manager")
+	}
+
+	var fscacheManager *mgr.Manager
+	if config.GetFsDriver() == config.FsDriverFscache {
+		mgr, err := mgr.NewManager(mgr.Opt{
+			NydusdBinaryPath: cfg.DaemonConfig.NydusdPath,
+			Database:         db,
+			CacheDir:         cfg.CacheManagerConfig.CacheDir,
+			RootDir:          cfg.Root,
+			RecoverPolicy:    rp,
+			FsDriver:         config.FsDriverFscache,
+			DaemonConfig:     daemonConfig,
+			CgroupMgr:        cgroupMgr,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "create fscache manager")
+		}
+		fscacheManager = mgr
+	}
+
+	var fusedevManager *mgr.Manager
+	if config.GetFsDriver() == config.FsDriverFusedev {
+		mgr, err := mgr.NewManager(mgr.Opt{
+			NydusdBinaryPath: cfg.DaemonConfig.NydusdPath,
+			Database:         db,
+			CacheDir:         cfg.CacheManagerConfig.CacheDir,
+			RootDir:          cfg.Root,
+			RecoverPolicy:    rp,
+			FsDriver:         config.FsDriverFusedev,
+			DaemonConfig:     daemonConfig,
+			CgroupMgr:        cgroupMgr,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "create fusedev manager")
+		}
+		fusedevManager = mgr
 	}
 
 	metricServer, err := metrics.NewServer(
 		ctx,
-		metrics.WithProcessManager(manager),
+		metrics.WithProcessManager(blockdevManager),
+		metrics.WithProcessManager(fscacheManager),
+		metrics.WithProcessManager(fusedevManager),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "create metrics server")
@@ -139,7 +176,9 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 
 	opts := []filesystem.NewFSOpt{
-		filesystem.WithManager(manager),
+		filesystem.WithManager(blockdevManager),
+		filesystem.WithManager(fscacheManager),
+		filesystem.WithManager(fusedevManager),
 		filesystem.WithNydusImageBinaryPath(cfg.DaemonConfig.NydusdPath),
 		filesystem.WithVerifier(verifier),
 		filesystem.WithRootMountpoint(config.GetRootMountpoint()),
@@ -169,7 +208,9 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	if cfg.Experimental.EnableTarfs {
 		// FIXME: get the insecure option from nydusd config.
 		_, backendConfig := daemonConfig.StorageBackend()
-		tarfsMgr := tarfs.NewManager(backendConfig.SkipVerify, cfg.Experimental.TarfsHint, cfg.DaemonConfig.NydusImagePath, int64(cfg.Experimental.TarfsMaxConcurrentProc))
+		tarfsMgr := tarfs.NewManager(backendConfig.SkipVerify, cfg.Experimental.TarfsHint,
+			cacheConfig.CacheDir, cfg.DaemonConfig.NydusImagePath,
+			int64(cfg.Experimental.TarfsMaxConcurrentProc))
 		opts = append(opts, filesystem.WithTarfsManager(tarfsMgr))
 	}
 
@@ -179,7 +220,16 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 
 	if config.IsSystemControllerEnabled() {
-		managers := []*mgr.Manager{manager}
+		managers := []*mgr.Manager{}
+		if blockdevManager != nil {
+			managers = append(managers, blockdevManager)
+		}
+		if fscacheManager != nil {
+			managers = append(managers, fscacheManager)
+		}
+		if fusedevManager != nil {
+			managers = append(managers, fusedevManager)
+		}
 		systemController, err := system.NewSystemController(nydusFs, managers, config.SystemControllerAddress())
 		if err != nil {
 			return nil, errors.Wrap(err, "create system controller")
@@ -232,7 +282,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 		ms:                   ms,
 		syncRemove:           syncRemove,
 		fs:                   nydusFs,
-		manager:              manager,
+		cgroupManager:        cgroupMgr,
 		enableNydusOverlayFS: cfg.SnapshotsConfig.EnableNydusOverlayFS,
 		cleanupOnClose:       cfg.CleanupOnClose,
 	}, nil
@@ -283,15 +333,17 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, e
 		usage = snapshots.Usage(du)
 	}
 
-	// Blob layers are all committed snapshots
-	if info.Kind == snapshots.KindCommitted && label.IsNydusDataLayer(info.Labels) {
-		blobDigest := info.Labels[snpkg.TargetLayerDigestLabel]
-		// Try to get nydus meta layer/snapshot disk usage
-		cacheUsage, err := o.fs.CacheUsage(ctx, blobDigest)
-		if err != nil {
-			return snapshots.Usage{}, errors.Wrapf(err, "try to get snapshot %s nydus disk usage", id)
+	// Caculate disk space usage under cacheDir of committed snapshots.
+	if info.Kind == snapshots.KindCommitted &&
+		(label.IsNydusDataLayer(info.Labels) || label.IsTarfsDataLayer(info.Labels)) {
+		if blobDigest, ok := info.Labels[snpkg.TargetLayerDigestLabel]; ok {
+			// Try to get nydus meta layer/snapshot disk usage
+			cacheUsage, err := o.fs.CacheUsage(ctx, blobDigest)
+			if err != nil {
+				return snapshots.Usage{}, errors.Wrapf(err, "try to get snapshot %s nydus disk usage", id)
+			}
+			usage.Add(cacheUsage)
 		}
-		usage.Add(cacheUsage)
 	}
 
 	return usage, nil
@@ -330,6 +382,9 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 			needRemoteMounts = true
 			metaSnapshotID = id
 		}
+	} else if label.IsTarfsDataLayer(info.Labels) {
+		needRemoteMounts = true
+		metaSnapshotID = id
 	}
 
 	if info.Kind == snapshots.KindActive && info.Parent != "" {
@@ -341,8 +396,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 				}
 				needRemoteMounts = true
 				metaSnapshotID = pID
-			}
-			if o.fs.TarfsEnabled() && o.fs.IsMergedTarfsLayer(pID) {
+			} else if o.fs.TarfsEnabled() && o.fs.IsMountedTarfsLayer(pID) {
 				needRemoteMounts = true
 				metaSnapshotID = pID
 			}
@@ -351,7 +405,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 		}
 	}
 
-	if o.fs.ReferrerDetectEnabled() {
+	if o.fs.ReferrerDetectEnabled() && !needRemoteMounts {
 		if id, _, err := o.findReferrerLayer(ctx, key); err == nil {
 			needRemoteMounts = true
 			metaSnapshotID = id
@@ -422,7 +476,7 @@ func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 		// Nydusd might not be running. We should run nydusd to reflect the rootfs.
 		if err = o.fs.WaitUntilReady(pID); err != nil {
 			if errors.Is(err, errdefs.ErrNotFound) {
-				if err := o.fs.Mount(pID, pInfo.Labels, false); err != nil {
+				if err := o.fs.Mount(pID, pInfo.Labels, nil); err != nil {
 					return nil, errors.Wrapf(err, "mount rafs, instance id %s", pID)
 				}
 
@@ -440,25 +494,23 @@ func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 		return nil, errors.New("only can view nydus topmost layer")
 	}
 	// Otherwise, it is OCI snapshots
+
 	base, s, err := o.createSnapshot(ctx, snapshots.KindView, key, parent, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	if o.fs.TarfsEnabled() {
-		if o.fs.IsTarfsLayer(pID) {
-			if !o.fs.IsMergedTarfsLayer(pID) {
-				if err := o.fs.MergeTarfsLayers(s, func(id string) string { return o.upperPath(id) }); err != nil {
-					return nil, errors.Wrapf(err, "tarfs merge fail %s", pID)
-				}
-
-				if err := o.fs.Mount(pID, pInfo.Labels, true); err != nil {
-					return nil, errors.Wrapf(err, "mount tarfs, snapshot id %s", pID)
-				}
+	if o.fs.TarfsEnabled() && label.IsTarfsDataLayer(pInfo.Labels) {
+		if !o.fs.IsMountedTarfsLayer(pID) {
+			if err := o.fs.MergeTarfsLayers(s, func(id string) string { return o.upperPath(id) }); err != nil {
+				return nil, errors.Wrapf(err, "tarfs merge fail %s", pID)
 			}
-			needRemoteMounts = true
-			metaSnapshotID = pID
+			if err := o.fs.Mount(pID, pInfo.Labels, &s); err != nil {
+				return nil, errors.Wrapf(err, "mount tarfs, snapshot id %s", pID)
+			}
 		}
+		needRemoteMounts = true
+		metaSnapshotID = pID
 	}
 
 	log.L.Infof("[View] snapshot with key %s parent %s", key, parent)
@@ -487,21 +539,18 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 	}()
 
 	// grab the existing id
-	id, info, _, err := storage.GetInfo(ctx, key)
+	id, _, _, err := storage.GetInfo(ctx, key)
 	if err != nil {
 		return err
 	}
 
 	log.L.Infof("[Commit] snapshot with key %q snapshot id %s", key, id)
 
-	var usage fs.Usage
-	// For OCI compatibility, we calculate disk usage and commit the usage to DB.
-	// Nydus disk usage calculation will be delayed until containerd queries.
-	if !label.IsNydusMetaLayer(info.Labels) && !label.IsNydusDataLayer(info.Labels) {
-		usage, err = fs.DiskUsage(ctx, o.upperPath(id))
-		if err != nil {
-			return err
-		}
+	// For OCI compatibility, we calculate disk usage of the snapshotDir and commit the usage to DB.
+	// Nydus disk usage under the cacheDir will be delayed until containerd queries.
+	usage, err := fs.DiskUsage(ctx, o.upperPath(id))
+	if err != nil {
+		return err
 	}
 
 	if _, err = storage.CommitActive(ctx, key, name, snapshots.Usage(usage), opts...); err != nil {
@@ -544,6 +593,8 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 
 	if label.IsNydusMetaLayer(info.Labels) {
 		log.L.Infof("[Remove] nydus meta snapshot with key %s snapshot id %s", key, id)
+	} else if label.IsTarfsDataLayer(info.Labels) {
+		log.L.Infof("[Remove] nydus tarfs snapshot with key %s snapshot id %s", key, id)
 	}
 
 	if info.Kind == snapshots.KindCommitted {
@@ -608,8 +659,8 @@ func (o *snapshotter) Close() error {
 
 	o.fs.TryStopSharedDaemon()
 
-	if o.manager.CgroupMgr != nil {
-		if err := o.manager.CgroupMgr.Delete(); err != nil {
+	if o.cgroupManager != nil {
+		if err := o.cgroupManager.Delete(); err != nil {
 			log.L.Errorf("failed to destroy cgroup, err %v", err)
 		}
 	}
@@ -744,8 +795,8 @@ func overlayMount(options []string) []mount.Mount {
 	}
 }
 
-func (o *snapshotter) prepareRemoteSnapshot(id string, labels map[string]string, isTarfs bool) error {
-	return o.fs.Mount(id, labels, isTarfs)
+func (o *snapshotter) prepareRemoteSnapshot(id string, labels map[string]string, s storage.Snapshot) error {
+	return o.fs.Mount(id, labels, &s)
 }
 
 // `s` is the upmost snapshot and `id` refers to the nydus meta snapshot

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -9,8 +9,6 @@ package snapshot
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,9 +29,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
 	"github.com/containerd/nydus-snapshotter/pkg/cgroup"
 	v2 "github.com/containerd/nydus-snapshotter/pkg/cgroup/v2"
-	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
-	"github.com/containerd/nydus-snapshotter/pkg/layout"
 	mgr "github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
@@ -856,82 +852,6 @@ func (o *snapshotter) remoteMounts(ctx context.Context, labels map[string]string
 	}
 
 	return overlayMount(overlayOptions), nil
-}
-
-type ExtraOption struct {
-	Source      string `json:"source"`
-	Config      string `json:"config"`
-	Snapshotdir string `json:"snapshotdir"`
-	Version     string `json:"fs_version"`
-}
-
-func (o *snapshotter) remoteMountWithExtraOptions(ctx context.Context, s storage.Snapshot, id string, overlayOptions []string) ([]mount.Mount, error) {
-	source, err := o.fs.BootstrapFile(id)
-	if err != nil {
-		return nil, err
-	}
-
-	instance := daemon.RafsSet.Get(id)
-	daemon, err := o.fs.GetDaemonByID(instance.DaemonID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "get daemon with ID %s", instance.DaemonID)
-	}
-
-	var c daemonconfig.DaemonConfig
-	if daemon.IsSharedDaemon() {
-		c, err = daemonconfig.NewDaemonConfig(daemon.States.FsDriver, daemon.ConfigFile(instance.SnapshotID))
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to load instance configuration %s",
-				daemon.ConfigFile(instance.SnapshotID))
-		}
-	} else {
-		c = daemon.Config
-	}
-	configContent, err := c.DumpString()
-	if err != nil {
-		return nil, errors.Wrapf(err, "remoteMounts: failed to marshal config")
-	}
-
-	// get version from bootstrap
-	f, err := os.Open(source)
-	if err != nil {
-		return nil, errors.Wrapf(err, "remoteMounts: check bootstrap version: failed to open bootstrap")
-	}
-	defer f.Close()
-	header := make([]byte, 4096)
-	sz, err := f.Read(header)
-	if err != nil {
-		return nil, errors.Wrapf(err, "remoteMounts: check bootstrap version: failed to read bootstrap")
-	}
-	version, err := layout.DetectFsVersion(header[0:sz])
-	if err != nil {
-		return nil, errors.Wrapf(err, "remoteMounts: failed to detect filesystem version")
-	}
-
-	// when enable nydus-overlayfs, return unified mount slice for runc and kata
-	extraOption := &ExtraOption{
-		Source:      source,
-		Config:      configContent,
-		Snapshotdir: o.snapshotDir(s.ID),
-		Version:     version,
-	}
-	no, err := json.Marshal(extraOption)
-	if err != nil {
-		return nil, errors.Wrapf(err, "remoteMounts: failed to marshal NydusOption")
-	}
-	// XXX: Log options without extraoptions as it might contain secrets.
-	log.G(ctx).Debugf("fuse.nydus-overlayfs mount options %v", overlayOptions)
-	// base64 to filter easily in `nydus-overlayfs`
-	opt := fmt.Sprintf("extraoption=%s", base64.StdEncoding.EncodeToString(no))
-	overlayOptions = append(overlayOptions, opt)
-
-	return []mount.Mount{
-		{
-			Type:    "fuse.nydus-overlayfs",
-			Source:  "overlay",
-			Options: overlayOptions,
-		},
-	}, nil
 }
 
 func (o *snapshotter) mounts(ctx context.Context, labels map[string]string, s storage.Snapshot) ([]mount.Mount, error) {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -169,7 +169,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	if cfg.Experimental.EnableTarfs {
 		// FIXME: get the insecure option from nydusd config.
 		_, backendConfig := daemonConfig.StorageBackend()
-		tarfsMgr := tarfs.NewManager(backendConfig.SkipVerify, cfg.Experimental.TarfsHint, cfg.DaemonConfig.NydusImagePath)
+		tarfsMgr := tarfs.NewManager(backendConfig.SkipVerify, cfg.Experimental.TarfsHint, cfg.DaemonConfig.NydusImagePath, int64(cfg.Experimental.TarfsMaxConcurrentProc))
 		opts = append(opts, filesystem.WithTarfsManager(tarfsMgr))
 	}
 


### PR DESCRIPTION
This PR is based on https://github.com/containerd/nydus-snapshotter/pull/497 , and improve tarfs by:
- move loopdev setup from Prepare()/Merge() into Mount(), preparing for support of nodev mode in addition to blockdev.
- store tar file in the global cache directory, mount tarfs at "mnt" instead of "tarfs", to keep consistence with fusedev/fscache drivers.
- use tempfile/rename mechanism to easy error recover
- use lock to avoid some possible race conditions
- use mode 0750 instead of 0755 for new directories
-  associate a Manager with filesystems managed by blockdev
