### PR TITLE
Adding an interface to the system socket to help nydusd obtain config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,7 @@ type Experimental struct {
 	EnableStargz         bool        `toml:"enable_stargz"`
 	EnableReferrerDetect bool        `toml:"enable_referrer_detect"`
 	TarfsConfig          TarfsConfig `toml:"tarfs"`
+	EnableBackendSource  bool        `toml:"enable_backend_source"`
 }
 
 type TarfsConfig struct {

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -221,11 +221,14 @@ func serializeWithSecretFilter(obj interface{}) map[string]interface{} {
 			continue
 		}
 
-		if fieldType.Type.Kind() == reflect.Struct {
+		switch fieldType.Type.Kind() {
+		case reflect.Struct:
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Interface())
-		} else if fieldType.Type.Kind() == reflect.Ptr {
+		case reflect.Ptr:
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Elem().Interface())
-		} else {
+		case reflect.Invalid: 
+			
+		default:
 			result[jsonTags[0]] = field.Interface()
 		}
 	}

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -221,7 +221,7 @@ func serializeWithSecretFilter(obj interface{}) map[string]interface{} {
 			continue
 		}
 
-		//nolint:staticcheck
+		//nolint:exhaustive
 		switch fieldType.Type.Kind() {
 		case reflect.Struct:
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Interface())

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -221,61 +221,12 @@ func serializeWithSecretFilter(obj interface{}) map[string]interface{} {
 			continue
 		}
 
+		//nolint:staticcheck
 		switch fieldType.Type.Kind() {
 		case reflect.Struct:
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Interface())
 		case reflect.Ptr:
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Elem().Interface())
-		case reflect.Bool:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Int:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Int8:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Int16:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Int32:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Int64:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Uint:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Uint8:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Uint16:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Uint32:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Uint64:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Uintptr:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Float32:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Float64:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Complex64:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Complex128:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Array:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Chan:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Func:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Interface:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Map:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Slice:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.String:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.UnsafePointer:
-			result[jsonTags[0]] = field.Interface()
-		case reflect.Invalid:
-			
 		default:
 			result[jsonTags[0]] = field.Interface()
 		}

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -221,12 +221,11 @@ func serializeWithSecretFilter(obj interface{}) map[string]interface{} {
 			continue
 		}
 
-		switch fieldType.Type.Kind() {
-		case reflect.Struct:
+		if fieldType.Type.Kind() == reflect.Struct {
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Interface())
-		case reflect.Ptr:
+		} else if fieldType.Type.Kind() == reflect.Ptr {
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Elem().Interface())
-		default:
+		} else {
 			result[jsonTags[0]] = field.Interface()
 		}
 	}

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -226,7 +226,55 @@ func serializeWithSecretFilter(obj interface{}) map[string]interface{} {
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Interface())
 		case reflect.Ptr:
 			result[jsonTags[0]] = serializeWithSecretFilter(field.Elem().Interface())
-		case reflect.Invalid: 
+		case reflect.Bool:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Int:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Int8:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Int16:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Int32:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Int64:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Uint:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Uint8:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Uint16:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Uint32:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Uint64:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Uintptr:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Float32:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Float64:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Complex64:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Complex128:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Array:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Chan:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Func:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Interface:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Map:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Slice:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.String:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.UnsafePointer:
+			result[jsonTags[0]] = field.Interface()
+		case reflect.Invalid:
 			
 		default:
 			result[jsonTags[0]] = field.Interface()

--- a/config/daemonconfig/daemonconfig_test.go
+++ b/config/daemonconfig/daemonconfig_test.go
@@ -62,3 +62,64 @@ func TestLoadConfig(t *testing.T) {
 	require.Equal(t, cfg.Device.Backend.Config.SkipVerify, true)
 	require.Equal(t, cfg.Device.Backend.Config.Proxy.CheckInterval, 5)
 }
+
+func TestSerializeWithSecretFilter(t *testing.T) {
+	buf := []byte(`{
+  "device": {
+    "backend": {
+      "type": "registry",
+      "config": {
+        "skip_verify": true,
+        "host": "acr-nydus-registry-vpc.cn-hangzhou.cr.aliyuncs.com",
+        "repo": "test/myserver",
+        "auth": "token_token",
+        "blob_url_scheme": "http",
+        "proxy": {
+          "url": "http://p2p-proxy:65001",
+          "fallback": true,
+          "ping_url": "http://p2p-proxy:40901/server/ping",
+          "check_interval": 5
+        },
+        "timeout": 5,
+        "connect_timeout": 5,
+        "retry_limit": 0
+      }
+    },
+    "cache": {
+      "type": "blobcache",
+      "config": {
+        "work_dir": "/cache"
+      }
+    }
+  },
+  "mode": "direct",
+  "digest_validate": true,
+  "iostats_files": true,
+  "enable_xattr": true,
+  "fs_prefetch": {
+    "enable": true,
+    "threads_count": 10,
+    "merging_size": 131072
+  }
+}`)
+	var cfg FuseDaemonConfig
+	_ = json.Unmarshal(buf, &cfg)
+	filter := serializeWithSecretFilter(&cfg)
+	jsonData, err := json.Marshal(filter)
+	require.Nil(t, err)
+	var newCfg FuseDaemonConfig
+	err = json.Unmarshal(jsonData, &newCfg)
+	require.Nil(t, err)
+	require.Equal(t, newCfg.FSPrefetch, cfg.FSPrefetch)
+	require.Equal(t, newCfg.Device.Cache.CacheType, cfg.Device.Cache.CacheType)
+	require.Equal(t, newCfg.Device.Cache.Config, cfg.Device.Cache.Config)
+	require.Equal(t, newCfg.Mode, cfg.Mode)
+	require.Equal(t, newCfg.DigestValidate, cfg.DigestValidate)
+	require.Equal(t, newCfg.IOStatsFiles, cfg.IOStatsFiles)
+	require.Equal(t, newCfg.Device.Backend.Config.Host, cfg.Device.Backend.Config.Host)
+	require.Equal(t, newCfg.Device.Backend.Config.Repo, cfg.Device.Backend.Config.Repo)
+	require.Equal(t, newCfg.Device.Backend.Config.Proxy, cfg.Device.Backend.Config.Proxy)
+	require.Equal(t, newCfg.Device.Backend.Config.BlobURLScheme, cfg.Device.Backend.Config.BlobURLScheme)
+	require.Equal(t, newCfg.Device.Backend.Config.Auth, "")
+	require.NotEqual(t, newCfg.Device.Backend.Config.Auth, cfg.Device.Backend.Config.Auth)
+}

--- a/config/global.go
+++ b/config/global.go
@@ -96,6 +96,10 @@ func GetLogToStdout() bool {
 	return globalConfig.origin.LoggingConfig.LogToStdout
 }
 
+func IsBackendSourceEnabled() bool {
+	return globalConfig.origin.Experimental.EnableBackendSource && globalConfig.origin.SystemControllerConfig.Enable
+}
+
 func IsSystemControllerEnabled() bool {
 	return globalConfig.origin.SystemControllerConfig.Enable
 }

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -107,6 +107,9 @@ enable_stargz = false
 # The option enables trying to fetch the Nydus image associated with the OCI image and run it.
 # Also see https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
 enable_referrer_detect = false
+# Whether to enable authentication support
+# The option enables nydus snapshot to provide backend information to nydusd.
+enable_backend_source = false
 [experimental.tarfs]
 # Whether to enable nydus tarfs mode. Tarfs is supported by:
 # - The EROFS filesystem driver since Linux 6.4

--- a/pkg/daemon/command/command.go
+++ b/pkg/daemon/command/command.go
@@ -36,6 +36,7 @@ type DaemonCommand struct {
 	Supervisor      string `type:"param" name:"supervisor"`
 	LogFile         string `type:"param" name:"log-file"`
 	PrefetchFiles   string `type:"param" name:"prefetch-files"`
+	BackendSource   string `type:"param" name:"backend-source"`
 }
 
 // Build exec style command line
@@ -187,5 +188,11 @@ func WithID(id string) Opt {
 func WithUpgrade() Opt {
 	return func(cmd *DaemonCommand) {
 		cmd.Upgrade = true
+	}
+}
+
+func WithBackendSource(source string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.BackendSource = source
 	}
 }

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -7,6 +7,7 @@
 package manager
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -24,6 +25,8 @@ import (
 	metrics "github.com/containerd/nydus-snapshotter/pkg/metrics/tool"
 	"github.com/containerd/nydus-snapshotter/pkg/prefetch"
 )
+
+const endpointGetBackend string = "/api/v1/daemons/%s/backend"
 
 // Spawn a nydusd daemon to serve the daemon instance.
 //
@@ -156,6 +159,12 @@ func (m *Manager) BuildDaemonCommand(d *daemon.Daemon, bin string, upgrade bool)
 				command.WithConfig(d.ConfigFile("")),
 				command.WithBootstrap(bootstrap),
 			)
+			if config.IsBackendSourceEnabled() {
+				configAPIPath := fmt.Sprintf(endpointGetBackend, d.States.ID)
+				cmdOpts = append(cmdOpts,
+					command.WithBackendSource(config.SystemControllerAddress()+configAPIPath),
+				)
+			}
 		default:
 			return nil, errors.Errorf("invalid daemon mode %s ", d.States.DaemonMode)
 		}


### PR DESCRIPTION
# Issue
[https://github.com/containerd/nydus-snapshotter/issues/388](url)

# Details
- Add interface endpointGetDaemonConfig string="/api/v1/daemons/{id}/config" in system. go
- Add handler func getDaemonConfig() to deliver config
- Pass the system socket and URL to nydusd through command-line arguments