### PR TITLE
action: remove the broken step of installing hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,18 +55,12 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v3
-      - name: install hub
-        run: |
-          HUB_VER=$(curl -s "https://api.github.com/repos/github/hub/releases/latest" | jq -r .tag_name | sed 's/^v//')
-          wget -q -O- https://github.com/github/hub/releases/download/v$HUB_VER/hub-linux-amd64-$HUB_VER.tgz | \
-          tar xz --strip-components=2 --wildcards '*/bin/hub'
-          sudo mv hub /usr/local/bin/hub
-      - name: download artifacts
+      - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
           name: nydus-snapshotter_artifacts
           path: nydus-snapshotter
-      - name: upload artifacts
+      - name: Upload Artifacts
         run: |
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           tarball="nydus-snapshotter-$tag-x86_64.tgz"


### PR DESCRIPTION
https://github.com/containerd/nydus-snapshotter/actions/runs/5584824903

The hub has been [integrated](https://github.com/mislav/hub#github-actions) to github action worker, so let's remove it to fix the failure.

A successful action example can be found here: https://github.com/imeoer/nydus-snapshotter/actions/runs/5586816647