### PR TITLE
config: remove useless auth_through option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,14 +157,11 @@ Dragonfly supports both **mirror** mode and HTTP **proxy** mode to boost the con
   "mirrors": [
     {
       "host": "http://127.0.0.1:65001",
-      "headers": "https://index.docker.io/v1/",
-      "auth_through": false
+      "headers": "https://index.docker.io/v1/"
     }
   ]
 }
 ```
-
-`auth_through=false` means nydusd's authentication request will directly go to original registry rather than relayed by Dragonfly.
 
 ### Hot updating mirror configurations
 
@@ -180,7 +177,6 @@ Configuration file is compatible with containerd's configuration file in toml fo
 ```toml
 [host]
   [host."http://127.0.0.1:65001"]
-    auth_through = false
     [host."http://127.0.0.1:65001".header]
       # NOTE: For Dragonfly, the HTTP scheme must be explicitly specified.
       X-Dragonfly-Registry = ["https://p2p-nydus.com"]

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -60,7 +60,6 @@ func NewDaemonConfig(fsDriver, path string) (DaemonConfig, error) {
 type MirrorConfig struct {
 	Host                string            `json:"host,omitempty"`
 	Headers             map[string]string `json:"headers,omitempty"`
-	AuthThrough         bool              `json:"auth_through,omitempty"`
 	HealthCheckInterval int               `json:"health_check_interval,omitempty"`
 	FailureLimit        uint8             `json:"failure_limit,omitempty"`
 	PingURL             string            `json:"ping_url,omitempty"`

--- a/config/daemonconfig/mirrors.go
+++ b/config/daemonconfig/mirrors.go
@@ -30,7 +30,6 @@ type HostFileConfig struct {
 	OverridePath bool                   `toml:"override_path"`
 
 	// The following configuration items are specific to nydus.
-	AuthThrough         bool   `toml:"auth_through,omitempty"`
 	HealthCheckInterval int    `toml:"health_check_interval,omitempty"`
 	FailureLimit        uint8  `toml:"failure_limit,omitempty"`
 	PingURL             string `toml:"ping_url,omitempty"`
@@ -41,7 +40,6 @@ type hostConfig struct {
 	Host   string
 	Header http.Header
 
-	AuthThrough         bool
 	HealthCheckInterval int
 	FailureLimit        uint8
 	PingURL             string
@@ -69,7 +67,6 @@ func parseMirrorsConfig(hosts []hostConfig) []MirrorConfig {
 
 	for i, host := range hosts {
 		parsedMirrors[i].Host = fmt.Sprintf("%s://%s", host.Scheme, host.Host)
-		parsedMirrors[i].AuthThrough = host.AuthThrough
 		parsedMirrors[i].HealthCheckInterval = host.HealthCheckInterval
 		parsedMirrors[i].FailureLimit = host.FailureLimit
 		parsedMirrors[i].PingURL = host.PingURL
@@ -176,7 +173,6 @@ func parseHostConfig(server string, config HostFileConfig) (hostConfig, error) {
 		result.Header = header
 	}
 
-	result.AuthThrough = config.AuthThrough
 	result.HealthCheckInterval = config.HealthCheckInterval
 	result.FailureLimit = config.FailureLimit
 	result.PingURL = config.PingURL

--- a/config/daemonconfig/mirrors_test.go
+++ b/config/daemonconfig/mirrors_test.go
@@ -43,7 +43,6 @@ func TestLoadMirrorConfig(t *testing.T) {
 	buf1 := []byte(`server = "https://default-docker.hub.com"
 	[host]
 	  [host."http://default-p2p-mirror1:65001"]
-		auth_through = true
 		[host."http://default-p2p-mirror1:65001".header]
 		  X-Dragonfly-Registry = ["https://default-docker.hub.com"]
 	`)
@@ -53,7 +52,6 @@ func TestLoadMirrorConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(mirrors), 1)
 	require.Equal(t, mirrors[0].Host, "http://default-p2p-mirror1:65001")
-	require.Equal(t, mirrors[0].AuthThrough, true)
 	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://default-docker.hub.com")
 
 	err = os.MkdirAll(registryHostConfigDir, os.ModePerm)
@@ -71,7 +69,6 @@ func TestLoadMirrorConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(mirrors), 1)
 	require.Equal(t, mirrors[0].Host, "http://p2p-mirror1:65001")
-	require.Equal(t, mirrors[0].AuthThrough, false)
 	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
 
 	buf3 := []byte(`
@@ -85,6 +82,5 @@ func TestLoadMirrorConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(mirrors), 1)
 	require.Equal(t, mirrors[0].Host, "http://p2p-mirror2:65001")
-	require.Equal(t, mirrors[0].AuthThrough, false)
 	require.Equal(t, mirrors[0].Headers["X-Dragonfly-Registry"], "https://docker.hub.com")
 }


### PR DESCRIPTION
We have removed the `auth_through` option in https://github.com/dragonflyoss/image-service/pull/1375

Let's remove it in snapshotter, since its default value is false, there is no compatibility impact.