### PR TITLE
feat: prevent unnecessary conversions

### DIFF
--- a/pkg/converter/constant.go
+++ b/pkg/converter/constant.go
@@ -20,6 +20,8 @@ const (
 	LayerAnnotationNydusBootstrap     = "containerd.io/snapshot/nydus-bootstrap"
 	LayerAnnotationNydusSourceChainID = "containerd.io/snapshot/nydus-source-chainid"
 	LayerAnnotationNydusEncryptedBlob = "containerd.io/snapshot/nydus-encrypted-blob"
+	LayerAnnotationNydusSourceDigest  = "containerd.io/snapshot/nydus-source-digest"
+	LayerAnnotationNydusTargetDigest  = "containerd.io/snapshot/nydus-target-digest"
 
 	LayerAnnotationNydusReferenceBlobIDs = "containerd.io/snapshot/nydus-reference-blob-ids"
 


### PR DESCRIPTION
Add remote cache of remote registry.

Changes:

- Skip conversion if layer cache exists.
- Add two LayerAnnotation  as constant labels

