### PR TITLE
Support to pass the image name to the remote mount slice

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -109,6 +109,7 @@ const (
 type Experimental struct {
 	EnableStargz         bool `toml:"enable_stargz"`
 	EnableReferrerDetect bool `toml:"enable_referrer_detect"`
+	EnablePassImageURL   bool `toml:"enable_pass_image_url"`
 }
 
 type CgroupConfig struct {

--- a/config/global.go
+++ b/config/global.go
@@ -110,7 +110,9 @@ func SystemControllerPprofAddress() string {
 func GetDaemonProfileCPUDuration() int64 {
 	return globalConfig.origin.SystemControllerConfig.DebugConfig.ProfileDuration
 }
-
+func GetPassImageURLEnabled() bool {
+	return globalConfig.origin.Experimental.EnablePassImageURL
+}
 func ProcessConfigurations(c *SnapshotterConfig) error {
 	if c.LoggingConfig.LogDir == "" {
 		c.LoggingConfig.LogDir = filepath.Join(c.Root, logging.DefaultLogDirName)


### PR DESCRIPTION
In the scenario of confidential containers, the image needs to be downloaded inside the vm. So an external method is needed to pass the name of the image to the vm. Therefore, we hope the snapshotter can pass the image name information through the mount slice.

Fixes: #516 