### PR TITLE
tarfs: check whether `labels` is nil

### DIFF
--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -540,6 +540,9 @@ func (t *Manager) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[
 		}
 
 		blockInfo := strconv.FormatUint(dataBlobks, 10) + "," + strconv.FormatUint(hashOffset, 10) + "," + "sha256:" + rootHash
+		if len(labels) == 0 {
+			labels = make(map[string]string)
+		}
 		if wholeImage {
 			labels[label.NydusImageBlockInfo] = blockInfo
 			updateFields = append(updateFields, "labels."+label.NydusImageBlockInfo)


### PR DESCRIPTION
Initialize `labels` if `labels` is a nil map.

Fixes #526