### PR TITLE
Support host sharing and guest pulling for Confidential Container image management

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,7 @@ const (
 	FsDriverFusedev  string = constant.FsDriverFusedev
 	FsDriverFscache  string = constant.FsDriverFscache
 	FsDriverNodev    string = constant.FsDriverNodev
+	FsDriverProxy    string = constant.FsDriverProxy
 )
 
 type Experimental struct {
@@ -276,7 +277,8 @@ func ValidateConfig(c *SnapshotterConfig) error {
 	}
 
 	if c.DaemonConfig.FsDriver != FsDriverFscache && c.DaemonConfig.FsDriver != FsDriverFusedev &&
-		c.DaemonConfig.FsDriver != FsDriverBlockdev && c.DaemonConfig.FsDriver != FsDriverNodev {
+		c.DaemonConfig.FsDriver != FsDriverBlockdev && c.DaemonConfig.FsDriver != FsDriverNodev &&
+		c.DaemonConfig.FsDriver != FsDriverProxy {
 		return errors.Errorf("invalid filesystem driver %q", c.DaemonConfig.FsDriver)
 	}
 	if _, err := ParseRecoverPolicy(c.DaemonConfig.RecoverPolicy); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -184,6 +184,7 @@ type AuthConfig struct {
 type RemoteConfig struct {
 	AuthConfig         AuthConfig    `toml:"auth"`
 	ConvertVpcRegistry bool          `toml:"convert_vpc_registry"`
+	SkipSSLVerify      bool          `toml:"skip_ssl_verify"`
 	MirrorsConfig      MirrorsConfig `toml:"mirrors_config"`
 }
 
@@ -274,7 +275,8 @@ func ValidateConfig(c *SnapshotterConfig) error {
 		return errors.New("empty root directory")
 	}
 
-	if c.DaemonConfig.FsDriver != FsDriverFscache && c.DaemonConfig.FsDriver != FsDriverFusedev {
+	if c.DaemonConfig.FsDriver != FsDriverFscache && c.DaemonConfig.FsDriver != FsDriverFusedev &&
+		c.DaemonConfig.FsDriver != FsDriverBlockdev && c.DaemonConfig.FsDriver != FsDriverNodev {
 		return errors.Errorf("invalid filesystem driver %q", c.DaemonConfig.FsDriver)
 	}
 	if _, err := ParseRecoverPolicy(c.DaemonConfig.RecoverPolicy); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,7 @@ type Experimental struct {
 
 type TarfsConfig struct {
 	EnableTarfs       bool   `toml:"enable_tarfs"`
+	MountTarfsOnHost  bool   `toml:"mount_tarfs_on_host"`
 	TarfsHint         bool   `toml:"tarfs_hint"`
 	MaxConcurrentProc int    `toml:"max_concurrent_proc"`
 	ExportMode        string `toml:"export_mode"`
@@ -156,6 +157,7 @@ type ImageConfig struct {
 // requests from containerd
 type SnapshotConfig struct {
 	EnableNydusOverlayFS bool `toml:"enable_nydus_overlayfs"`
+	EnableKataVolume     bool `toml:"enable_kata_volume"`
 	SyncRemove           bool `toml:"sync_remove"`
 }
 

--- a/config/global.go
+++ b/config/global.go
@@ -112,6 +112,10 @@ func GetDaemonProfileCPUDuration() int64 {
 	return globalConfig.origin.SystemControllerConfig.DebugConfig.ProfileDuration
 }
 
+func GetSkipSSLVerify() bool {
+	return globalConfig.origin.RemoteConfig.SkipSSLVerify
+}
+
 const (
 	TarfsLayerVerityOnly      string = "layer_verity_only"
 	TarfsImageVerityOnly      string = "image_verity_only"

--- a/config/global.go
+++ b/config/global.go
@@ -121,6 +121,10 @@ const (
 	TarfsImageBlockWithVerity string = "image_block_with_verity"
 )
 
+func GetTarfsMountOnHost() bool {
+	return globalConfig.origin.Experimental.TarfsConfig.MountTarfsOnHost
+}
+
 func GetTarfsExportEnabled() bool {
 	switch globalConfig.origin.Experimental.TarfsConfig.ExportMode {
 	case TarfsLayerVerityOnly, TarfsLayerBlockDevice, TarfsLayerBlockWithVerity:

--- a/internal/constant/values.go
+++ b/internal/constant/values.go
@@ -25,6 +25,8 @@ const (
 	FsDriverFscache string = "fscache"
 	// Only prepare/supply meta/data blobs, do not mount RAFS filesystem.
 	FsDriverNodev string = "nodev"
+	// Relay layer content download operation to other agents.
+	FsDriverProxy string = "proxy"
 )
 
 const (

--- a/misc/snapshotter/config-coco-guest-pulling.toml
+++ b/misc/snapshotter/config-coco-guest-pulling.toml
@@ -1,0 +1,15 @@
+version = 1
+
+# Snapshotter's own home directory where it stores and creates necessary resources
+root = "/var/lib/containerd-nydus"
+
+# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+
+[daemon]
+# Enable proxy mode
+fs_driver = "proxy"
+
+[snapshot]
+# Insert Kata volume information to `Mount.Options`
+enable_kata_volume = true

--- a/misc/snapshotter/config-coco-host-sharing.toml
+++ b/misc/snapshotter/config-coco-host-sharing.toml
@@ -1,0 +1,40 @@
+
+version = 1
+# Snapshotter's own home directory where it stores and creates necessary resources
+root = "/var/lib/containerd-nydus"
+# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+# No nydusd daemon needed
+daemon_mode = "none"
+
+[daemon]
+# Use `blockdev` for tarfs
+fs_driver = "blockdev"
+# Path to nydus-image binary
+nydusimage_path = "/usr/local/bin/nydus-image"
+
+[remote]
+skip_ssl_verify = true
+
+[snapshot]
+# Insert Kata volume information to `Mount.Options`
+enable_kata_volume = true
+
+[experimental.tarfs]
+# Whether to enable nydus tarfs mode. Tarfs is supported by:
+# - The EROFS filesystem driver since Linux 6.4
+# - Nydus Image Service release v2.3
+enable_tarfs = true
+
+# Mount rafs on host by loopdev and EROFS
+mount_tarfs_on_host = false
+
+# Mode to export tarfs images:
+# - "none" or "": do not export tarfs
+# - "layer_verity_only": only generate disk verity information for a layer blob
+# - "image_verity_only": only generate disk verity information for all blobs of an image
+# - "layer_block": generate a raw block disk image with tarfs for a layer
+# - "image_block": generate a raw block disk image with tarfs for an image
+# - "layer_block_with_verity": generate a raw block disk image with tarfs for a layer with dm-verity info
+# - "image_block_with_verity": generate a raw block disk image with tarfs for an image with dm-verity info
+export_mode = "image_block_with_verity"

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -83,6 +83,8 @@ enable_cri_keychain = false
 [snapshot]
 # Let containerd use nydus-overlayfs mount helper
 enable_nydus_overlayfs = false
+# Insert Kata Virtual Volume option to `Mount.Options`
+enable_kata_volume = false
 # Whether to remove resources when a snapshot is removed
 sync_remove = false
 
@@ -109,6 +111,8 @@ enable_referrer_detect = false
 # - The EROFS filesystem driver since Linux 6.4
 # - Nydus Image Service release v2.3
 enable_tarfs = false
+# Mount rafs on host by loopdev and EROFS
+mount_tarfs_on_host = false
 # Only enable nydus tarfs mode for images with `tarfs hint` label when true
 tarfs_hint = false
 # Maximum of concurrence to converting OCIv1 images to tarfs, 0 means default

--- a/pkg/filesystem/config.go
+++ b/pkg/filesystem/config.go
@@ -8,7 +8,6 @@
 package filesystem
 
 import (
-	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
@@ -27,20 +26,14 @@ func WithNydusImageBinaryPath(p string) NewFSOpt {
 	}
 }
 
-func WithManager(pm *manager.Manager) NewFSOpt {
+func WithManagers(managers []*manager.Manager) NewFSOpt {
 	return func(fs *Filesystem) error {
-		if pm != nil {
-			switch pm.FsDriver {
-			case config.FsDriverBlockdev:
-				fs.blockdevManager = pm
-			case config.FsDriverFscache:
-				fs.fscacheManager = pm
-			case config.FsDriverFusedev:
-				fs.fusedevManager = pm
-			}
-			fs.enabledManagers = append(fs.enabledManagers, pm)
+		if fs.enabledManagers == nil {
+			fs.enabledManagers = map[string]*manager.Manager{}
 		}
-
+		for _, pm := range managers {
+			fs.enabledManagers[pm.FsDriver] = pm
+		}
 		return nil
 	}
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -358,7 +358,7 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 			err = errors.Wrapf(err, "mount file system by daemon %s, snapshot %s", d.ID(), snapshotID)
 		}
 	case config.FsDriverBlockdev:
-		err = fs.tarfsMgr.MountTarErofs(snapshotID, s, rafs)
+		err = fs.tarfsMgr.MountTarErofs(snapshotID, s, labels, rafs)
 		if err != nil {
 			err = errors.Wrapf(err, "mount tarfs for snapshot %s", snapshotID)
 		}

--- a/pkg/filesystem/tarfs_adaptor.go
+++ b/pkg/filesystem/tarfs_adaptor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/containerd/log"
 	snpkg "github.com/containerd/containerd/pkg/snapshotters"
 	"github.com/containerd/containerd/snapshots/storage"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -55,6 +56,9 @@ func (fs *Filesystem) PrepareTarfsLayer(ctx context.Context, labels map[string]s
 	if limiter != nil {
 		limiter.Release(1)
 	}
+
+	layerBlobID := layerDigest.Hex()
+	labels[label.NydusTarfsLayer] = layerBlobID
 
 	return nil
 }

--- a/pkg/filesystem/tarfs_adaptor.go
+++ b/pkg/filesystem/tarfs_adaptor.go
@@ -71,3 +71,10 @@ func (fs *Filesystem) ExportBlockData(s storage.Snapshot, perLayer bool, labels 
 	storageLocater func(string) string) ([]string, error) {
 	return fs.tarfsMgr.ExportBlockData(s, perLayer, labels, storageLocater)
 }
+
+func (fs *Filesystem) GetTarfsImageDiskFilePath(id string) (string, error) {
+	if fs.tarfsMgr == nil {
+		return "", errors.New("tarfs mode is not enabled")
+	}
+	return fs.tarfsMgr.ImageDiskFilePath(id), nil
+}

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -42,9 +42,9 @@ const (
 	NydusImagePullUsername = "containerd.io/snapshot/pullusername"
 	// A bool flag to enable integrity verification of meta data blob
 	NydusSignature = "containerd.io/snapshot/nydus-signature"
-	// Information for image block device
+	// Dm-verity information for image block device
 	NydusImageBlockInfo = "containerd.io/snapshot/nydus-image-block"
-	// Information for layer block device
+	// Dm-verity information for layer block device
 	NydusLayerBlockInfo = "containerd.io/snapshot/nydus-layer-block"
 
 	// A bool flag to mark the blob as a estargz data blob, set by the snapshotter.

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -44,6 +44,8 @@ const (
 	NydusImagePullSecret = "containerd.io/snapshot/pullsecret"
 	// Annotation containing username to pull images from registry, set by the snapshotter.
 	NydusImagePullUsername = "containerd.io/snapshot/pullusername"
+	// Proxy image pull actions to other agents.
+	NydusProxyMode = "containerd.io/snapshot/nydus-proxy-mode"
 	// A bool flag to enable integrity verification of meta data blob
 	NydusSignature = "containerd.io/snapshot/nydus-signature"
 
@@ -72,6 +74,11 @@ func IsNydusMetaLayer(labels map[string]string) bool {
 
 func IsTarfsDataLayer(labels map[string]string) bool {
 	_, ok := labels[NydusTarfsLayer]
+	return ok
+}
+
+func IsNydusProxyMode(labels map[string]string) bool {
+	_, ok := labels[NydusProxyMode]
 	return ok
 }
 

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -34,18 +34,18 @@ const (
 	NydusMetaLayer = "containerd.io/snapshot/nydus-bootstrap"
 	// The referenced blob sha256 in format of `sha256:xxx`, set by image builders.
 	NydusRefLayer = "containerd.io/snapshot/nydus-ref"
-	// A bool flag to mark the layer as a nydus tarfs, set by the snapshotter
+	// The blobID of associated layer, also marking the layer as a nydus tarfs, set by the snapshotter
 	NydusTarfsLayer = "containerd.io/snapshot/nydus-tarfs"
+	// Dm-verity information for image block device
+	NydusImageBlockInfo = "containerd.io/snapshot/nydus-image-block"
+	// Dm-verity information for layer block device
+	NydusLayerBlockInfo = "containerd.io/snapshot/nydus-layer-block"
 	// Annotation containing secret to pull images from registry, set by the snapshotter.
 	NydusImagePullSecret = "containerd.io/snapshot/pullsecret"
 	// Annotation containing username to pull images from registry, set by the snapshotter.
 	NydusImagePullUsername = "containerd.io/snapshot/pullusername"
 	// A bool flag to enable integrity verification of meta data blob
 	NydusSignature = "containerd.io/snapshot/nydus-signature"
-	// Dm-verity information for image block device
-	NydusImageBlockInfo = "containerd.io/snapshot/nydus-image-block"
-	// Dm-verity information for layer block device
-	NydusLayerBlockInfo = "containerd.io/snapshot/nydus-layer-block"
 
 	// A bool flag to mark the blob as a estargz data blob, set by the snapshotter.
 	StargzLayer = "containerd.io/snapshot/stargz"

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -42,7 +42,7 @@ type Manager struct {
 	// The `daemonCache` is cache for nydusd daemons stored in `store`.
 	// You should update `store` first before modifying cached state.
 	daemonCache      *DaemonCache
-	DaemonConfig     daemonconfig.DaemonConfig // Daemon configuration template.
+	DaemonConfig     *daemonconfig.DaemonConfig // Daemon configuration template.
 	CgroupMgr        *cgroup.Manager
 	monitor          LivenessMonitor
 	LivenessNotifier chan deathEvent // TODO: Close me
@@ -54,7 +54,7 @@ type Manager struct {
 type Opt struct {
 	CacheDir         string
 	CgroupMgr        *cgroup.Manager
-	DaemonConfig     daemonconfig.DaemonConfig
+	DaemonConfig     *daemonconfig.DaemonConfig
 	Database         *store.Database
 	FsDriver         string
 	NydusdBinaryPath string

--- a/pkg/metrics/serve.go
+++ b/pkg/metrics/serve.go
@@ -34,11 +34,9 @@ type Server struct {
 	inflightCollector *collector.InflightMetricsVecCollector
 }
 
-func WithProcessManager(pm *manager.Manager) ServerOpt {
+func WithProcessManagers(managers []*manager.Manager) ServerOpt {
 	return func(s *Server) error {
-		if pm != nil {
-			s.managers = append(s.managers, pm)
-		}
+		s.managers = append(s.managers, managers...)
 		return nil
 	}
 }

--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -494,13 +494,18 @@ func (t *Manager) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[
 		return updateFields, errors.Errorf("tarfs snapshot %s is not ready, %d", snapshotID, st.status)
 	}
 
+	blobID, ok := labels[label.NydusTarfsLayer]
+	if !ok {
+		return updateFields, errors.Errorf("Missing Nydus tarfs layer annotation for snapshot %s", s.ID)
+	}
+
 	var metaFileName, diskFileName string
 	if wholeImage {
 		metaFileName = t.imageMetaFilePath(storageLocater(snapshotID))
-		diskFileName = t.ImageDiskFilePath(st.blobID)
+		diskFileName = t.ImageDiskFilePath(blobID)
 	} else {
 		metaFileName = t.layerMetaFilePath(storageLocater(snapshotID))
-		diskFileName = t.layerDiskFilePath(st.blobID)
+		diskFileName = t.layerDiskFilePath(blobID)
 	}
 
 	// Do not regenerate if the disk image already exists.
@@ -520,7 +525,7 @@ func (t *Manager) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[
 	if withVerity {
 		options = append(options, "--verity")
 	}
-	log.L.Warnf("nydus image command %v", options)
+	log.L.Debugf("nydus image command %v", options)
 	cmd := exec.Command(t.nydusImagePath, options...)
 	var errb, outb bytes.Buffer
 	cmd.Stderr = &errb

--- a/snapshot/mount_option.go
+++ b/snapshot/mount_option.go
@@ -405,7 +405,7 @@ func EncodeKataVirtualVolumeToBase64(volume KataVirtualVolume) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "marshal KataVirtualVolume object")
 	}
-	log.L.Infof("Mount info with kata volume %s", validKataVirtualVolumeJSON)
+	log.L.Infof("encode kata volume %s", validKataVirtualVolumeJSON)
 	option := base64.StdEncoding.EncodeToString(validKataVirtualVolumeJSON)
 	return option, nil
 }

--- a/snapshot/mount_option.go
+++ b/snapshot/mount_option.go
@@ -9,9 +9,11 @@ package snapshot
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
@@ -96,4 +98,179 @@ func (o *snapshotter) remoteMountWithExtraOptions(ctx context.Context, s storage
 			Options: overlayOptions,
 		},
 	}, nil
+}
+
+// Consts and data structures for Kata Virtual Volume
+const (
+	minBlockSize = 1 << 9
+	maxBlockSize = 1 << 19
+)
+
+const (
+	KataVirtualVolumeOptionName          = "io.katacontainers.volume"
+	KataVirtualVolumeDirectBlockType     = "direct_block"
+	KataVirtualVolumeImageRawBlockType   = "image_raw_block"
+	KataVirtualVolumeLayerRawBlockType   = "layer_raw_block"
+	KataVirtualVolumeImageNydusBlockType = "image_nydus_block"
+	KataVirtualVolumeLayerNydusBlockType = "layer_nydus_block"
+	KataVirtualVolumeImageNydusFsType    = "image_nydus_fs"
+	KataVirtualVolumeLayerNydusFsType    = "layer_nydus_fs"
+	KataVirtualVolumeImageGuestPullType  = "image_guest_pull"
+)
+
+// DmVerityInfo contains configuration information for DmVerity device.
+type DmVerityInfo struct {
+	HashType  string `json:"hashtype"`
+	Hash      string `json:"hash"`
+	BlockNum  uint64 `json:"blocknum"`
+	Blocksize uint64 `json:"blocksize"`
+	Hashsize  uint64 `json:"hashsize"`
+	Offset    uint64 `json:"offset"`
+}
+
+func (d *DmVerityInfo) Validate() error {
+	err := d.validateHashType()
+	if err != nil {
+		return err
+	}
+
+	if d.BlockNum == 0 || d.BlockNum > uint64(^uint32(0)) {
+		return fmt.Errorf("Zero block count for DmVerity device %s", d.Hash)
+	}
+
+	if !validateBlockSize(d.Blocksize) || !validateBlockSize(d.Hashsize) {
+		return fmt.Errorf("Unsupported verity block size: data_block_size = %d, hash_block_size = %d", d.Blocksize, d.Hashsize)
+	}
+
+	if d.Offset%d.Hashsize != 0 || d.Offset < d.Blocksize*d.BlockNum {
+		return fmt.Errorf("Invalid hashvalue offset %d for DmVerity device %s", d.Offset, d.Hash)
+	}
+
+	return nil
+}
+
+func (d *DmVerityInfo) validateHashType() error {
+	switch strings.ToLower(d.HashType) {
+	case "sha256":
+		return d.validateHash(64, "sha256")
+	case "sha1":
+		return d.validateHash(40, "sha1")
+	default:
+		return fmt.Errorf("Unsupported hash algorithm %s for DmVerity device %s", d.HashType, d.Hash)
+	}
+}
+
+func (d *DmVerityInfo) validateHash(expectedLen int, hashType string) error {
+	_, err := hex.DecodeString(d.Hash)
+	if len(d.Hash) != expectedLen || err != nil {
+		return fmt.Errorf("Invalid hash value %s:%s for DmVerity device with %s", hashType, d.Hash, hashType)
+	}
+	return nil
+}
+
+func validateBlockSize(blockSize uint64) bool {
+	return minBlockSize <= blockSize && blockSize <= maxBlockSize
+}
+
+func ParseDmVerityInfo(option string) (*DmVerityInfo, error) {
+	no := &DmVerityInfo{}
+	if err := json.Unmarshal([]byte(option), no); err != nil {
+		return nil, errors.Wrapf(err, "DmVerityInfo json unmarshal err")
+	}
+	if err := no.Validate(); err != nil {
+		return nil, fmt.Errorf("DmVerityInfo is not correct, %+v; error = %+v", no, err)
+	}
+	return no, nil
+}
+
+// DirectAssignedVolume contains meta information for a directly assigned volume.
+type DirectAssignedVolume struct {
+	Metadata map[string]string `json:"metadata"`
+}
+
+func (d *DirectAssignedVolume) Validate() bool {
+	return d.Metadata != nil
+}
+
+// ImagePullVolume contains meta information for pulling an image inside the guest.
+type ImagePullVolume struct {
+	Metadata map[string]string `json:"metadata"`
+}
+
+func (i *ImagePullVolume) Validate() bool {
+	return i.Metadata != nil
+}
+
+// NydusImageVolume contains Nydus image volume information.
+type NydusImageVolume struct {
+	Config      string `json:"config"`
+	SnapshotDir string `json:"snapshot_dir"`
+}
+
+func (n *NydusImageVolume) Validate() bool {
+	return len(n.Config) > 0 || len(n.SnapshotDir) > 0
+}
+
+// KataVirtualVolume encapsulates information for extra mount options and direct volumes.
+type KataVirtualVolume struct {
+	VolumeType   string                `json:"volume_type"`
+	Source       string                `json:"source,omitempty"`
+	FSType       string                `json:"fs_type,omitempty"`
+	Options      []string              `json:"options,omitempty"`
+	DirectVolume *DirectAssignedVolume `json:"direct_volume,omitempty"`
+	ImagePull    *ImagePullVolume      `json:"image_pull,omitempty"`
+	NydusImage   *NydusImageVolume     `json:"nydus_image,omitempty"`
+	DmVerity     *DmVerityInfo         `json:"dm_verity,omitempty"`
+}
+
+func (k *KataVirtualVolume) Validate() bool {
+	switch k.VolumeType {
+	case KataVirtualVolumeDirectBlockType:
+		if k.Source != "" && k.DirectVolume != nil && k.DirectVolume.Validate() {
+			return true
+		}
+	case KataVirtualVolumeImageRawBlockType, KataVirtualVolumeLayerRawBlockType:
+		if k.Source != "" && (k.DmVerity == nil || k.DmVerity.Validate() == nil) {
+			return true
+		}
+	case KataVirtualVolumeImageNydusBlockType, KataVirtualVolumeLayerNydusBlockType, KataVirtualVolumeImageNydusFsType, KataVirtualVolumeLayerNydusFsType:
+		if k.Source != "" && k.NydusImage != nil && k.NydusImage.Validate() {
+			return true
+		}
+	case KataVirtualVolumeImageGuestPullType:
+		if k.ImagePull != nil && k.ImagePull.Validate() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ParseKataVirtualVolume(option []byte) (*KataVirtualVolume, error) {
+	no := &KataVirtualVolume{}
+	if err := json.Unmarshal(option, no); err != nil {
+		return nil, errors.Wrapf(err, "KataVirtualVolume json unmarshal err")
+	}
+	if !no.Validate() {
+		return nil, fmt.Errorf("KataVirtualVolume is not correct, %+v", no)
+	}
+
+	return no, nil
+}
+
+func ParseKataVirtualVolumeFromBase64(option string) (*KataVirtualVolume, error) {
+	opt, err := base64.StdEncoding.DecodeString(option)
+	if err != nil {
+		return nil, errors.Wrap(err, "KataVirtualVolume base64 decoding err")
+	}
+	return ParseKataVirtualVolume(opt)
+}
+
+func EncodeKataVirtualVolumeToBase64(volume KataVirtualVolume) (string, error) {
+	validKataVirtualVolumeJSON, err := json.Marshal(volume)
+	if err != nil {
+		return "", errors.Wrapf(err, "marshal KataVirtualVolume object")
+	}
+	option := base64.StdEncoding.EncodeToString(validKataVirtualVolumeJSON)
+	return option, nil
 }

--- a/snapshot/mount_option.go
+++ b/snapshot/mount_option.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
 	"github.com/containerd/nydus-snapshotter/pkg/layout"
 	"github.com/containerd/nydus-snapshotter/pkg/rafs"
 	"github.com/pkg/errors"
@@ -98,6 +99,101 @@ func (o *snapshotter) remoteMountWithExtraOptions(ctx context.Context, s storage
 			Options: overlayOptions,
 		},
 	}, nil
+}
+
+func (o *snapshotter) mountWithKataVolume(ctx context.Context, s storage.Snapshot, id string,
+	overlayOptions []string) ([]mount.Mount, error) {
+	hasVolume := false
+	rafs := rafs.RafsGlobalCache.Get(id)
+	if rafs == nil {
+		return []mount.Mount{}, errors.Errorf("failed to find RAFS instance for snapshot %s", id)
+	}
+
+	// Insert Kata volume for tarfs
+	if label.IsTarfsDataLayer(rafs.Annotations) {
+		options, err := o.mountWithTarfsVolume(*rafs, id)
+		if err != nil {
+			return []mount.Mount{}, errors.Wrapf(err, "create kata volume for tarfs")
+		}
+		if len(options) > 0 {
+			overlayOptions = append(overlayOptions, options...)
+			hasVolume = true
+		}
+	}
+
+	if hasVolume {
+		log.G(ctx).Debugf("fuse.nydus-overlayfs mount options %v", overlayOptions)
+		return []mount.Mount{
+			{
+				Type:    "fuse.nydus-overlayfs",
+				Source:  "overlay",
+				Options: overlayOptions,
+			},
+		}, nil
+	}
+
+	return overlayMount(overlayOptions), nil
+}
+
+func (o *snapshotter) mountWithTarfsVolume(rafs rafs.Rafs, id string) ([]string, error) {
+	var volume *KataVirtualVolume
+
+	if info, ok := rafs.Annotations[label.NydusImageBlockInfo]; ok {
+		path, err := o.fs.GetTarfsImageDiskFilePath(id)
+		if err != nil {
+			return []string{}, errors.Wrapf(err, "get tarfs image disk file path")
+		}
+		volume = &KataVirtualVolume{
+			VolumeType: KataVirtualVolumeImageRawBlockType,
+			Source:     path,
+			FSType:     "erofs",
+			Options:    []string{"ro"},
+		}
+		if len(info) > 0 {
+			dmverity, err := parseTarfsDmVerityInfo(info)
+			if err != nil {
+				return []string{}, err
+			}
+			volume.DmVerity = &dmverity
+		}
+	}
+
+	if volume != nil {
+		if !volume.Validate() {
+			return []string{}, errors.Errorf("got invalid kata volume, %v", volume)
+		}
+		info, err := EncodeKataVirtualVolumeToBase64(*volume)
+		if err != nil {
+			return []string{}, errors.Errorf("failed to encoding Kata Volume info %v", volume)
+		}
+		opt := fmt.Sprintf("%s=%s", KataVirtualVolumeOptionName, info)
+		return []string{opt}, nil
+	}
+
+	return []string{}, nil
+}
+
+func parseTarfsDmVerityInfo(info string) (DmVerityInfo, error) {
+	var dataBlocks, hashOffset uint64
+	var rootHash string
+
+	pattern := "%d,%d,sha256:%s"
+	if count, err := fmt.Sscanf(info, pattern, &dataBlocks, &hashOffset, &rootHash); err == nil && count == 3 {
+		di := DmVerityInfo{
+			HashType:  "sha256",
+			Hash:      rootHash,
+			BlockNum:  dataBlocks,
+			Blocksize: 512,
+			Hashsize:  4096,
+			Offset:    hashOffset,
+		}
+		if err := di.Validate(); err != nil {
+			return DmVerityInfo{}, errors.Wrap(err, "validate dm-verity information")
+		}
+		return di, nil
+	}
+
+	return DmVerityInfo{}, errors.Errorf("invalid dm-verity information: %s", info)
 }
 
 // Consts and data structures for Kata Virtual Volume

--- a/snapshot/mount_option_test.go
+++ b/snapshot/mount_option_test.go
@@ -1,0 +1,260 @@
+package snapshot
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDmVerityInfoValidation(t *testing.T) {
+	TestData := []DmVerityInfo{
+		{
+			HashType:  "md5", // "md5" is not a supported hash algorithm
+			Blocksize: 512,
+			Hashsize:  512,
+			BlockNum:  16384,
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 3000, // Invalid block size, not a power of 2.
+			Hashsize:  512,
+			BlockNum:  16384,
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 0, // Invalid block size, less than 512.
+			Hashsize:  512,
+			BlockNum:  16384,
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 524800, // Invalid block size, greater than 524288.
+			Hashsize:  512,
+			BlockNum:  16384,
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 512,
+			Hashsize:  3000, // Invalid hash block size, not a power of 2.
+			BlockNum:  16384,
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 512,
+			Hashsize:  0, // Invalid hash block size, less than 512.
+			BlockNum:  16384,
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 512,
+			Hashsize:  524800, // Invalid hash block size, greater than 524288.
+			BlockNum:  16384,
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 512,
+			Hashsize:  512,
+			BlockNum:  0, // Invalid BlockNum, it must be greater than 0.
+			Offset:    8388608,
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 512,
+			Hashsize:  512,
+			BlockNum:  16384,
+			Offset:    0, // Invalid offset, it must be greater than 0.
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 512,
+			Hashsize:  512,
+			BlockNum:  16384,
+			Offset:    8193, // Invalid offset, it must be aligned to 512.
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+		{
+			HashType:  "sha256",
+			Blocksize: 512,
+			Hashsize:  512,
+			BlockNum:  16384,
+			Offset:    8388608 - 4096, // Invalid offset, it must be equal to blocksize * BlockNum.
+			Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+		},
+	}
+
+	for _, d := range TestData {
+		assert.Error(t, d.Validate())
+	}
+	TestCorrectData := DmVerityInfo{
+		HashType:  "sha256",
+		Blocksize: 512,
+		Hashsize:  512,
+		BlockNum:  16384,
+		Offset:    8388608,
+		Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+	}
+	assert.NoError(t, TestCorrectData.Validate())
+}
+
+func TestDirectAssignedVolumeValidation(t *testing.T) {
+	validDirectVolume := DirectAssignedVolume{
+		Metadata: map[string]string{"key": "value"},
+	}
+	assert.True(t, validDirectVolume.Validate())
+
+	invalidDirectVolume := DirectAssignedVolume{
+		Metadata: nil,
+	}
+	assert.False(t, invalidDirectVolume.Validate())
+}
+
+func TestImagePullVolumeValidation(t *testing.T) {
+	validImagePull := ImagePullVolume{
+		Metadata: map[string]string{"key": "value"},
+	}
+	assert.True(t, validImagePull.Validate())
+
+	invalidImagePull := ImagePullVolume{
+		Metadata: nil,
+	}
+	assert.False(t, invalidImagePull.Validate())
+}
+
+func TestNydusImageVolumeValidation(t *testing.T) {
+	validNydusImage := NydusImageVolume{
+		Config:      "config_value",
+		SnapshotDir: "",
+	}
+	assert.True(t, validNydusImage.Validate())
+
+	invalidNydusImage := NydusImageVolume{
+		Config:      "",
+		SnapshotDir: "",
+	}
+	assert.False(t, invalidNydusImage.Validate())
+}
+
+func TestKataVirtualVolumeValidation(t *testing.T) {
+	validKataVirtualVolume := KataVirtualVolume{
+		VolumeType: "direct_block",
+		Source:     "/dev/sdb",
+		FSType:     "ext4",
+		Options:    []string{"rw"},
+		DirectVolume: &DirectAssignedVolume{
+			Metadata: map[string]string{"key": "value"},
+		},
+		// Initialize other fields
+	}
+	assert.True(t, validKataVirtualVolume.Validate())
+
+	invalidKataVirtualVolume := KataVirtualVolume{
+		VolumeType: "direct_block",
+		Source:     "/dev/sdb",
+		FSType:     "",
+		Options:    nil,
+		DirectVolume: &DirectAssignedVolume{
+			Metadata: nil,
+		},
+		// Initialize other fields
+	}
+	assert.False(t, invalidKataVirtualVolume.Validate())
+}
+func TestParseDmVerityInfo(t *testing.T) {
+	// Create a mock valid KataVirtualVolume
+	validDmVerityInfo := DmVerityInfo{
+		HashType:  "sha256",
+		Blocksize: 512,
+		Hashsize:  512,
+		BlockNum:  16384,
+		Offset:    8388608,
+		Hash:      "9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174",
+	}
+	validKataVirtualVolumeJSON, _ := json.Marshal(validDmVerityInfo)
+
+	t.Run("Valid Option", func(t *testing.T) {
+		volume, err := ParseDmVerityInfo(string(validKataVirtualVolumeJSON))
+		assert.NoError(t, err)
+		assert.NotNil(t, volume)
+		assert.NoError(t, volume.Validate())
+	})
+
+	t.Run("Invalid JSON Option", func(t *testing.T) {
+		volume, err := ParseDmVerityInfo("invalid_json")
+		assert.Error(t, err)
+		assert.Nil(t, volume)
+	})
+
+}
+func TestParseKataVirtualVolume(t *testing.T) {
+	// Create a mock valid KataVirtualVolume
+	validKataVirtualVolume := KataVirtualVolume{
+		VolumeType: "direct_block",
+		Source:     "/dev/sdb",
+		FSType:     "ext4",
+		Options:    []string{"rw"},
+		DirectVolume: &DirectAssignedVolume{
+			Metadata: map[string]string{"key": "value"},
+		},
+		// Initialize other fields
+	}
+	validOption, err := EncodeKataVirtualVolumeToBase64(validKataVirtualVolume)
+	assert.Nil(t, err)
+
+	t.Run("Valid Option", func(t *testing.T) {
+		volume, err := ParseKataVirtualVolumeFromBase64(validOption)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, volume)
+		assert.True(t, volume.Validate())
+	})
+
+	t.Run("Invalid JSON Option", func(t *testing.T) {
+		invalidJSONOption := base64.StdEncoding.EncodeToString([]byte("invalid_json"))
+		volume, err := ParseKataVirtualVolumeFromBase64(invalidJSONOption)
+
+		assert.Error(t, err)
+		assert.Nil(t, volume)
+	})
+
+	invalidBase64Option := "invalid_base64"
+	t.Run("Invalid Base64 Option", func(t *testing.T) {
+		volume, err := ParseKataVirtualVolumeFromBase64(invalidBase64Option)
+
+		assert.Error(t, err)
+		assert.Nil(t, volume)
+	})
+
+	t.Run("Invalid Fields", func(t *testing.T) {
+		// Create a mock invalid KataVirtualVolume
+		validKataVirtualVolume = KataVirtualVolume{
+			VolumeType: "direct_block",
+			Source:     "/dev/sdb",
+			FSType:     "ext4",
+			Options:    []string{"rw"},
+			// Initialize other fields
+		}
+		invalidFieldOption, err := EncodeKataVirtualVolumeToBase64(validKataVirtualVolume)
+		assert.Nil(t, err)
+		volume, err := ParseKataVirtualVolumeFromBase64(invalidFieldOption)
+		assert.Error(t, err)
+		assert.Nil(t, volume)
+	})
+}

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -42,7 +42,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 	remoteHandler := func(id string, labels map[string]string) func() (bool, []mount.Mount, error) {
 		return func() (bool, []mount.Mount, error) {
 			logger.Debugf("Prepare remote snapshot %s", id)
-			if err := sn.fs.Mount(id, labels, &s); err != nil {
+			if err := sn.fs.Mount(ctx, id, labels, &s); err != nil {
 				return false, nil, err
 			}
 

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -101,7 +101,6 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 							return nil, "", errors.Wrap(err, "export layer as tarfs block device")
 						}
 					}
-					labels[label.NydusTarfsLayer] = "true"
 					handler = skipHandler
 				}
 			}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -843,16 +843,8 @@ func overlayMount(options []string) []mount.Mount {
 // `s` and `id` can represent a different layer, it's useful when View an image
 func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string, s storage.Snapshot, id string) ([]mount.Mount, error) {
 	var overlayOptions []string
-	if s.Kind == snapshots.KindActive {
-		overlayOptions = append(overlayOptions,
-			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
-			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
-		)
-		if _, ok := labels[label.OverlayfsVolatileOpt]; ok {
-			overlayOptions = append(overlayOptions, "volatile")
-		}
-	} else if len(s.ParentIDs) == 1 {
-		return bindMount(o.upperPath(s.ParentIDs[0]), "ro"), nil
+	if _, ok := labels[label.OverlayfsVolatileOpt]; ok {
+		overlayOptions = append(overlayOptions, "volatile")
 	}
 
 	lowerPaths := make([]string, 0, 8)
@@ -862,7 +854,12 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 	}
 	lowerPaths = append(lowerPaths, lowerPathNydus)
 
-	if s.Kind == snapshots.KindView {
+	if s.Kind == snapshots.KindActive {
+		overlayOptions = append(overlayOptions,
+			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
+			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
+		)
+	} else if s.Kind == snapshots.KindView {
 		lowerPathNormal, err := o.lowerPath(s.ID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to locate overlay lowerdir for view snapshot")

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -482,7 +482,7 @@ func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 		// Nydusd might not be running. We should run nydusd to reflect the rootfs.
 		if err = o.fs.WaitUntilReady(pID); err != nil {
 			if errors.Is(err, errdefs.ErrNotFound) {
-				if err := o.fs.Mount(pID, pInfo.Labels, nil); err != nil {
+				if err := o.fs.Mount(ctx, pID, pInfo.Labels, nil); err != nil {
 					return nil, errors.Wrapf(err, "mount rafs, instance id %s", pID)
 				}
 
@@ -522,7 +522,7 @@ func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 				}
 			}
 		}
-		if err := o.fs.Mount(pID, pInfo.Labels, &s); err != nil {
+		if err := o.fs.Mount(ctx, pID, pInfo.Labels, &s); err != nil {
 			return nil, errors.Wrapf(err, "mount tarfs, snapshot id %s", pID)
 		}
 		needRemoteMounts = true


### PR DESCRIPTION
Support host sharing and guest pulling for Confidential Container image management:
- import a `KataVirtualVolume` structure, which acts as a superset of `ExtraOptions`
- support build a disk image for a container image with EROFS and passing disk image info to kata-runtime through `KataVirtualVolume`.
- support downloading container image inside guest by introducing `proxy` mode, which doesn't download any layer content on host but only insert a `KataVirutalVolume` into `Mount.Options`.

This PR is based on #528