### PR TITLE
Manager: make nydusd daemon reach desired state

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -582,6 +582,20 @@ func (d *Daemon) Wait() error {
 	return nil
 }
 
+func (d *Daemon) IsProcessRunning() (bool, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	if d.Pid() > 0 {
+		if _, err := os.FindProcess(d.Pid()); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // When daemon dies, clean up its vestige before start a new one.
 func (d *Daemon) ClearVestige() {
 	mounter := mount.Mounter{}

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -25,6 +25,28 @@ import (
 	metrics "github.com/containerd/nydus-snapshotter/pkg/metrics/tool"
 )
 
+func (m *Manager) IsSubscribedDaemon(id, path string) bool {
+	return m.monitor.IsSubscribed(id, path)
+}
+
+func (m *Manager) StartDaemonUntilSubscribed(d *daemon.Daemon) {
+	for {
+		if err := m.StartDaemon(d); err != nil {
+			log.L.WithError(err).Errorf("fail to start daemon %s when recovering", d.ID())
+		}
+
+		running, err := d.IsProcessRunning()
+		if err != nil {
+			log.L.WithError(err).Errorf("fail to get process state, pid %d", d.Pid())
+		}
+		if m.IsSubscribedDaemon(d.ID(), d.GetAPISock()) && running {
+			break
+		}
+
+		log.L.Warnf("daemon %s, retry...", d.ID())
+	}
+}
+
 // Fork the nydusd daemon with the process PID decided
 func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 	cmd, err := m.BuildDaemonCommand(d, "", false)
@@ -72,22 +94,22 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 		log.L.Errorf("Fail to update daemon info (%+v) to DB: %v", d, err)
 	}
 
+	if err := daemon.WaitUntilSocketExisted(d.GetAPISock(), d.States.ProcessID); err != nil {
+		// FIXME: Should clean the daemon record in DB if the nydusd fails starting
+		log.L.Errorf("Nydusd %s probably not started", d.ID())
+		return err
+	}
+
+	// TODO: It's better to subscribe death event when snapshotter
+	// has set daemon's state to RUNNING or READY.
+	if err := m.monitor.Subscribe(d.ID(), d.GetAPISock(), m.LivenessNotifier); err != nil {
+		log.L.Errorf("Nydusd %s probably not started", d.ID())
+		return err
+	}
+
 	// If nydusd fails startup, manager can't subscribe its death event.
 	// So we can ignore the subscribing error.
 	go func() {
-		if err := daemon.WaitUntilSocketExisted(d.GetAPISock(), d.States.ProcessID); err != nil {
-			// FIXME: Should clean the daemon record in DB if the nydusd fails starting
-			log.L.Errorf("Nydusd %s probably not started", d.ID())
-			return
-		}
-
-		// TODO: It's better to subscribe death event when snapshotter
-		// has set daemon's state to RUNNING or READY.
-		if err := m.monitor.Subscribe(d.ID(), d.GetAPISock(), m.LivenessNotifier); err != nil {
-			log.L.Errorf("Nydusd %s probably not started", d.ID())
-			return
-		}
-
 		if err := d.WaitUntilState(types.DaemonStateRunning); err != nil {
 			log.L.WithError(err).Errorf("daemon %s is not managed to reach RUNNING state", d.ID())
 			return

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -176,15 +176,10 @@ func (m *Manager) doDaemonFailover(d *daemon.Daemon) {
 	}
 
 	// Failover nydusd still depends on the old supervisor
-
-	if err := m.StartDaemon(d); err != nil {
-		log.L.Errorf("fail to start daemon %s when recovering", d.ID())
-		return
-	}
+	m.StartDaemonUntilSubscribed(d)
 
 	if err := d.WaitUntilState(types.DaemonStateInit); err != nil {
-		log.L.WithError(err).Errorf("daemon didn't reach state %s,", types.DaemonStateInit)
-		return
+		log.L.WithError(err).Errorf("daemon didn't reach state %s", types.DaemonStateInit)
 	}
 
 	if err := d.TakeOver(); err != nil {
@@ -209,10 +204,7 @@ func (m *Manager) doDaemonRestart(d *daemon.Daemon) {
 	}
 
 	d.ClearVestige()
-	if err := m.StartDaemon(d); err != nil {
-		log.L.Errorf("fails to start daemon %s when recovering", d.ID())
-		return
-	}
+	m.StartDaemonUntilSubscribed(d)
 
 	// Mount rafs instance by http API
 	instances := d.Instances.List()

--- a/pkg/manager/monitor.go
+++ b/pkg/manager/monitor.go
@@ -29,6 +29,8 @@ type LivenessMonitor interface {
 	Subscribe(id string, path string, notifier chan<- deathEvent) error
 	// Unsubscribe death event of a nydusd daemon.
 	Unsubscribe(id string) error
+	// Check subscription status of a nydusd daemon.
+	IsSubscribed(id, path string) bool
 	// Run the monitor, wait for nydusd death event.
 	Run()
 	// Stop the monitor and release all the resources.
@@ -76,6 +78,16 @@ func newMonitor() (_ *livenessMonitor, err error) {
 	}
 
 	return m, nil
+}
+
+func (m *livenessMonitor) IsSubscribed(id, path string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if s, ok := m.subscribers[id]; ok && s.path == path {
+		return true
+	}
+	return false
 }
 
 func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deathEvent) (err error) {


### PR DESCRIPTION
In the faileover process, if the new daemon is unexpectedly killed before the new daemon is subscribed to by monitor, the manager will not retry to start the daemon to ensure that the new daemon runs successfully.

In this PR, the manager will retry to start the daemon if the process is not running.

Test command:
```shell
for i in $(seq 500);do ps -ef | grep nydusd| grep -v grep | awk '{print $2}'|xargs kill -9;sleep 0.01; done
```

Expected result: all nydusd will eventually recover.