### PR TITLE
Manager: add timeout when retrying to start daemon

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -83,6 +83,9 @@ type Daemon struct {
 	ref int32
 	// Cache the nydusd daemon state to avoid frequently querying nydusd by API.
 	state types.DaemonState
+
+	// Status of daemon process.
+	Process DaemonProcess
 }
 
 func (d *Daemon) Lock() {
@@ -670,6 +673,7 @@ func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 	d.States.ID = newID()
 	d.States.DaemonMode = config.DaemonModeDedicated
 	d.Instances = rafsSet{instances: make(map[string]*Rafs)}
+	d.Process = DaemonProcess{Status: DaemonProcessStatusUnknown}
 
 	for _, o := range opt {
 		err := o(d)

--- a/pkg/daemon/daemon_process.go
+++ b/pkg/daemon/daemon_process.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package daemon
+
+import "sync"
+
+type DaemonProcessStatus string
+
+const (
+	DaemonProcessStatusUnknown DaemonProcessStatus = "UNKNOWN"
+	DaemonProcessStatusRunning DaemonProcessStatus = "RUNNING"
+	DaemonProcessStatusExited  DaemonProcessStatus = "EXITED"
+)
+
+type DaemonProcess struct {
+	mu     sync.Mutex
+	Status DaemonProcessStatus
+}
+
+func (p *DaemonProcess) SetStatus(s DaemonProcessStatus) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.Status = s
+}
+
+func (p *DaemonProcess) IsExitedStatus() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.Status == DaemonProcessStatusExited
+}


### PR DESCRIPTION
Add timeout when retrying to start daemon to avoid dead loop.
Also, avoid the existing nydusd zombie process.

Related to https://github.com/containerd/nydus-snapshotter/pull/531