### PR TITLE
manager: avoid to start daemon in dead loop 

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -582,20 +582,6 @@ func (d *Daemon) Wait() error {
 	return nil
 }
 
-func (d *Daemon) IsProcessRunning() (bool, error) {
-	d.Lock()
-	defer d.Unlock()
-
-	if d.Pid() > 0 {
-		if _, err := os.FindProcess(d.Pid()); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-
-	return false, nil
-}
-
 // When daemon dies, clean up its vestige before start a new one.
 func (d *Daemon) ClearVestige() {
 	mounter := mount.Mounter{}

--- a/pkg/manager/monitor.go
+++ b/pkg/manager/monitor.go
@@ -29,8 +29,6 @@ type LivenessMonitor interface {
 	Subscribe(id string, path string, notifier chan<- deathEvent) error
 	// Unsubscribe death event of a nydusd daemon.
 	Unsubscribe(id string) error
-	// Check subscription status of a nydusd daemon.
-	IsSubscribed(id, path string) bool
 	// Run the monitor, wait for nydusd death event.
 	Run()
 	// Stop the monitor and release all the resources.
@@ -78,16 +76,6 @@ func newMonitor() (_ *livenessMonitor, err error) {
 	}
 
 	return m, nil
-}
-
-func (m *livenessMonitor) IsSubscribed(id, path string) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if s, ok := m.subscribers[id]; ok && s.path == path {
-		return true
-	}
-	return false
 }
 
 func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deathEvent) (err error) {


### PR DESCRIPTION
Revert https://github.com/containerd/nydus-snapshotter/pull/531 
If nydusd is not subscribed and is unexpectedly killed, send an event to the death event handler.