### PR TITLE
cache: fix null pointer access when cachemanager.Disable is true

### DIFF
--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -35,7 +35,6 @@ threads_number = 4
 # Log rotation size for nydusd, in unit MB(megabytes)
 log_rotation_size = 100
 
-
 [cgroup]
 # Whether to use separate cgroup for nydusd.
 enable = true
@@ -89,7 +88,9 @@ enable_kata_volume = false
 sync_remove = false
 
 [cache_manager]
+# Disable or enable recyclebin
 disable = false
+# How long to keep deleted files in recyclebin
 gc_period = "24h"
 # Directory to host cached files
 cache_dir = ""

--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -37,6 +37,7 @@ type Manager struct {
 }
 
 type Opt struct {
+	Disabled bool
 	CacheDir string
 	Period   time.Duration
 	Database *store.Database

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -208,17 +208,16 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 
 	cacheConfig := &cfg.CacheManagerConfig
-	if !cacheConfig.Disable {
-		cacheMgr, err := cache.NewManager(cache.Opt{
-			Database: db,
-			Period:   config.GetCacheGCPeriod(),
-			CacheDir: cacheConfig.CacheDir,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "create cache manager")
-		}
-		opts = append(opts, filesystem.WithCacheManager(cacheMgr))
+	cacheMgr, err := cache.NewManager(cache.Opt{
+		Database: db,
+		Period:   config.GetCacheGCPeriod(),
+		CacheDir: cacheConfig.CacheDir,
+		Disabled: cacheConfig.Disable,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "create cache manager")
 	}
+	opts = append(opts, filesystem.WithCacheManager(cacheMgr))
 
 	if cfg.Experimental.EnableReferrerDetect {
 		referrerMgr := referrer.NewManager(skipSSLVerify)


### PR DESCRIPTION
Filesystem.cacheMgr is null when cacheManager.Disable is configured to be true, thus cause null pointer access. Fix it by always create the cacheMgr object no matter cacheManager.Disable is true or false.