### PR TITLE
fix: update windows public functions to match linux

### DIFF
--- a/pkg/converter/convert_windows.go
+++ b/pkg/converter/convert_windows.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images/converter"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -22,11 +23,11 @@ func Pack(ctx context.Context, dest io.Writer, opt PackOption) (io.WriteCloser, 
 	panic("not implemented")
 }
 
-func Merge(ctx context.Context, layers []Layer, dest io.Writer, opt MergeOption) error {
+func Merge(ctx context.Context, layers []Layer, dest io.Writer, opt MergeOption) ([]digest.Digest, error) {
 	panic("not implemented")
 }
 
-func Unpack(ctx context.Context, ia content.ReaderAt, dest io.Writer, opt UnpackOption) error {
+func Unpack(ctx context.Context, ra content.ReaderAt, dest io.Writer, opt UnpackOption) error {
 	panic("not implemented")
 }
 
@@ -34,7 +35,11 @@ func IsNydusBlobAndExists(ctx context.Context, cs content.Store, desc ocispec.De
 	panic("not implemented")
 }
 
-func IsNydusBlob(ctx context.Context, desc ocispec.Descriptor) bool {
+func IsNydusBlob(desc ocispec.Descriptor) bool {
+	panic("not implemented")
+}
+
+func IsNydusBootstrap(desc ocispec.Descriptor) bool {
 	panic("not implemented")
 }
 
@@ -46,6 +51,6 @@ func ConvertHookFunc(opt MergeOption) converter.ConvertHookFunc {
 	panic("not implemented")
 }
 
-func MergeLayers(ctx context.Context, cs content.Store, descs []ocispec.Descriptor, opt MergeOption) (*ocispec.Descriptor, error) {
+func MergeLayers(ctx context.Context, cs content.Store, descs []ocispec.Descriptor, opt MergeOption) (*ocispec.Descriptor, []ocispec.Descriptor, error) {
 	panic("not implemented")
 }


### PR DESCRIPTION
Previously, the function signatures differed after being updated in b16a06858426dd2034bc361cb29805734e32d7c3. This patch updates the corresponding windows functions to match the linux signatures.

Discovered this in BuildKit when attempting to enable linting for Windows: https://github.com/moby/buildkit/pull/4261