### PR TITLE
workflow: fix containerd not ready error for optimizer test

### DIFF
--- a/.github/workflows/optimizer.yml
+++ b/.github/workflows/optimizer.yml
@@ -75,6 +75,21 @@ jobs:
           sudo install -D -m 755 misc/example/optimizer-nri-plugin.conf /etc/nri/conf.d/02-optimizer-nri-plugin.conf
           sudo systemctl restart containerd
           systemctl status containerd --no-pager -l
+      - name: Wait containerd ready
+        run: |
+          unset READY
+          for i in $(seq 30); do
+            if eval "timeout 180 ls /run/containerd/containerd.sock"; then
+                READY=true
+                break
+            fi
+            echo "Fail(${i}). Retrying..."
+            sleep 1
+          done
+          if [ "$READY" != "true" ];then
+            echo "containerd is not ready"
+            exit 1
+          fi
       - name: Generate accessed files list
         run: |
           sed -i "s|host_path: script|host_path: $(pwd)/misc/optimizer/script|g" misc/optimizer/nginx.yaml


### PR DESCRIPTION
This PR try to fix the error that contained is not ready when generating accessed files list in optimizer test.

The error is:
```
time="2023-09-21T10:06:07Z" level=fatal msg="running container: run pod sandbox: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial unix /run/containerd/containerd.sock: connect: no such file or directory\""
```