### PR TITLE
converter: move out encryption package

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -1168,7 +1168,7 @@ func MergeLayers(ctx context.Context, cs content.Store, descs []ocispec.Descript
 			blobDesc.Annotations[label.NydusRefLayer] = layers[idx].OriginalDigest.String()
 		}
 
-		if len(opt.EncryptRecipients) != 0 {
+		if opt.Encrypt != nil {
 			blobDesc.Annotations[LayerAnnotationNydusEncryptedBlob] = "true"
 		}
 
@@ -1195,9 +1195,9 @@ func MergeLayers(ctx context.Context, cs content.Store, descs []ocispec.Descript
 		},
 	}
 
-	if len(opt.EncryptRecipients) != 0 {
+	if opt.Encrypt != nil {
 		// Encrypt the Nydus bootstrap layer.
-		bootstrapDesc, err = EncryptNydusBootstrap(ctx, cs, bootstrapDesc, opt.EncryptRecipients)
+		bootstrapDesc, err = opt.Encrypt(ctx, cs, bootstrapDesc)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "encrypt bootstrap layer")
 		}

--- a/pkg/converter/types.go
+++ b/pkg/converter/types.go
@@ -21,6 +21,8 @@ import (
 
 type Compressor = uint32
 
+type Encrypter = func(context.Context, content.Store, ocispec.Descriptor) (ocispec.Descriptor, error)
+
 const (
 	CompressorNone     Compressor = 0x0000_0001
 	CompressorZstd     Compressor = 0x0000_0002
@@ -121,8 +123,8 @@ type MergeOption struct {
 	Backend Backend
 	// Timeout cancels execution once exceed the specified time.
 	Timeout *time.Duration
-	// Recipients to encrypt bootstrap, do not encrypt if empty.
-	EncryptRecipients []string
+	// Encrypt encrypts the bootstrap layer if it's specified.
+	Encrypt Encrypter
 }
 
 type UnpackOption struct {

--- a/pkg/encryption/encryption.go
+++ b/pkg/encryption/encryption.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package converter
+package encryption
 
 import (
 	"context"

--- a/tests/converter_test.go
+++ b/tests/converter_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/nydus-snapshotter/pkg/backend"
 	"github.com/containerd/nydus-snapshotter/pkg/converter"
+	"github.com/containerd/nydus-snapshotter/pkg/encryption"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const envNydusdPath = "NYDUS_NYDUSD"
@@ -809,15 +811,21 @@ func testImageConvertBasic(testOpt *ConvertTestOption) {
 		Backend:   testOpt.backend,
 	}
 	convertFunc := converter.LayerConvertFunc(*nydusOpts)
+	var encrypter converter.Encrypter
+	if len(testOpt.encryptRecipients) > 0 {
+		encrypter = func(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (ocispec.Descriptor, error) {
+			return encryption.EncryptNydusBootstrap(ctx, cs, desc, testOpt.encryptRecipients)
+		}
+	}
 	convertHooks := containerdconverter.ConvertHooks{
 		PostConvertHook: converter.ConvertHookFunc(converter.MergeOption{
-			WorkDir:           nydusOpts.WorkDir,
-			BuilderPath:       nydusOpts.BuilderPath,
-			FsVersion:         nydusOpts.FsVersion,
-			ChunkDictPath:     nydusOpts.ChunkDictPath,
-			Backend:           testOpt.backend,
-			PrefetchPatterns:  nydusOpts.PrefetchPatterns,
-			EncryptRecipients: testOpt.encryptRecipients,
+			WorkDir:          nydusOpts.WorkDir,
+			BuilderPath:      nydusOpts.BuilderPath,
+			FsVersion:        nydusOpts.FsVersion,
+			ChunkDictPath:    nydusOpts.ChunkDictPath,
+			Backend:          testOpt.backend,
+			PrefetchPatterns: nydusOpts.PrefetchPatterns,
+			Encrypt:          encrypter,
 		}),
 	}
 	convertFuncOpt := containerdconverter.WithIndexConvertFunc(


### PR DESCRIPTION
```
  Due to the introduction of the github.com/containers/ocicrypt package
  in converter, which brings in many other dependencies, but encryption
  should currently be an experimental optional feature, we need to move
  this part of the codes out to reduce the burden on other projects that
  reference the package.
```

Ref: https://github.com/moby/buildkit/pull/4288