### PR TITLE
[backport v0.13] converter: fix missed BatchSize arg for dir-rafs packing

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -408,6 +408,7 @@ func packFromDirectory(ctx context.Context, dest io.Writer, opt PackOption, buil
 				PrefetchPatterns: opt.PrefetchPatterns,
 				AlignedChunk:     opt.AlignedChunk,
 				ChunkSize:        opt.ChunkSize,
+				BatchSize:        opt.BatchSize,
 				Compressor:       opt.Compressor,
 				Timeout:          opt.Timeout,
 				Encrypt:          opt.Encrypt,


### PR DESCRIPTION
dir-rafs lacks the `batch-size` build parameter,
making the converting failed when tar-rafs is disabled and fallbacked to dir-rafs