### PR TITLE
daemon: add `amplify_io` support in nydusd configuration file

### DIFF
--- a/config/daemonconfig/daemonconfig_test.go
+++ b/config/daemonconfig/daemonconfig_test.go
@@ -46,6 +46,7 @@ func TestLoadConfig(t *testing.T) {
   "digest_validate": true,
   "iostats_files": true,
   "enable_xattr": true,
+  "amplify_io": 1048576,
   "fs_prefetch": {
     "enable": true,
     "threads_count": 10,

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -27,6 +27,7 @@ type FuseDaemonConfig struct {
 	EnableXattr     bool          `json:"enable_xattr,omitempty"`
 	AccessPattern   bool          `json:"access_pattern,omitempty"`
 	LatestReadFiles bool          `json:"latest_read_files,omitempty"`
+	AmplifyIo       int           `json:"amplify_io,omitempty"`
 	FSPrefetch      `json:"fs_prefetch,omitempty"`
 	// (experimental) The nydus daemon could cache more data to increase hit ratio when enabled the warmup feature.
 	Warmup uint64 `json:"warmup,omitempty"`

--- a/misc/snapshotter/nydusd-config-localfs.json
+++ b/misc/snapshotter/nydusd-config-localfs.json
@@ -14,6 +14,7 @@
   "digest_validate": false,
   "iostats_files": false,
   "enable_xattr": true,
+  "amplify_io": 1048576,
   "fs_prefetch": {
     "enable": true,
     "threads_count": 2

--- a/misc/snapshotter/nydusd-config.fusedev.json
+++ b/misc/snapshotter/nydusd-config.fusedev.json
@@ -16,6 +16,7 @@
   "digest_validate": false,
   "iostats_files": false,
   "enable_xattr": true,
+  "amplify_io": 1048576,
   "fs_prefetch": {
     "enable": true,
     "threads_count": 8,

--- a/pkg/stargz/testdata/config/nydus.json
+++ b/pkg/stargz/testdata/config/nydus.json
@@ -20,6 +20,7 @@
   "digest_validate": true,
   "iostats_files": true,
   "enable_xattr": true,
+  "amplify_io": 1048576,
   "fs_prefetch": {
     "enable": true,
     "threads_count": 10,

--- a/tests/e2e/k8s/snapshotter-cri.yaml
+++ b/tests/e2e/k8s/snapshotter-cri.yaml
@@ -107,6 +107,7 @@ data:
       "digest_validate": false,
       "iostats_files": false,
       "enable_xattr": true,
+      "amplify_io": 1048576,
       "fs_prefetch": {
         "enable": true,
         "threads_count": 10,

--- a/tests/e2e/k8s/snapshotter-kubeconf.yaml
+++ b/tests/e2e/k8s/snapshotter-kubeconf.yaml
@@ -130,6 +130,7 @@ data:
       "digest_validate": false,
       "iostats_files": false,
       "enable_xattr": true,
+      "amplify_io": 1048576,
       "fs_prefetch": {
         "enable": true,
         "threads_count": 10,

--- a/tests/nydusd.go
+++ b/tests/nydusd.go
@@ -67,7 +67,8 @@ var configTpl = `
 		"merging_size": 131072
 	},
 	"digest_validate": {{.DigestValidate}},
-	"enable_xattr": true
+	"enable_xattr": true,
+	"amplify_io": 1048576
 }
 `
 


### PR DESCRIPTION
Add `amplify_io` support, by reading and forwarding this arg.

`amplify_io` is an arg supported by nydusd to configure read amplification.

Related PR: https://github.com/dragonflyoss/nydus/pull/1452