### PR TITLE
release: Upload s390x tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,26 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        goarch:
+          - amd64
+          - s390x
+        include:
+          - goarch: amd64
+            rust_arch: x86_64
+          - goarch: s390x
+            rust_arch: s390x
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19.6"
+      - name: Install dependencies for multiarch build
+        run: |
+          sudo apt-get -y install gcc-s390x-linux-gnu
+          rustup target add s390x-unknown-linux-gnu
       - name: cache go mod
         uses: actions/cache@v3
         with:
@@ -41,17 +55,29 @@ jobs:
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
           export PATH=$PATH:$(go env GOPATH)/bin
+          export GOARCH=${{ matrix.goarch }}
+          export TARGET_ARCH=${{ matrix.rust_arch }}
           make static-release
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: nydus-snapshotter_artifacts
+          name: nydus-snapshotter_artifacts-${{ matrix.goarch }}
           path: |
             bin/containerd-nydus-grpc
             bin/nydus-overlayfs
             bin/optimizer-nri-plugin
             bin/optimizer-server
   upload:
+    strategy:
+      matrix:
+        goarch:
+          - amd64
+          - s390x
+        include:
+          - goarch: amd64
+            release_arch: x86_64
+          - goarch: s390x
+            release_arch: s390x
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -59,12 +85,12 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: nydus-snapshotter_artifacts
+          name: nydus-snapshotter_artifacts-${{ matrix.goarch }}
           path: nydus-snapshotter
       - name: Upload Artifacts
         run: |
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-          tarball="nydus-snapshotter-$tag-x86_64.tgz"
+          tarball="nydus-snapshotter-$tag-${{ matrix.release_arch }}.tgz"
           chmod +x nydus-snapshotter/*
           tar cf - nydus-snapshotter | gzip > ${tarball}
           echo "tag=$tag" >> $GITHUB_ENV
@@ -82,7 +108,7 @@ jobs:
             ${{ env.tarball }}
             ${{ env.tarball_shasum }}
 
-  publish-image:
+  publish-x86_64-image:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -97,7 +123,7 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@v3
         with:
-          name: nydus-snapshotter_artifacts
+          name: nydus-snapshotter_artifacts-amd64
           path: misc/snapshotter
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/tools/optimizer-server/Makefile
+++ b/tools/optimizer-server/Makefile
@@ -1,3 +1,10 @@
+TARGET_ARCH ?= x86_64
+EXTRA_RUSTFLAGS ?=
+
+ifeq ($(TARGET_ARCH), s390x)
+        override EXTRA_RUSTFLAGS += -C linker=s390x-linux-gnu-gcc
+endif
+
 all: build
 
 .PHONY: .release_version .format build release
@@ -16,7 +23,7 @@ release: .format .release_version build
 
 static-release: .format 
 	cargo clippy $(CARGO_BUILD_FLAGS) -- -Dwarnings
-	RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu
+	RUSTFLAGS="-C target-feature=+crt-static ${EXTRA_RUSTFLAGS}" cargo build --release --target ${TARGET_ARCH}-unknown-linux-gnu
 
 clean:
 	cargo clean


### PR DESCRIPTION
This series is the very start to allow shipping tarball including binaries for different architectures than x86_64.

The focus here is s390x, which is used by Confidential Containers, but this can easily be expanded in the future.

Last but not least, for now we have *no* interest in publishing a multi-architecture image.

Fixes: https://github.com/containerd/nydus-snapshotter/issues/548