### PR TITLE
Support sharing image on the host for layer block mode

### DIFF
--- a/pkg/filesystem/tarfs_adaptor.go
+++ b/pkg/filesystem/tarfs_adaptor.go
@@ -82,3 +82,10 @@ func (fs *Filesystem) GetTarfsImageDiskFilePath(id string) (string, error) {
 	}
 	return fs.tarfsMgr.ImageDiskFilePath(id), nil
 }
+
+func (fs *Filesystem) GetTarfsLayerDiskFilePath(id string) (string, error) {
+	if fs.tarfsMgr == nil {
+		return "", errors.New("tarfs mode is not enabled")
+	}
+	return fs.tarfsMgr.LayerDiskFilePath(id), nil
+}

--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -505,7 +505,7 @@ func (t *Manager) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[
 		diskFileName = t.ImageDiskFilePath(blobID)
 	} else {
 		metaFileName = t.layerMetaFilePath(storageLocater(snapshotID))
-		diskFileName = t.layerDiskFilePath(blobID)
+		diskFileName = t.LayerDiskFilePath(blobID)
 	}
 
 	// Do not regenerate if the disk image already exists.
@@ -821,7 +821,7 @@ func (t *Manager) layerTarFilePath(blobID string) string {
 	return filepath.Join(t.cacheDirPath, blobID)
 }
 
-func (t *Manager) layerDiskFilePath(blobID string) string {
+func (t *Manager) LayerDiskFilePath(blobID string) string {
 	return filepath.Join(t.cacheDirPath, blobID+"."+TarfsLayerDiskName)
 }
 

--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -466,10 +466,17 @@ func (t *Manager) ExportBlockData(s storage.Snapshot, perLayer bool, labels map[
 	updateFields := []string{}
 
 	wholeImage, exportDisk, withVerity := config.GetTarfsExportFlags()
+
+	log.L.Debugf("ExportBlockData wholeImage = %v, exportDisk = %v, withVerity = %v, perLayer = %v", wholeImage, exportDisk, withVerity, perLayer)
 	// Nothing to do for this case, all needed datum are ready.
 	if !exportDisk && !withVerity {
 		return updateFields, nil
 	} else if !wholeImage != perLayer {
+		// Special handling for `layer_block` mode
+		if exportDisk && !withVerity && !perLayer {
+			labels[label.NydusLayerBlockInfo] = ""
+			updateFields = append(updateFields, "labels."+label.NydusLayerBlockInfo)
+		}
 		return updateFields, nil
 	}
 

--- a/snapshot/mount_option.go
+++ b/snapshot/mount_option.go
@@ -151,10 +151,11 @@ func (o *snapshotter) mountWithKataVolume(ctx context.Context, id string, overla
 
 func (o *snapshotter) mountWithProxyVolume(rafs rafs.Rafs) ([]string, error) {
 	options := []string{}
+	source := rafs.Annotations[label.CRIImageRef]
 	for k, v := range rafs.Annotations {
 		options = append(options, fmt.Sprintf("%s=%s", k, v))
 	}
-	opt, err := o.prepareKataVirtualVolume(label.NydusProxyMode, "", KataVirtualVolumeImageGuestPullType, "", options, rafs.Annotations)
+	opt, err := o.prepareKataVirtualVolume(label.NydusProxyMode, source, KataVirtualVolumeImageGuestPullType, "", options, rafs.Annotations)
 	if err != nil {
 		return options, errors.Wrapf(err, "failed to prepare KataVirtualVolume")
 	}

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -52,7 +52,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 			}
 
 			logger.Infof("Nydus remote snapshot %s is ready", id)
-			mounts, err := sn.mountRemote(ctx, labels, s, id)
+			mounts, err := sn.mountRemote(ctx, labels, s, id, key)
 			return false, mounts, err
 		}
 	}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -433,7 +433,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 	}
 
 	if needRemoteMounts {
-		return o.mountRemote(ctx, info.Labels, *snap, metaSnapshotID)
+		return o.mountRemote(ctx, info.Labels, *snap, metaSnapshotID, key)
 	}
 
 	return o.mountNative(ctx, info.Labels, *snap)
@@ -531,7 +531,7 @@ func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 	}
 
 	if needRemoteMounts {
-		return o.mountRemote(ctx, base.Labels, s, metaSnapshotID)
+		return o.mountRemote(ctx, base.Labels, s, metaSnapshotID, key)
 	}
 	return o.mountNative(ctx, base.Labels, s)
 }
@@ -840,7 +840,7 @@ func overlayMount(options []string) []mount.Mount {
 
 // `s` is the upmost snapshot and `id` refers to the nydus meta snapshot
 // `s` and `id` can represent a different layer, it's useful when View an image
-func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string, s storage.Snapshot, id string) ([]mount.Mount, error) {
+func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string, s storage.Snapshot, id, key string) ([]mount.Mount, error) {
 	var overlayOptions []string
 	if _, ok := labels[label.OverlayfsVolatileOpt]; ok {
 		overlayOptions = append(overlayOptions, "volatile")
@@ -871,7 +871,7 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 	log.G(ctx).Infof("remote mount options %v", overlayOptions)
 
 	if o.enableKataVolume {
-		return o.mountWithKataVolume(ctx, id, overlayOptions)
+		return o.mountWithKataVolume(ctx, id, overlayOptions, key)
 	}
 	// Add `extraoption` if NydusOverlayFS is enable or daemonMode is `None`
 	if o.enableNydusOverlayFS || config.GetDaemonMode() == config.DaemonModeNone {


### PR DESCRIPTION
Nydus snapshotter supports both image block and layer block modes, with or without dm-verity. However, for confidential containers, nydus-snapshotter only supports image block mode, with or without dm-verity. Therefore, we need to extend nydus-snapshotter to support layer block mode, with or without dm-verity, for confidential containers as well.

options example for pulling `docker.io/library/nginx:latest `
```       
workdir=/var/lib/containerd-nydus/snapshots/8/work upperdir=/var/lib/containerd-nydus/snapshots/8/fs lowerdir=/var/lib/containerd-nydus/snapshots/7/fs
io.katacontainers.volume=eyJ2b2x1bWVfdHlwZSI6ImxheWVyX3Jhd19ibG9jayIsInNvdXJjZSI6Ii92YXIvbGliL2NvbnRhaW5lcmQtbnlkdXMvY2FjaGUvNTE3MzU3ODMxOTY3ODVkMWY2MDRkYzc3MTFlYTcwZmIzZmFiM2NkOWQ5OWVhZWZmOTkxYzVhZmJmYTBmMjBlOC5sYXllci5kaXNrIiwiZnNfdHlwZSI6ImVyb2ZzIiwib3B0aW9ucyI6WyJybyJdLCJkbV92ZXJpdHkiOnsiaGFzaHR5cGUiOiJzaGEyNTYiLCJoYXNoIjoiNmYzOTgyODNhMDBhNjllZTRmMWRkN2Y0MWJhNWEzNmRmY2FmYWY4ODNmYmQ5MzU2NmQ1ZmZlYmIxNzk2Njg0ZCIsImJsb2NrbnVtIjoxMDM4LCJibG9ja3NpemUiOjUxMiwiaGFzaHNpemUiOjQwOTYsIm9mZnNldCI6NTMyNDgwfX0=
io.katacontainers.volume=eyJ2b2x1bWVfdHlwZSI6ImxheWVyX3Jhd19ibG9jayIsInNvdXJjZSI6Ii92YXIvbGliL2NvbnRhaW5lcmQtbnlkdXMvY2FjaGUvODRiMWZmMTAzODdiMjZlMjk1MmYwMDZjMGE0ZmU0YzZmM2MwNzQzY2IwOGVlNDQ4YmI3MTU3MjIwYWQyZmM4Zi5sYXllci5kaXNrIiwiZnNfdHlwZSI6ImVyb2ZzIiwib3B0aW9ucyI6WyJybyJdLCJkbV92ZXJpdHkiOnsiaGFzaHR5cGUiOiJzaGEyNTYiLCJoYXNoIjoiODUxOGE2Y2UwOGY4NTViNzc1YWU1ZTFkNmU1YTAyMjBjMzA3ZmZlMGQ4ZGI1ZjY3NzlhNzMzN2M4ZTkyZDQ1OCIsImJsb2NrbnVtIjoxMDM0LCJibG9ja3NpemUiOjUxMiwiaGFzaHNpemUiOjQwOTYsIm9mZnNldCI6NTMyNDgwfX0= 
io.katacontainers.volume=eyJ2b2x1bWVfdHlwZSI6ImxheWVyX3Jhd19ibG9jayIsInNvdXJjZSI6Ii92YXIvbGliL2NvbnRhaW5lcmQtbnlkdXMvY2FjaGUvYzZlZGYzM2UyNTI0YjI0MWEwYjE5MWQwYTBkMmNhM2Q4ZDRhZTc0NzAzMzNiMDU5ZGQ5N2JhMzBlNjYzYTFhMy5sYXllci5kaXNrIiwiZnNfdHlwZSI6ImVyb2ZzIiwib3B0aW9ucyI6WyJybyJdLCJkbV92ZXJpdHkiOnsiaGFzaHR5cGUiOiJzaGEyNTYiLCJoYXNoIjoiZmIzODQ1MDliZDU4NzFiN2JlMTA3Mjc0NjcxYWE1YWJiNTMwODgyYjBmMjA1NWU5YjljNDBiODMyNWFkZGM2ZSIsImJsb2NrbnVtIjoxMDI5LCJibG9ja3NpemUiOjUxMiwiaGFzaHNpemUiOjQwOTYsIm9mZnNldCI6NTI4Mzg0fX0= 
io.katacontainers.volume=eyJ2b2x1bWVfdHlwZSI6ImxheWVyX3Jhd19ibG9jayIsInNvdXJjZSI6Ii92YXIvbGliL2NvbnRhaW5lcmQtbnlkdXMvY2FjaGUvOWVhMjdiMDc0ZjcxZDU3NjZhNTljZGJmYWExNWY0Y2QzZDE3YmZmYjgzZmVkMDY2MzczZWIyODczMjZhYmJkMy5sYXllci5kaXNrIiwiZnNfdHlwZSI6ImVyb2ZzIiwib3B0aW9ucyI6WyJybyJdLCJkbV92ZXJpdHkiOnsiaGFzaHR5cGUiOiJzaGEyNTYiLCJoYXNoIjoiZjMzZjJlOWU3YmYxNjkzNGE3YTMxMjQxNDU1ZjYxNDRmMGRmOWNiNGNjZDEzMjNiMDczYmUwNjRiODg2ZDNkOCIsImJsb2NrbnVtIjoxMDMzLCJibG9ja3NpemUiOjUxMiwiaGFzaHNpemUiOjQwOTYsIm9mZnNldCI6NTMyNDgwfX0= 
io.katacontainers.volume=eyJ2b2x1bWVfdHlwZSI6ImxheWVyX3Jhd19ibG9jayIsInNvdXJjZSI6Ii92YXIvbGliL2NvbnRhaW5lcmQtbnlkdXMvY2FjaGUvOWE1OWQxOWY5YzViYjFlYmRmZWYyMjU1NDk2YjFiYjVkNjU4ZmRjY2MzMDBjNGMxZjBkMThjNzNmMWJiMTRiNS5sYXllci5kaXNrIiwiZnNfdHlwZSI6ImVyb2ZzIiwib3B0aW9ucyI6WyJybyJdLCJkbV92ZXJpdHkiOnsiaGFzaHR5cGUiOiJzaGEyNTYiLCJoYXNoIjoiZDRlYTQ1NjhjNDFhNzVmZTAzMTZiY2QwMjc4YjNlMzMwMGQ1M2RlNzEwNGUwOTYyNDI1ZjgwYmQwNjg5ZjBiNiIsImJsb2NrbnVtIjoxMDMxLCJibG9ja3NpemUiOjUxMiwiaGFzaHNpemUiOjQwOTYsIm9mZnNldCI6NTI4Mzg0fX0= 
io.katacontainers.volume=eyJ2b2x1bWVfdHlwZSI6ImxheWVyX3Jhd19ibG9jayIsInNvdXJjZSI6Ii92YXIvbGliL2NvbnRhaW5lcmQtbnlkdXMvY2FjaGUvOWIxNmM5NGJiNjg2Mjg3NTNhOTRiODlkZGYyNmFiYzA5NzRjZDM1YTk2Zjc4NTg5NWFiMDExZDliNTA0MmVlNS5sYXllci5kaXNrIiwiZnNfdHlwZSI6ImVyb2ZzIiwib3B0aW9ucyI6WyJybyJdLCJkbV92ZXJpdHkiOnsiaGFzaHR5cGUiOiJzaGEyNTYiLCJoYXNoIjoiZTc4ZjI2MjNiMWFlY2U5OGYyZjQ4ZmVjMGMyMmNlOTZlNDczZjYwN2M2OTc2ZDI2MWM1MGM3YzQxNDNjOTdjOCIsImJsb2NrbnVtIjoyMjE4MzEsImJsb2Nrc2l6ZSI6NTEyLCJoYXNoc2l6ZSI6NDA5Niwib2Zmc2V0IjoxMTM1Nzc5ODR9fQ== 
io.katacontainers.volume=eyJ2b2x1bWVfdHlwZSI6ImxheWVyX3Jhd19ibG9jayIsInNvdXJjZSI6Ii92YXIvbGliL2NvbnRhaW5lcmQtbnlkdXMvY2FjaGUvMWY3Y2UyZmE0NmFiMzk0MmZlYWJlZTY1NDkzMzk0ODgyMTMwM2E1YTgyMTc4OWRkZGFiMmQ4YzNkZjU5ZTIyNy5sYXllci5kaXNrIiwiZnNfdHlwZSI6ImVyb2ZzIiwib3B0aW9ucyI6WyJybyJdLCJkbV92ZXJpdHkiOnsiaGFzaHR5cGUiOiJzaGEyNTYiLCJoYXNoIjoiYTY0NDcwYjZkNDA0NGEyODVjNTNkOTEwNWM4ZTZhNjZmNmU3NGQwZGRmNTJjZTk1YjZjMTRkOGEzY2VlMTI5MyIsImJsb2NrbnVtIjoxNTQxMzksImJsb2Nrc2l6ZSI6NTEyLCJoYXNoc2l6ZSI6NDA5Niwib2Zmc2V0Ijo3ODkyMTcyOH19
```
decoded data:
```
{"volume_type":"layer_raw_block","source":"/var/lib/containerd-nydus/cache/51735783196785d1f604dc7711ea70fb3fab3cd9d99eaeff991c5afbfa0f20e8.layer.disk","fs_type":"erofs","options":["ro"],"dm_verity":{"hashtype":"sha256","hash":"6f398283a00a69ee4f1dd7f41ba5a36dfcafaf883fbd93566d5ffebb1796684d","blocknum":1038,"blocksize":512,"hashsize":4096,"offset":532480}}
{"volume_type":"layer_raw_block","source":"/var/lib/containerd-nydus/cache/84b1ff10387b26e2952f006c0a4fe4c6f3c0743cb08ee448bb7157220ad2fc8f.layer.disk","fs_type":"erofs","options":["ro"],"dm_verity":{"hashtype":"sha256","hash":"8518a6ce08f855b775ae5e1d6e5a0220c307ffe0d8db5f6779a7337c8e92d458","blocknum":1034,"blocksize":512,"hashsize":4096,"offset":532480}}
{"volume_type":"layer_raw_block","source":"/var/lib/containerd-nydus/cache/c6edf33e2524b241a0b191d0a0d2ca3d8d4ae7470333b059dd97ba30e663a1a3.layer.disk","fs_type":"erofs","options":["ro"],"dm_verity":{"hashtype":"sha256","hash":"fb384509bd5871b7be107274671aa5abb530882b0f2055e9b9c40b8325addc6e","blocknum":1029,"blocksize":512,"hashsize":4096,"offset":528384}}
{"volume_type":"layer_raw_block","source":"/var/lib/containerd-nydus/cache/9ea27b074f71d5766a59cdbfaa15f4cd3d17bffb83fed066373eb287326abbd3.layer.disk","fs_type":"erofs","options":["ro"],"dm_verity":{"hashtype":"sha256","hash":"f33f2e9e7bf16934a7a31241455f6144f0df9cb4ccd1323b073be064b886d3d8","blocknum":1033,"blocksize":512,"hashsize":4096,"offset":532480}}
{"volume_type":"layer_raw_block","source":"/var/lib/containerd-nydus/cache/9a59d19f9c5bb1ebdfef2255496b1bb5d658fdccc300c4c1f0d18c73f1bb14b5.layer.disk","fs_type":"erofs","options":["ro"],"dm_verity":{"hashtype":"sha256","hash":"d4ea4568c41a75fe0316bcd0278b3e3300d53de7104e0962425f80bd0689f0b6","blocknum":1031,"blocksize":512,"hashsize":4096,"offset":528384}}
{"volume_type":"layer_raw_block","source":"/var/lib/containerd-nydus/cache/9b16c94bb68628753a94b89ddf26abc0974cd35a96f785895ab011d9b5042ee5.layer.disk","fs_type":"erofs","options":["ro"],"dm_verity":{"hashtype":"sha256","hash":"e78f2623b1aece98f2f48fec0c22ce96e473f607c6976d261c50c7c4143c97c8","blocknum":221831,"blocksize":512,"hashsize":4096,"offset":113577984}}
{"volume_type":"layer_raw_block","source":"/var/lib/containerd-nydus/cache/1f7ce2fa46ab3942feabee654933948821303a5a821789dddab2d8c3df59e227.layer.disk","fs_type":"erofs","options":["ro"],"dm_verity":{"hashtype":"sha256","hash":"a64470b6d4044a285c53d9105c8e6a66f6e74d0ddf52ce95b6c14d8a3cee1293","blocknum":154139,"blocksize":512,"hashsize":4096,"offset":78921728}}
```

Fixes: #559 