### PR TITLE
release: get latest nydusd version from Github API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,12 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Get the nydusd version
+        id: step_one
+        run: |
+          export NYDUS_STABLE_VER=$(curl https://api.github.com/repos/dragonflyoss/nydus/releases/latest | jq -r .tag_name)
+          echo "NYDUS_STABLE_VER=$NYDUS_STABLE_VER" >> "$GITHUB_ENV"
+          printf 'nydus version is: %s\n' "$NYDUS_STABLE_VER"
       - name: build and push nydus-snapshotter image
         uses: docker/build-push-action@v3
         with:
@@ -112,3 +118,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: NYDUS_VER=${{ env.NYDUS_STABLE_VER }}


### PR DESCRIPTION
In our released nydus-snapshotter images, the nydusd version is always v2.1.5, and this patch fixes that.