### PR TITLE
action: fix incorrect release asset link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          name: "Nydus Snapshotter ${{ env.tag }} Release"
+          name: "Nydus Snapshotter ${{ github.ref_name }} Release"
           generate_release_notes: true
           files: |
             builds/release-tars-**/*
@@ -120,12 +120,6 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Get the nydusd version
-        id: step_one
-        run: |
-          export NYDUS_STABLE_VER=$(curl https://api.github.com/repos/dragonflyoss/nydus/releases/latest | jq -r .tag_name)
-          echo "NYDUS_STABLE_VER=$NYDUS_STABLE_VER" >> "$GITHUB_ENV"
-          printf 'nydus version is: %s\n' "$NYDUS_STABLE_VER"
       - name: build and push nydus-snapshotter image
         uses: docker/build-push-action@v3
         with:
@@ -134,4 +128,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: NYDUS_VER=${{ env.NYDUS_STABLE_VER }}
+          build-args: NYDUS_VER=${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
 
-RELEASE=nydus-snapshotter-$(VERSION:v%=%)-${GOOS}-${GOARCH}
-STATIC_RELEASE=nydus-snapshotter-$(VERSION:v%=%)-${GOOS}-static
+RELEASE=nydus-snapshotter-v$(VERSION:v%=%)-${GOOS}-${GOARCH}
+STATIC_RELEASE=nydus-snapshotter-v$(VERSION:v%=%)-${GOOS}-static
 
 # Relpace test target images for e2e tests.
 ifdef E2E_TEST_TARGET_IMAGES_FILE


### PR DESCRIPTION
Fixed the asset link in github release page from
`nydus-snapshotter-x.x.x-linux-amd64.tar.gz` to `nydus-snapshotter-vx.x.x-linux-amd64.tar.gz`

Tested release: https://github.com/imeoer/nydus-snapshotter/releases/tag/v0.13.8