### PR TITLE
action: fix failed image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,11 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Get the nydusd version
+        run: |
+          export NYDUS_STABLE_VER=$(curl https://api.github.com/repos/dragonflyoss/nydus/releases/latest | jq -r .tag_name)
+          echo "NYDUS_STABLE_VER=$NYDUS_STABLE_VER" >> "$GITHUB_ENV"
+          printf 'nydus version is: %s\n' "$NYDUS_STABLE_VER"
       - name: build and push nydus-snapshotter image
         uses: docker/build-push-action@v3
         with:
@@ -128,4 +133,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: NYDUS_VER=${{ github.ref_name }}
+          build-args: NYDUS_VER=${{ env.NYDUS_STABLE_VER }}


### PR DESCRIPTION
The nydus latest reelase version should be got from dragonfly/nydus repo.

Tested CI: https://github.com/imeoer/nydus-snapshotter/actions/runs/7709106171/job/21009677183