### PR TITLE
action: update nodejs20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,48 +15,36 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.20.1"
       - name: Check out code
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55.2
+          skip-cache: true
       - name: Build
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
-          export PATH=$PATH:$(go env GOPATH)/bin
           make
           make test
-          make check
   build-optimizer:
     name: Build optimizer
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.20.1"
       - name: Check out code
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: Build
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
-          export PATH=$PATH:$(go env GOPATH)/bin
           rustup component add rustfmt clippy
           make build-optimizer
   smoke:
@@ -64,21 +52,15 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.6"
       - name: Check out code
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: Set up containerd
-        uses: crazy-max/ghaction-setup-containerd@v2
+        uses: crazy-max/ghaction-setup-containerd@v3
       - name: Build
         run: |
           # Download nydus components
@@ -99,19 +81,13 @@ jobs:
         GOOS: ["linux", "windows", "darwin"]
         GOARCH: ["amd64", "arm64"]
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.6"
       - name: Check out code
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: Build
         run: |
           make -e GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} converter
@@ -122,23 +98,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.6"
       - name: Checkout code
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: Run unit tests.
         run: make cover
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./coverage.txt

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,21 +22,15 @@ jobs:
   run-e2e-for-cgroups-v1:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.6"
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: Log in to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,21 +45,15 @@ jobs:
   run-e2e-for-cgroups-v2:
     runs-on: ubuntu-22.04
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.6"
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: Log in to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -17,13 +17,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.19.6"
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.5.0
         with:

--- a/.github/workflows/optimizer.yml
+++ b/.github/workflows/optimizer.yml
@@ -21,21 +21,15 @@ jobs:
   run_optimizer:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.6"
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
       - name: cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -60,7 +60,7 @@ func LoadFuseConfig(p string) (*FuseDaemonConfig, error) {
 	return &cfg, nil
 }
 
-func (c *FuseDaemonConfig) Supplement(host, repo, snapshotID string, params map[string]string) {
+func (c *FuseDaemonConfig) Supplement(host, repo, _ string, params map[string]string) {
 	c.Device.Backend.Config.Host = host
 	c.Device.Backend.Config.Repo = repo
 	c.Device.Cache.Config.WorkDir = params[CacheDir]

--- a/pkg/auth/image_proxy_test.go
+++ b/pkg/auth/image_proxy_test.go
@@ -25,7 +25,7 @@ type MockAlphaImageService struct {
 	runtime_alpha.UnimplementedImageServiceServer
 }
 
-func (*MockAlphaImageService) PullImage(ctx context.Context, req *runtime_alpha.PullImageRequest) (*runtime_alpha.PullImageResponse, error) {
+func (*MockAlphaImageService) PullImage(_ context.Context, _ *runtime_alpha.PullImageRequest) (*runtime_alpha.PullImageResponse, error) {
 	return &runtime_alpha.PullImageResponse{}, nil
 }
 
@@ -33,7 +33,7 @@ type MockImageService struct {
 	runtime.UnimplementedImageServiceServer
 }
 
-func (*MockImageService) PullImage(ctx context.Context, req *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
+func (*MockImageService) PullImage(_ context.Context, _ *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
 	return &runtime.PullImageResponse{}, nil
 }
 

--- a/pkg/auth/keychain.go
+++ b/pkg/auth/keychain.go
@@ -117,7 +117,7 @@ func GetKeyChainByRef(ref string, labels map[string]string) (*PassKeyChain, erro
 	return keychain, nil
 }
 
-func (kc PassKeyChain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+func (kc PassKeyChain) Resolve(_ authn.Resource) (authn.Authenticator, error) {
 	return authn.FromConfig(kc.toAuthConfig()), nil
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -300,17 +300,13 @@ func (d *Daemon) sharedErofsMount(ra *rafs.Rafs) error {
 		return errors.Wrapf(err, "create mountpoint %s", mountPoint)
 	}
 
-	bootstrapPath, err := ra.BootstrapFile()
-	if err != nil {
-		return err
-	}
 	fscacheID := erofs.FscacheID(ra.SnapshotID)
 
 	cfg := c.(*daemonconfig.FscacheDaemonConfig)
 	ra.AddAnnotation(rafs.AnnoFsCacheDomainID, cfg.DomainID)
 	ra.AddAnnotation(rafs.AnnoFsCacheID, fscacheID)
 
-	if err := erofs.Mount(bootstrapPath, cfg.DomainID, fscacheID, mountPoint); err != nil {
+	if err := erofs.Mount(cfg.DomainID, fscacheID, mountPoint); err != nil {
 		if !errdefs.IsErofsMounted(err) {
 			return errors.Wrapf(err, "mount erofs to %s", mountPoint)
 		}

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -384,7 +384,7 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 	return nil
 }
 
-func (fs *Filesystem) Umount(ctx context.Context, snapshotID string) error {
+func (fs *Filesystem) Umount(_ context.Context, snapshotID string) error {
 	rafs := racache.RafsGlobalCache.Get(snapshotID)
 	if rafs == nil {
 		log.L.Debugf("no RAFS filesystem instance associated with snapshot %s", snapshotID)

--- a/pkg/filesystem/stargz_adaptor.go
+++ b/pkg/filesystem/stargz_adaptor.go
@@ -162,7 +162,7 @@ func (fs *Filesystem) MergeStargzMetaLayer(ctx context.Context, s storage.Snapsh
 // Generate nydus bootstrap from stargz layers
 // Download estargz TOC part from each layer as `nydus-image` conversion source.
 // After conversion, a nydus metadata or bootstrap is used to pointing to each estargz blob
-func (fs *Filesystem) PrepareStargzMetaLayer(blob *stargz.Blob, storagePath string, labels map[string]string) error {
+func (fs *Filesystem) PrepareStargzMetaLayer(blob *stargz.Blob, storagePath string, _ map[string]string) error {
 	ref := blob.GetImageReference()
 	layerDigest := blob.GetDigest()
 

--- a/pkg/metrics/serve.go
+++ b/pkg/metrics/serve.go
@@ -63,7 +63,7 @@ func NewServer(ctx context.Context, opts ...ServerOpt) (*Server, error) {
 	return &s, nil
 }
 
-func (s *Server) CollectDaemonResourceMetrics(ctx context.Context) {
+func (s *Server) CollectDaemonResourceMetrics(_ context.Context) {
 	var daemonResource collector.DaemonResourceCollector
 	for _, pm := range s.managers {
 		// Collect daemon resource usage metrics.

--- a/pkg/rafs/rafs.go
+++ b/pkg/rafs/rafs.go
@@ -74,10 +74,9 @@ func (rs *Cache) Get(snapshotID string) *Rafs {
 
 func (rs *Cache) Len() int {
 	rs.mu.Lock()
-	len := len(rs.instances)
-	rs.mu.Unlock()
+	defer rs.mu.Unlock()
 
-	return len
+	return len(rs.instances)
 }
 
 func (rs *Cache) Head() *Rafs {

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -114,7 +114,7 @@ func (remote *Remote) RetryWithPlainHTTP(ref string, err error) bool {
 	return remote.withPlainHTTP
 }
 
-func (remote *Remote) Resolve(ctx context.Context, ref string) remotes.Resolver {
+func (remote *Remote) Resolve(_ context.Context, _ string) remotes.Resolver {
 	return remote.resolverFunc(remote.withPlainHTTP)
 }
 

--- a/pkg/remote/unpack.go
+++ b/pkg/remote/unpack.go
@@ -31,9 +31,8 @@ func Unpack(reader io.Reader, source, target string) error {
 		if err != nil {
 			if err == io.EOF {
 				break
-			} else {
-				return err
 			}
+			return err
 		}
 		if hdr.Name == source {
 			file, err := os.Create(target)

--- a/pkg/stargz/resolver_test.go
+++ b/pkg/stargz/resolver_test.go
@@ -56,7 +56,7 @@ func TestResolver_resolve(t *testing.T) {
 type MockResolver struct {
 }
 
-func (res *MockResolver) Resolve(ref name.Reference, digest string, keychain authn.Keychain) (string, http.RoundTripper, error) {
+func (res *MockResolver) Resolve(_ name.Reference, _ string, _ authn.Keychain) (string, http.RoundTripper, error) {
 	return "http://oss.com/v2/test/myserver/blobs/sha256:mock", &mockRoundTripper{}, nil
 }
 

--- a/pkg/store/database.go
+++ b/pkg/store/database.go
@@ -199,7 +199,7 @@ func (db *Database) Close() error {
 	return nil
 }
 
-func (db *Database) SaveDaemon(ctx context.Context, d *daemon.Daemon) error {
+func (db *Database) SaveDaemon(_ context.Context, d *daemon.Daemon) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		bucket := getDaemonsBucket(tx)
 		var existing daemon.ConfigState
@@ -210,7 +210,7 @@ func (db *Database) SaveDaemon(ctx context.Context, d *daemon.Daemon) error {
 	})
 }
 
-func (db *Database) UpdateDaemon(ctx context.Context, d *daemon.Daemon) error {
+func (db *Database) UpdateDaemon(_ context.Context, d *daemon.Daemon) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		bucket := getDaemonsBucket(tx)
 
@@ -223,7 +223,7 @@ func (db *Database) UpdateDaemon(ctx context.Context, d *daemon.Daemon) error {
 	})
 }
 
-func (db *Database) DeleteDaemon(ctx context.Context, id string) error {
+func (db *Database) DeleteDaemon(_ context.Context, id string) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		bucket := getDaemonsBucket(tx)
 
@@ -236,7 +236,7 @@ func (db *Database) DeleteDaemon(ctx context.Context, id string) error {
 }
 
 // Cleanup deletes all daemon records
-func (db *Database) CleanupDaemons(ctx context.Context) error {
+func (db *Database) CleanupDaemons(_ context.Context) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		bucket := getDaemonsBucket(tx)
 
@@ -246,7 +246,7 @@ func (db *Database) CleanupDaemons(ctx context.Context) error {
 	})
 }
 
-func (db *Database) WalkDaemons(ctx context.Context, cb func(info *daemon.ConfigState) error) error {
+func (db *Database) WalkDaemons(_ context.Context, cb func(info *daemon.ConfigState) error) error {
 	return db.db.View(func(tx *bolt.Tx) error {
 		bucket := getDaemonsBucket(tx)
 
@@ -263,7 +263,7 @@ func (db *Database) WalkDaemons(ctx context.Context, cb func(info *daemon.Config
 }
 
 // WalkDaemons iterates all daemon records and invoke callback on each
-func (db *Database) WalkRafsInstances(ctx context.Context, cb func(r *rafs.Rafs) error) error {
+func (db *Database) WalkRafsInstances(_ context.Context, cb func(r *rafs.Rafs) error) error {
 	return db.db.View(func(tx *bolt.Tx) error {
 		bucket := getInstancesBucket(tx)
 
@@ -279,7 +279,7 @@ func (db *Database) WalkRafsInstances(ctx context.Context, cb func(r *rafs.Rafs)
 	})
 }
 
-func (db *Database) AddRafsInstance(ctx context.Context, instance *rafs.Rafs) error {
+func (db *Database) AddRafsInstance(_ context.Context, instance *rafs.Rafs) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		bucket := getInstancesBucket(tx)
 
@@ -287,7 +287,7 @@ func (db *Database) AddRafsInstance(ctx context.Context, instance *rafs.Rafs) er
 	})
 }
 
-func (db *Database) DeleteRafsInstance(ctx context.Context, snapshotID string) error {
+func (db *Database) DeleteRafsInstance(_ context.Context, snapshotID string) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		bucket := getInstancesBucket(tx)
 

--- a/pkg/store/database_compat.go
+++ b/pkg/store/database_compat.go
@@ -42,7 +42,7 @@ type CompatDaemon struct {
 	CustomMountPoint *string
 }
 
-func (db *Database) WalkCompatDaemons(ctx context.Context, handler func(cd *CompatDaemon) error) error {
+func (db *Database) WalkCompatDaemons(_ context.Context, handler func(cd *CompatDaemon) error) error {
 
 	return db.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(daemonsBucket)

--- a/pkg/utils/erofs/erofs.go
+++ b/pkg/utils/erofs/erofs.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Mount(bootstrapPath, domainID, fscacheID, mountpoint string) error {
+func Mount(domainID, fscacheID, mountpoint string) error {
 	mount := unix.Mount
 	var opts string
 


### PR DESCRIPTION
1. use `nodejs 20` version action: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ .
2. update golangci-lint v1.55.2 and use official GitHub action for [golangci-lint](https://github.com/golangci/golangci-lint).
3. use setup-go @v5 native cache ability.
4. fix lint errors.