### PR TITLE
misc: fix incorrect nydus-overlayfs version

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -4,7 +4,7 @@ ARG CONTAINERD_PROJECT=/containerd
 ARG RUNC_VERSION=1.1.4
 ARG NYDUS_SNAPSHOTTER_PROJECT=/nydus-snapshotter
 ARG DOWNLOADS_MIRROR="https://github.com"
-ARG NYDUS_VER=2.1.4
+ARG NYDUS_VER=2.2.4
 ARG NERDCTL_VER=1.0.0
 
 FROM golang:1.19.6-bullseye AS golang-base
@@ -29,25 +29,25 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install containerd
 RUN wget ${DOWNLOADS_MIRROR}/containerd/containerd/releases/download/v${CONTAINERD_VER}/containerd-${CONTAINERD_VER}-linux-amd64.tar.gz && \
-tar xzf containerd-${CONTAINERD_VER}-linux-amd64.tar.gz && \
-install -D -m 755 bin/* /usr/local/bin/
+  tar xzf containerd-${CONTAINERD_VER}-linux-amd64.tar.gz && \
+  install -D -m 755 bin/* /usr/local/bin/
 COPY misc/example/containerd-config.toml /etc/containerd/config.toml
 
 # Install runc
 RUN wget ${DOWNLOADS_MIRROR}/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.amd64 && \
-install -D -m 755 runc.amd64 /usr/local/bin/runc
+  install -D -m 755 runc.amd64 /usr/local/bin/runc
 
 # Install nydusd nydus-image
 RUN  wget ${DOWNLOADS_MIRROR}/dragonflyoss/nydus/releases/download/v${NYDUS_VER}/nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
-tar xzf nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
-install -D -m 755 nydus-static/nydusd /usr/local/bin/nydusd && \
-install -D -m 755 nydus-static/nydus-image /usr/local/bin/nydus-image && \
-install -D -m 755 nydus-static/nydusctl /usr/local/bin/nydusctl
+  tar xzf nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
+  install -D -m 755 nydus-static/nydusd /usr/local/bin/nydusd && \
+  install -D -m 755 nydus-static/nydus-image /usr/local/bin/nydus-image && \
+  install -D -m 755 nydus-static/nydusctl /usr/local/bin/nydusctl
 
 # Install nerdctl
 RUN wget ${DOWNLOADS_MIRROR}/containerd/nerdctl/releases/download/v${NERDCTL_VER}/nerdctl-${NERDCTL_VER}-linux-amd64.tar.gz && \
-tar xzf nerdctl-${NERDCTL_VER}-linux-amd64.tar.gz && \
-install -D -m 755 nerdctl /usr/local/bin/nerdctl
+  tar xzf nerdctl-${NERDCTL_VER}-linux-amd64.tar.gz && \
+  install -D -m 755 nerdctl /usr/local/bin/nerdctl
 
 # Install fscache driver configuration file
 COPY misc/snapshotter/nydusd-config.fscache.json /etc/nydus/nydusd-config.fscache.json

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.17.0 AS base
 
 FROM base AS sourcer
-ARG NYDUS_VER=v2.1.5
+ARG NYDUS_VER=v2.2.4
 
 RUN apk add --no-cache curl && \
     apk add --no-cache --upgrade grep && \
@@ -9,7 +9,8 @@ RUN apk add --no-cache curl && \
     echo $NYDUS_VER > /.nydus_version && \
     tar xzf nydus-static-$NYDUS_VER-linux-amd64.tgz && \
     rm nydus-static-$NYDUS_VER-linux-amd64.tgz && \
-    mv nydus-static/* /
+    mv nydus-static/* / \
+    && rm -rf /nydus-overlayfs
 
 FROM base AS kubectl-sourcer
 RUN apk add --no-cache curl && \
@@ -35,12 +36,11 @@ COPY --from=kubectl-sourcer /usr/bin/kubectl /usr/bin/kubectl
 
 RUN mkdir -p ${CONFIG_DESTINATION} ${BINARY_DESTINATION} ${SCRIPT_DESTINATION} /var/lib/containerd-nydus/cache /tmp/blobs/
 COPY --from=sourcer /nydus* ${BINARY_DESTINATION}/
-COPY containerd-nydus-grpc ${BINARY_DESTINATION}/
+COPY containerd-nydus-grpc nydus-overlayfs ${BINARY_DESTINATION}/
 COPY snapshotter.sh ${SCRIPT_DESTINATION}/snapshotter.sh
-RUN chmod +x ${BINARY_DESTINATION}/containerd-nydus-grpc ${SCRIPT_DESTINATION}/snapshotter.sh
+RUN chmod +x ${BINARY_DESTINATION}/containerd-nydus-grpc ${BINARY_DESTINATION}/nydus-overlayfs ${SCRIPT_DESTINATION}/snapshotter.sh
 COPY nydusd-config.fusedev.json ${CONFIG_DESTINATION}/nydusd-fusedev.json
 COPY nydusd-config-localfs.json ${CONFIG_DESTINATION}/nydusd-localfs.json
 COPY nydusd-config.fscache.json ${CONFIG_DESTINATION}/nydusd-fscache.json
 COPY config.toml ${CONFIG_DESTINATION}/config.toml
 COPY nydus-snapshotter.service ${DESTINATION}/etc/systemd/system/nydus-snapshotter.service
-


### PR DESCRIPTION
1. The nydus-overlayfs component has been moved into the cmd/nydus-overlayfs directory in snapshotter repository, we should also use the nydus-overlayfs binary in docker image.

2. Bump the nydus binary version v2.2.4, it's the latest stable release.