### PR TITLE
action: enable nydus-snapshotter image to support multi-arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,9 +98,27 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     needs: [build]
+    strategy:
+      matrix:
+        include:
+          - build-os: linux
+            build-arch: amd64
+          - build-os: linux
+            build-arch: arm64
+          - build-os: linux
+            build-arch: s390x
+          - build-os: linux
+            build-arch: ppc64le
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the container registry
         uses: docker/login-action@v2
         with:
@@ -110,7 +128,7 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@v3
         with:
-          name: release-tars-linux-static
+          name: release-tars-${{ matrix.build-os }}-${{ matrix.build-arch }}
           path: misc/snapshotter
       - name: unpack static release
         run: |
@@ -131,6 +149,29 @@ jobs:
           context: misc/snapshotter
           file: misc/snapshotter/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.build-os }}/${{ matrix.build-arch }}
+          tags: ${{ steps.meta.outputs.tags }}-${{ matrix.build-arch }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: NYDUS_VER=${{ env.NYDUS_STABLE_VER }}
+
+  publish-manifest:
+    runs-on: ubuntu-latest
+    needs: [publish-image]
+    steps:
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Publish manifest for multi-arch image
+        run: |
+          docker manifest create ${{ steps.meta.outputs.tags }} \
+          --amend ${{ steps.meta.outputs.tags }}-amd64 --amend ${{ steps.meta.outputs.tags }}-arm64 \
+          --amend ${{ steps.meta.outputs.tags }}-s390x --amend ${{ steps.meta.outputs.tags }}-ppc64le
+          docker manifest push ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This commit is to build and release `ghcr.io/containerd/nydus-snapshotter` for multiple platforms (below) by leveraging GHA's QEMU/buildx funtionalities.

- amd64
- arm64
- s390x
- ppc64le

The workflow was verified and the image is available at https://github.com/BbolroC/nydus-snapshotter/pkgs/container/nydus-snapshotter/179477460?tag=enable-multi-arch-image.

Fixes: #583

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>