### PR TITLE
CI fix, part I: update and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build and Lint
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
   build-optimizer:
     name: Build optimizer
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   smoke:
     name: Smoke
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
   cross-build-test:
     name: Cross Build Test
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         GOOS: ["linux", "windows", "darwin"]
@@ -95,7 +95,7 @@ jobs:
   coverage:
     name: Code coverage
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build]
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build
         run: |
           # Download nydus components
-          NYDUS_VER=v$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s "https://api.github.com/repos/dragonflyoss/nydus/releases/latest" | jq -r .tag_name | sed 's/^v//')
+          NYDUS_VER=v$(curl -fsSL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://api.github.com/repos/dragonflyoss/nydus/releases/latest" | jq -r .tag_name | sed 's/^v//')
           wget -q https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz
           tar xzvf nydus-static-$NYDUS_VER-linux-amd64.tgz
           mkdir -p /usr/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           # Download nydus components
           NYDUS_VER=v$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s "https://api.github.com/repos/dragonflyoss/nydus/releases/latest" | jq -r .tag_name | sed 's/^v//')
-          wget https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz
+          wget -q https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz
           tar xzvf nydus-static-$NYDUS_VER-linux-amd64.tgz
           mkdir -p /usr/bin
           sudo mv nydus-static/nydus-image nydus-static/nydusd nydus-static/nydusify /usr/bin/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   run-e2e-for-cgroups-v1:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -146,7 +146,7 @@ jobs:
 
           cat ~/.docker/config.json > $log_dir/docker.config.json || echo "~/.docker/config.json  not found"
       - name: Upload Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: k8s-e2e-tests-logs

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -37,7 +37,7 @@ jobs:
           cp bin/nydus-overlayfs ./
           cp -r misc/snapshotter/* ./
           ls -tl ./
-          NYDUS_VER=v$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s "https://api.github.com/repos/dragonflyoss/nydus/releases/latest" | jq -r .tag_name | sed 's/^v//')
+          NYDUS_VER=v$(curl -fsSL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://api.github.com/repos/dragonflyoss/nydus/releases/latest" | jq -r .tag_name | sed 's/^v//')
           docker build --build-arg NYDUS_VER=${NYDUS_VER} -t local-dev:e2e .
 
           ## load local test image into kind node
@@ -93,7 +93,7 @@ jobs:
           docker exec kind-control-plane systemctl restart containerd
       - name: Install Nydus binaries and convert nydus image
         run: |
-          NYDUS_VER=v$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s "https://api.github.com/repos/dragonflyoss/nydus/releases/latest" | jq -r .tag_name | sed 's/^v//')
+          NYDUS_VER=v$(curl -fsSL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://api.github.com/repos/dragonflyoss/nydus/releases/latest" | jq -r .tag_name | sed 's/^v//')
           wget -q https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz
           tar xzf nydus-static-$NYDUS_VER-linux-amd64.tgz
           sudo cp nydus-static/nydusify nydus-static/nydus-image /usr/local/bin/

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   e2e_tests_k8s:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -152,3 +152,4 @@ jobs:
           name: k8s-e2e-tests-logs
           path: |
             /tmp/nydus-log
+          overwrite: true

--- a/.github/workflows/optimizer.yml
+++ b/.github/workflows/optimizer.yml
@@ -42,19 +42,19 @@ jobs:
             ${{ runner.os }}-cargo
       - name: containerd runc and crictl
         run: |
-          sudo wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.26.0/crictl-v1.26.0-linux-amd64.tar.gz
+          sudo wget -q https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.26.0/crictl-v1.26.0-linux-amd64.tar.gz
           sudo tar zxvf ./crictl-v1.26.0-linux-amd64.tar.gz -C /usr/local/bin
           sudo install -D -m 755 misc/optimizer/crictl.yaml /etc/crictl.yaml
-          sudo wget https://github.com/containerd/containerd/releases/download/v1.7.0/containerd-static-1.7.0-linux-amd64.tar.gz
+          sudo wget -q https://github.com/containerd/containerd/releases/download/v1.7.0/containerd-static-1.7.0-linux-amd64.tar.gz
           sudo systemctl stop containerd
           sudo tar -zxf ./containerd-static-1.7.0-linux-amd64.tar.gz -C /usr/
           sudo install -D -m 755 misc/optimizer/containerd-config.toml /etc/containerd/config.toml
           sudo systemctl restart containerd
-          sudo wget https://github.com/opencontainers/runc/releases/download/v1.1.5/runc.amd64 -O /usr/bin/runc
+          sudo wget -q https://github.com/opencontainers/runc/releases/download/v1.1.5/runc.amd64 -O /usr/bin/runc
           sudo chmod +x /usr/bin/runc
       - name: Setup CNI
         run: |
-          wget https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
+          wget -q https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
           sudo mkdir -p /opt/cni/bin
           sudo tar xzf cni-plugins-linux-amd64-v1.2.0.tgz -C /opt/cni/bin/
           sudo install -D -m 755 misc/example/10-containerd-net.conflist /etc/cni/net.d/10-containerd-net.conflist

--- a/.github/workflows/optimizer.yml
+++ b/.github/workflows/optimizer.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   run_optimizer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-.github/workflows/release.ymlname: release
+name: release
 
 on:
   push:
@@ -140,7 +140,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Get the nydusd version
         run: |
-          export NYDUS_STABLE_VER=$(curl https://api.github.com/repos/dragonflyoss/nydus/releases/latest | jq -r .tag_name)
+          export NYDUS_STABLE_VER=$(curl -fsSL https://api.github.com/repos/dragonflyoss/nydus/releases/latest | jq -r .tag_name)
           echo "NYDUS_STABLE_VER=$NYDUS_STABLE_VER" >> "$GITHUB_ENV"
           printf 'nydus version is: %s\n' "$NYDUS_STABLE_VER"
       - name: build and push nydus-snapshotter image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,19 +35,19 @@ jobs:
             build-arch: static
             build-linker: static
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.19.6"
       - name: cache go mod
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ matrix.build-os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ matrix.build-os }}-go
       - name: cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -73,7 +73,7 @@ jobs:
             make package GOOS=${{ matrix.build-os }} GOARCH=${{ matrix.build-arch }}
           fi
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-tars-${{ matrix.build-os }}-${{ matrix.build-arch }}
           path: |
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: builds
       - name: Release
@@ -111,7 +111,7 @@ jobs:
             build-arch: ppc64le
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -120,13 +120,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: release-tars-${{ matrix.build-os }}-${{ matrix.build-arch }}
           path: misc/snapshotter
@@ -162,7 +162,7 @@ jobs:
     needs: [publish-image]
     steps:
       - name: Log in to the container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.19.6"
+          go-version: "1.21.12"
       - name: cache go mod
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -78,8 +78,9 @@ jobs:
           name: release-tars-${{ matrix.build-os }}-${{ matrix.build-arch }}
           path: |
             package/*.tar.gz*
+          overwrite: true
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build]
     steps:
       - uses: actions/checkout@v4
@@ -96,7 +97,7 @@ jobs:
             builds/release-tars-**/*
 
   publish-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build]
     strategy:
       matrix:
@@ -158,7 +159,7 @@ jobs:
           build-args: NYDUS_VER=${{ env.NYDUS_STABLE_VER }}
 
   publish-manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [publish-image]
     steps:
       - name: Log in to the container registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+.github/workflows/release.ymlname: release
 
 on:
   push:
@@ -61,7 +61,7 @@ jobs:
       - name: install gnu gcc linker
         run: |
           if [ "${{ matrix.build-linker }}" != "static" ]; then
-            sudo apt-get install -y gcc-${{ matrix.build-linker }}-linux-gnu
+            sudo apt-get install -qq gcc-${{ matrix.build-linker }}-linux-gnu
           fi
       - name: build nydus-snapshotter and optimizer
         run: |

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ smoke:
 integration:
 	CGO_ENABLED=1 ${PROXY} GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags '-X "${PKG}/version.Version=${VERSION}" -extldflags "-static"' -race -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
 	CGO_ENABLED=1 ${PROXY} GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags '-X "${PKG}/version.Version=${VERSION}" -extldflags "-static"' -race -v -o bin/nydus-overlayfs ./cmd/nydus-overlayfs
-	$(SUDO) DOCKER_BUILDKIT=1 docker build ${BUILD_ARG_E2E_DOWNLOADS_MIRROR} -t nydus-snapshotter-e2e:0.1 -f integration/Dockerfile .
+	$(SUDO) docker build ${BUILD_ARG_E2E_DOWNLOADS_MIRROR} -t nydus-snapshotter-e2e:0.1 -f integration/Dockerfile .
 	$(SUDO) docker run --cap-add SYS_ADMIN --security-opt seccomp=unconfined --cgroup-parent=system.slice --cgroupns private --name nydus-snapshotter_e2e --rm --privileged -v /root/.docker:/root/.docker -v `go env GOMODCACHE`:/go/pkg/mod \
 	-v `go env GOCACHE`:/root/.cache/go-build -v `pwd`:/nydus-snapshotter \
 	-v /usr/src/linux-headers-${KERNEL_VER}:/usr/src/linux-headers-${KERNEL_VER} \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nydus-snapshotter
 
-go 1.19
+go 1.21
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -63,4 +63,7 @@ WORKDIR /nydus-snapshotter
 ENV PATH="${PATH}:/usr/local/bin/"
 ENV GO111MODULE=on
 
+# Prevent git from complaining about ownership
+RUN git config --global --add safe.directory /nydus-snapshotter
+
 ENTRYPOINT [ "/bin/bash",  "-c",  "make install && /entrypoint.sh"]

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -28,24 +28,24 @@ RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev sudo psm
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install containerd
-RUN wget ${DOWNLOADS_MIRROR}/containerd/containerd/releases/download/v${CONTAINERD_VER}/containerd-${CONTAINERD_VER}-linux-amd64.tar.gz && \
+RUN wget -q ${DOWNLOADS_MIRROR}/containerd/containerd/releases/download/v${CONTAINERD_VER}/containerd-${CONTAINERD_VER}-linux-amd64.tar.gz && \
   tar xzf containerd-${CONTAINERD_VER}-linux-amd64.tar.gz && \
   install -D -m 755 bin/* /usr/local/bin/
 COPY misc/example/containerd-config.toml /etc/containerd/config.toml
 
 # Install runc
-RUN wget ${DOWNLOADS_MIRROR}/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.amd64 && \
+RUN wget -q ${DOWNLOADS_MIRROR}/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.amd64 && \
   install -D -m 755 runc.amd64 /usr/local/bin/runc
 
 # Install nydusd nydus-image
-RUN  wget ${DOWNLOADS_MIRROR}/dragonflyoss/nydus/releases/download/v${NYDUS_VER}/nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
+RUN  wget -q ${DOWNLOADS_MIRROR}/dragonflyoss/nydus/releases/download/v${NYDUS_VER}/nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
   tar xzf nydus-static-v${NYDUS_VER}-linux-amd64.tgz && \
   install -D -m 755 nydus-static/nydusd /usr/local/bin/nydusd && \
   install -D -m 755 nydus-static/nydus-image /usr/local/bin/nydus-image && \
   install -D -m 755 nydus-static/nydusctl /usr/local/bin/nydusctl
 
 # Install nerdctl
-RUN wget ${DOWNLOADS_MIRROR}/containerd/nerdctl/releases/download/v${NERDCTL_VER}/nerdctl-${NERDCTL_VER}-linux-amd64.tar.gz && \
+RUN wget -q ${DOWNLOADS_MIRROR}/containerd/nerdctl/releases/download/v${NERDCTL_VER}/nerdctl-${NERDCTL_VER}-linux-amd64.tar.gz && \
   tar xzf nerdctl-${NERDCTL_VER}-linux-amd64.tar.gz && \
   install -D -m 755 nerdctl /usr/local/bin/nerdctl
 

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -23,7 +23,7 @@ ARG NERDCTL_VER
 # deb https://mirrors.tuna.tsinghua.edu.cn/debian/ bullseye-backports main contrib non-free\n\
 # deb https://mirrors.tuna.tsinghua.edu.cn/debian-security bullseye-security main contrib non-free\n' > /etc/apt/sources.list
 
-RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev sudo psmisc jq lsof net-tools
+RUN apt-get update -qq && apt-get install -qq libbtrfs-dev libseccomp-dev sudo psmisc jq lsof net-tools
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -61,7 +61,6 @@ COPY integration/entrypoint.sh /
 WORKDIR /nydus-snapshotter
 
 ENV PATH="${PATH}:/usr/local/bin/"
-ENV GO111MODULE=on
 
 # Prevent git from complaining about ownership
 RUN git config --global --add safe.directory /nydus-snapshotter

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -7,7 +7,7 @@ ARG DOWNLOADS_MIRROR="https://github.com"
 ARG NYDUS_VER=2.2.4
 ARG NERDCTL_VER=1.0.0
 
-FROM golang:1.21.12-bullseye AS golang-base
+FROM golang:1.21.12-bookworm AS golang-base
 
 ARG CONTAINERD_VER
 ARG CONTAINERD_PROJECT

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -7,7 +7,7 @@ ARG DOWNLOADS_MIRROR="https://github.com"
 ARG NYDUS_VER=2.2.4
 ARG NERDCTL_VER=1.0.0
 
-FROM golang:1.19.6-bullseye AS golang-base
+FROM golang:1.21.12-bullseye AS golang-base
 
 ARG CONTAINERD_VER
 ARG CONTAINERD_PROJECT

--- a/integration/entrypoint.sh
+++ b/integration/entrypoint.sh
@@ -142,7 +142,7 @@ function reboot_containerd {
     killall "nydusd" || true
 
     # Let snapshotter shutdown all its services.
-    sleep 0.5
+    sleep 2
 
     # FIXME
     echo "umount globally shared mountpoint"
@@ -267,7 +267,7 @@ function start_single_container_on_stargz {
     reboot_containerd multiple
 
     killall "containerd-nydus-grpc" || true
-    sleep 0.5
+    sleep 2
 
     containerd-nydus-grpc --enable-stargz --daemon-mode multiple --fs-driver fusedev \
         --recover-policy none --log-to-stdout --config-path /etc/nydus/nydusd-config.json &

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.17.0 AS base
 FROM base AS sourcer
 ARG NYDUS_VER=v2.2.4
 
-RUN apk add --no-cache curl && \
-    apk add --no-cache --upgrade grep && \
+RUN apk add -q --no-cache curl && \
+    apk add -q --no-cache --upgrade grep && \
     curl -fsSL -O https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz && \
     echo $NYDUS_VER > /.nydus_version && \
     tar xzf nydus-static-$NYDUS_VER-linux-amd64.tgz && \
@@ -13,7 +13,7 @@ RUN apk add --no-cache curl && \
     && rm -rf /nydus-overlayfs
 
 FROM base AS kubectl-sourcer
-RUN apk add --no-cache curl && \
+RUN apk add -q --no-cache curl && \
     ARCH=$(uname -m) && \
     if [ "${ARCH}" = "x86_64" ]; then ARCH=amd64; fi && \
     if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
@@ -27,7 +27,7 @@ ARG BINARY_DESTINATION=${DESTINATION}/usr/local/bin
 ARG SCRIPT_DESTINATION=${DESTINATION}/opt/nydus
 
 WORKDIR /root/
-RUN apk add --no-cache libc6-compat bash
+RUN apk add -q --no-cache libc6-compat bash
 
 VOLUME /var/lib/containerd/io.containerd.snapshotter.v1.nydus /run/containerd-nydus
 

--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -5,7 +5,7 @@ ARG NYDUS_VER=v2.2.4
 
 RUN apk add --no-cache curl && \
     apk add --no-cache --upgrade grep && \
-    curl -OL https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz && \
+    curl -fsSL -O https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz && \
     echo $NYDUS_VER > /.nydus_version && \
     tar xzf nydus-static-$NYDUS_VER-linux-amd64.tgz && \
     rm nydus-static-$NYDUS_VER-linux-amd64.tgz && \
@@ -17,7 +17,7 @@ RUN apk add --no-cache curl && \
     ARCH=$(uname -m) && \
     if [ "${ARCH}" = "x86_64" ]; then ARCH=amd64; fi && \
     if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
-    curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
+    curl -fsSL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/bin/kubectl
 
 FROM base


### PR DESCRIPTION
Work on #604 required a set of changes, fixes and updates to the test rig and CI, and has grown really large.

This PR does split out some of the more minor changes to make it easier to review.

Furthermore, the CI is in a shaky state right now and is just red, as the build fails because of delve latest being dependent on a more recent version of go (which in turns requires a series of changes), and also as #603 seems to break e2e kube tests (or this test is very flaky).


Changes:
- quiet apk, apt-get, wget and curl to make the logs less noisy and easier to read
- update github actions to their latest versions
- update golang to 1.21 - delve requires it - also, go 1.23 is soon to be out - and containerd v2 requires 1.22
- remove no longer useful variables
- increase sleep after kill to avoid racy metrics server restart causing port conflict
- bump and pin ubuntu to 22.04 (and golang from bullseye to bookworm) - fix GLIBC issue
