### PR TITLE
supervisor: fix large opaque data handle

### DIFF
--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -7,6 +7,7 @@
 package supervisor
 
 import (
+	"crypto/rand"
 	"net"
 	"os"
 	"reflect"
@@ -14,7 +15,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/unix"
 )
 
 func TestSupervisor(t *testing.T) {
@@ -26,49 +26,59 @@ func TestSupervisor(t *testing.T) {
 	})
 
 	supervisorSet, err := NewSupervisorSet(rootDir)
-	assert.Nil(t, err, "%v", err)
+	assert.Nil(t, err)
 
 	su1 := supervisorSet.NewSupervisor("su1")
 	assert.NotNil(t, su1)
+	defer func() {
+		err = supervisorSet.DestroySupervisor("su1")
+		assert.NotNil(t, su1)
+	}()
 
-	_, err = su1.waitStatesTimeout(2 * time.Second)
-	assert.Nil(t, err, "%v", err)
 	sock := su1.Sock()
-
 	addr, err := net.ResolveUnixAddr("unix", sock)
 	assert.Nil(t, err)
 
-	conn, err := net.DialUnix("unix", nil, addr)
-	assert.Nil(t, err, "%v", err)
-
-	sentData := []byte("abcde")
-
-	sentLen, err := conn.Write(sentData)
+	// Build a large data to test the multiple recvmsg / sendmsg
+	// syscalls can handle all the data.
+	sentData := make([]byte, 1024*1024*2)
+	_, err = rand.Read(sentData)
 	assert.Nil(t, err)
 
-	conn.Close()
-
-	// FIXME: Delay for some time until states are stored
-	time.Sleep(500 * time.Millisecond)
-
-	// Must set length not only capacity
-	receivedData := make([]byte, 16, 32)
-	oob := make([]byte, 16, 32)
-	err = su1.SendStatesTimeout(0)
-	assert.Nil(t, err, "%v", err)
-
-	conn1, err := net.DialUnix("unix", nil, addr)
-	assert.Nil(t, err, "%v", err)
-
-	f, _ := conn1.File()
-
-	//nolint:dogsled
-	receivedLen, _, _, _, err := unix.Recvmsg(int(f.Fd()), receivedData, oob, 0)
+	tmpFile, err := os.CreateTemp("", "nydus-supervisor-test")
 	assert.Nil(t, err)
+	defer tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
 
-	assert.Equal(t, sentLen, receivedLen)
-	assert.True(t, reflect.DeepEqual(receivedData[:receivedLen], sentData), "%v", receivedData)
+	nydusdSendFd := func() error {
+		conn, err := net.DialUnix("unix", nil, addr)
+		assert.Nil(t, err)
+		defer conn.Close()
 
+		err = send(conn, sentData, int(tmpFile.Fd()))
+		assert.Nil(t, err)
+
+		return nil
+	}
+
+	err = su1.FetchDaemonStates(nydusdSendFd)
+	assert.NoError(t, err)
+
+	nydusdTakeover := func() {
+		err = su1.SendStatesTimeout(0)
+		assert.Nil(t, err)
+
+		conn, err := net.DialUnix("unix", nil, addr)
+		assert.Nil(t, err)
+
+		recvData, _, err := recv(conn)
+		assert.Nil(t, err)
+
+		assert.Equal(t, len(sentData), len(recvData))
+		assert.True(t, reflect.DeepEqual(recvData, sentData))
+	}
+
+	nydusdTakeover()
 }
 
 func TestSupervisorTimeout(t *testing.T) {


### PR DESCRIPTION
```
When the supervisor needs to process a large amount of opaque data (for example,
a nydusd instance has a large number of sub mounts, and the opaque is usually
larger than 32kb), a recvmsg / sendmsg system call cannot process all data.

The commit fixes the problem with multiple recvmsg/sendmsg calls and updates
the test cases.
```