### PR TITLE
tests/converter: modify unpack testcase

### DIFF
--- a/pkg/converter/tool/builder.go
+++ b/pkg/converter/tool/builder.go
@@ -305,7 +305,33 @@ func Unpack(option UnpackOption) error {
 	}
 
 	if option.BackendConfigPath != "" {
-		args = append(args, "--backend-config", option.BackendConfigPath)
+		configBytes, err := os.ReadFile(option.BackendConfigPath)
+		if err != nil {
+			return errors.Wrapf(err, "fail to read backend config file %s", option.BackendConfigPath)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(configBytes, &config); err != nil {
+			return errors.Wrapf(err, "fail to unmarshal backend config file %s", option.BackendConfigPath)
+		}
+
+		backendConfigType, ok := config["backend"].(map[string]interface{})["type"]
+		if !ok {
+			return errors.New("backend config file should contain a valid backend type")
+		}
+
+		backendConfig, ok := config["backend"].(map[string]interface{})[backendConfigType.(string)]
+		if !ok {
+			return errors.New("failed to get backend config with type " + backendConfigType.(string))
+		}
+
+		backendConfigBytes, err := json.Marshal(backendConfig)
+		if err != nil {
+			return errors.Wrapf(err, "fail to marshal backend config %v", backendConfig)
+		}
+
+		args = append(args, "--backend-type", backendConfigType.(string))
+		args = append(args, "--backend-config", string(backendConfigBytes))
 	} else if option.BlobPath != "" {
 		args = append(args, "--blob", option.BlobPath)
 	}

--- a/tests/converter_test.go
+++ b/tests/converter_test.go
@@ -137,7 +137,7 @@ func writeFileToTar(t *testing.T, tw *tar.Writer, name string, data string) {
 		Name:  name,
 		Mode:  0444,
 		Size:  int64(len(data)),
-		Uname: u.Name,
+		Uname: u.Username,
 		Gname: g.Name,
 	}
 	err = tw.WriteHeader(hdr)
@@ -158,7 +158,7 @@ func writeDirToTar(t *testing.T, tw *tar.Writer, name string) {
 		Name:     name,
 		Mode:     0444,
 		Typeflag: tar.TypeDir,
-		Uname:    u.Name,
+		Uname:    u.Username,
 		Gname:    g.Name,
 	}
 	err = tw.WriteHeader(hdr)


### PR DESCRIPTION
This patch modifies the unpack testcase to keep consistent with the new `nydus-image unpack` interface in nydus-image.