### PR TITLE
snapshotter: add flag to specify nydus-overlayfs path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -158,9 +158,10 @@ type ImageConfig struct {
 // Configure containerd snapshots interfaces and how to process the snapshots
 // requests from containerd
 type SnapshotConfig struct {
-	EnableNydusOverlayFS bool `toml:"enable_nydus_overlayfs"`
-	EnableKataVolume     bool `toml:"enable_kata_volume"`
-	SyncRemove           bool `toml:"sync_remove"`
+	EnableNydusOverlayFS bool   `toml:"enable_nydus_overlayfs"`
+	NydusOverlayFSPath   string `toml:"nydus_overlayfs_path"`
+	EnableKataVolume     bool   `toml:"enable_kata_volume"`
+	SyncRemove           bool   `toml:"sync_remove"`
 }
 
 // Configure cache manager that manages the cache files lifecycle
@@ -357,7 +358,9 @@ func ParseParameters(args *flags.Args, cfg *SnapshotterConfig) error {
 	// empty
 
 	// --- snapshot configuration
-	// empty
+	if args.NydusOverlayFSPath != "" {
+		cfg.SnapshotsConfig.NydusOverlayFSPath = args.NydusOverlayFSPath
+	}
 
 	// --- metrics configuration
 	// empty

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,6 +51,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 		},
 		SnapshotsConfig: SnapshotConfig{
 			EnableNydusOverlayFS: false,
+			NydusOverlayFSPath:   "nydus-overlayfs",
 			SyncRemove:           false,
 		},
 		RemoteConfig: RemoteConfig{
@@ -92,7 +93,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 
 	A.EqualValues(cfg, &exampleConfig)
 
-	var args = flags.Args{}
+	args := flags.Args{}
 	args.RootDir = "/var/lib/containerd/nydus"
 	exampleConfig.Root = "/var/lib/containerd/nydus"
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -19,6 +19,7 @@ type Args struct {
 	RootDir               string
 	NydusdPath            string
 	NydusImagePath        string
+	NydusOverlayFSPath    string
 	DaemonMode            string
 	FsDriver              string
 	LogLevel              string
@@ -67,6 +68,11 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "path to nydusd configuration (such as: nydusd-config.json or nydusd-config-v2.toml)",
 			Destination: &args.NydusdConfigPath,
 			DefaultText: constant.DefaultNydusDaemonConfigPath,
+		},
+		&cli.StringFlag{
+			Name:        "nydus-overlayfs-path",
+			Usage:       "path of nydus-overlayfs or name of binary from $PATH, defaults to 'nydus-overlayfs'",
+			Destination: &args.NydusOverlayFSPath,
 		},
 		&cli.StringFlag{
 			Name:        "daemon-mode",

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -85,6 +85,8 @@ enable_cri_keychain = false
 [snapshot]
 # Let containerd use nydus-overlayfs mount helper
 enable_nydus_overlayfs = false
+# Path to the nydus-overlayfs binary or name of the binary in $PATH
+nydus_overlayfs_path = "nydus-overlayfs"
 # Insert Kata Virtual Volume option to `Mount.Options`
 enable_kata_volume = false
 # Whether to remove resources when a snapshot is removed

--- a/snapshot/mount_option.go
+++ b/snapshot/mount_option.go
@@ -94,9 +94,15 @@ func (o *snapshotter) remoteMountWithExtraOptions(ctx context.Context, s storage
 	opt := fmt.Sprintf("extraoption=%s", base64.StdEncoding.EncodeToString(no))
 	overlayOptions = append(overlayOptions, opt)
 
+	mountType := "fuse.nydus-overlayfs"
+	if o.nydusOverlayFSPath != "" {
+		log.G(ctx).Infof("Using nydus-overlayfs from path: %s", o.nydusOverlayFSPath)
+		mountType = fmt.Sprintf("fuse.%s", o.nydusOverlayFSPath)
+	}
+
 	return []mount.Mount{
 		{
-			Type:    "fuse.nydus-overlayfs",
+			Type:    mountType,
 			Source:  "overlay",
 			Options: overlayOptions,
 		},
@@ -136,9 +142,16 @@ func (o *snapshotter) mountWithKataVolume(ctx context.Context, id string, overla
 
 	if hasVolume {
 		log.G(ctx).Debugf("fuse.nydus-overlayfs mount options %v", overlayOptions)
+
+		mountType := "fuse.nydus-overlayfs"
+		if o.nydusOverlayFSPath != "" {
+			log.G(ctx).Infof("Using nydus-overlayfs from path: %s", o.nydusOverlayFSPath)
+			mountType = fmt.Sprintf("fuse.%s", o.nydusOverlayFSPath)
+		}
+
 		mounts := []mount.Mount{
 			{
-				Type:    "fuse.nydus-overlayfs",
+				Type:    mountType,
 				Source:  "overlay",
 				Options: overlayOptions,
 			},


### PR DESCRIPTION
This allows installation of multiple nydus-overlayfs versions on the same machine.