### PR TITLE
fix: update chunkmap suffix

### DIFF
--- a/misc/snapshotter/Dockerfile
+++ b/misc/snapshotter/Dockerfile
@@ -17,7 +17,7 @@ FROM base AS kubectl-sourcer
 ARG TARGETARCH
 
 RUN apk add -q --no-cache curl && \
-    curl -fsSL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/"$(curl -L -s https://dl.k8s.io/release/stable.txt)"/bin/linux/"$TARGETARCH"/kubectl && \
+    curl -fsSL -o /usr/bin/kubectl https://dl.k8s.io/release/"$(curl -L -s https://dl.k8s.io/release/stable.txt)"/bin/linux/"$TARGETARCH"/kubectl && \
     chmod +x /usr/bin/kubectl
 
 FROM base

--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -71,14 +71,15 @@ func (m *Manager) CacheUsage(ctx context.Context, blobID string) (snapshots.Usag
 	var usage snapshots.Usage
 
 	blobCachePath := path.Join(m.cacheDir, blobID)
+	blobChunkMap := path.Join(m.cacheDir, blobID+chunkMapFileSuffix)
 	// For backward compatibility
 	blobCacheSuffixedPath := path.Join(m.cacheDir, blobID+dataFileSuffix)
-	blobChunkMap := path.Join(m.cacheDir, blobID+chunkMapFileSuffix)
+	blobChunkMapSuffixedPath := path.Join(m.cacheDir, blobID+dataFileSuffix+chunkMapFileSuffix)
 	blobMeta := path.Join(m.cacheDir, blobID+metaFileSuffix)
 	imageDisk := path.Join(m.cacheDir, blobID+imageDiskFileSuffix)
 	layerDisk := path.Join(m.cacheDir, blobID+layerDiskFileSuffix)
 
-	stuffs := []string{blobCachePath, blobCacheSuffixedPath, blobChunkMap, blobMeta, imageDisk, layerDisk}
+	stuffs := []string{blobCachePath, blobChunkMap, blobCacheSuffixedPath, blobChunkMapSuffixedPath, blobMeta, imageDisk, layerDisk}
 
 	for _, f := range stuffs {
 		du, err := fs.DiskUsage(ctx, f)
@@ -97,14 +98,15 @@ func (m *Manager) CacheUsage(ctx context.Context, blobID string) (snapshots.Usag
 
 func (m *Manager) RemoveBlobCache(blobID string) error {
 	blobCachePath := path.Join(m.cacheDir, blobID)
-	blobCacheSuffixedPath := path.Join(m.cacheDir, blobID+dataFileSuffix)
 	blobChunkMap := path.Join(m.cacheDir, blobID+chunkMapFileSuffix)
+	blobCacheSuffixedPath := path.Join(m.cacheDir, blobID+dataFileSuffix)
+	blobChunkMapSuffixedPath := path.Join(m.cacheDir, blobID+dataFileSuffix+chunkMapFileSuffix)
 	blobMeta := path.Join(m.cacheDir, blobID+metaFileSuffix)
 	imageDisk := path.Join(m.cacheDir, blobID+imageDiskFileSuffix)
 	layerDisk := path.Join(m.cacheDir, blobID+layerDiskFileSuffix)
 
 	// NOTE: Delete chunk bitmap file before data blob
-	stuffs := []string{blobChunkMap, blobMeta, blobCachePath, blobCacheSuffixedPath, imageDisk, layerDisk}
+	stuffs := []string{blobChunkMap, blobChunkMapSuffixedPath, blobMeta, blobCachePath, blobCacheSuffixedPath, imageDisk, layerDisk}
 
 	for _, f := range stuffs {
 		err := os.Remove(f)

--- a/tests/helpers/helpers.sh
+++ b/tests/helpers/helpers.sh
@@ -104,7 +104,7 @@ install::kubectl(){
   local temp
   temp="$(fs::mktemp "install")"
 
-  http::get "$temp"/kubectl "https://storage.googleapis.com/kubernetes-release/release/$version/bin/linux/${GOARCH:-amd64}/kubectl"
+  http::get "$temp"/kubectl "https://dl.k8s.io/release/$version/bin/linux/${GOARCH:-amd64}/kubectl"
   host::install "$temp"/kubectl
 }
 


### PR DESCRIPTION
Nydus latest chunk_map path has changed to `{blob_id}.blob.data.chunk_map`. Add `blobChunkMapSuffixedPath` to keep backward compatibility.
