### PR TITLE
Dealing with optimizer-server zombie processes

### DIFF
--- a/pkg/fanotify/fanotify.go
+++ b/pkg/fanotify/fanotify.go
@@ -79,6 +79,12 @@ func (fserver *Server) RunServer() error {
 	fserver.Cmd = cmd
 
 	go func() {
+		if err := cmd.Wait(); err != nil {
+			logrus.WithError(err).Errorf("Failed to wait for command to finish")
+		}
+	}()
+
+	go func() {
 		if err := fserver.RunReceiver(); err != nil {
 			logrus.WithError(err).Errorf("Failed to receive event information from server")
 		}

--- a/pkg/fanotify/fanotify.go
+++ b/pkg/fanotify/fanotify.go
@@ -80,7 +80,7 @@ func (fserver *Server) RunServer() error {
 
 	go func() {
 		if err := cmd.Wait(); err != nil {
-			logrus.WithError(err).Errorf("Failed to wait for command to finish")
+			logrus.WithError(err).Errorf("Failed to wait for fserver to finish")
 		}
 	}()
 

--- a/tools/optimizer-server/src/main.rs
+++ b/tools/optimizer-server/src/main.rs
@@ -273,7 +273,7 @@ fn main() {
 
             match waitpid(child, None) {
                 Ok(WaitStatus::Signaled(pid, signal, _)) => {
-                    eprintln!("cophild process {pid} was killed by signal {signal}");
+                    eprintln!("child process {pid} was killed by signal {signal}");
                 }
                 Ok(WaitStatus::Stopped(pid, signal)) => {
                     eprintln!("child process {pid} was stopped by signal {signal}");


### PR DESCRIPTION
### Problem Description
Based on the process outlined in [optimize_nydus_image](https://github.com/containerd/nydus-snapshotter/blob/main/docs/optimize_nydus_image.md), we attempted to build an optimizer to generate the accessed files list. The optimizer-server and optimizer-nri-plugin were deployed on the server. After some time, we noticed that some of the optimizer-servers became defunct. The specific screenshots are as follows:
![image](https://github.com/user-attachments/assets/7b0f4284-02d0-40ad-832e-b355b36be9ad)
The parent processes of these zombie processes all belong to the optimizer-nri-plugin. We have also verified that this issue occurs on every server we deployed. 
We believe that if the servers continue to retain these zombie processes, they will accumulate to a certain number and eventually affect the normal operation of the business.
### Modified Sections
We checked and found that the issue primarily lies in two areas:
1. When the optimizer-nri-plugin performs the fanotifyServer operation, it needs to invoke the optimizer-server executable, which creates a child process. It is necessary to wait for the completion of this process and properly clean up the resources.
2. When the optimizer-server is running, it also creates a child process for the fanotify operation. Similarly, it is necessary to wait for this process to complete and clean up the resources.
### Validation Results
We deployed the modified functionality on four servers for observation. After a full day of monitoring, no zombie processes were observed.
### Testing Method
The modified code was recompiled, and the newly generated optimizer-server and optimizer-nri-plugin binaries replaced the existing ones.
The process status was checked using the command ps -ef | grep optimizer to verify that no zombie processes had appeared.