### PR TITLE
docs: rename repo Dragonfly2 to dragonfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ We can also use the `nydus-snapshotter` container image when we want to put Nydu
 
 ## Integrate with Dragonfly to Distribute Images by P2P
 
-Nydus is a sub-project of [Dragonfly](https://github.com/dragonflyoss/Dragonfly2). So it closely works with Dragonfly to distribute container images in a fast and efficient P2P fashion to reduce network latency and lower the pressure on a single-point of the registry.
+Nydus is a sub-project of [Dragonfly](https://github.com/dragonflyoss/dragonfly). So it closely works with Dragonfly to distribute container images in a fast and efficient P2P fashion to reduce network latency and lower the pressure on a single-point of the registry.
 
 ### Quickstart Dragonfly & Nydus in Kubernetes
 


### PR DESCRIPTION
This pull request includes a small but important change to the `README.md` file. The change corrects the URL for the Dragonfly project to its proper location.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R143): Corrected the URL for the Dragonfly project from `https://github.com/dragonflyoss/Dragonfly2` to `https://github.com/dragonflyoss/dragonfly`.

Refer to https://github.com/dragonflyoss/dragonfly/issues/3714.