### PR TITLE
Fix converter to be able to push manifests to ECR

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -1054,6 +1054,8 @@ func convertManifest(ctx context.Context, cs content.Store, oldDesc ocispec.Desc
 		// See the `subject` field description in
 		// https://github.com/opencontainers/image-spec/blob/main/manifest.md#image-manifest-property-descriptions
 		manifest.Subject = &oldDesc
+		// Remove the platform field as it is not supported by certain registries like ECR.
+		manifest.Subject.Platform = nil
 	}
 
 	// Update image manifest in content store.


### PR DESCRIPTION
This attempts to solve both https://github.com/dragonflyoss/nydus/issues/1691 and https://github.com/dragonflyoss/nydus/issues/1692.

Attempting to push some ECR manifests has 2 issues currently:
- `with-referrer` fails because the `subject` field in the manifest has a `platform` field. Although this is ok from an OCI spec perspective, ECR doesn't support it and it is not really needed so we can remove it
- `platform` fails when attempting to build multi-arch manifests because the `os.feature` field in the manifest is not supported either. We can remove it because this is not really supported yet in any container runtime. However, we still keep it when building images through `merge-platform` as it is the only way to differentiate a regular OCI image from a nydus one in that case. Fortunately, the merge-platform code goes through a different code path that uses Harbor's acceleration service and the os.feature field is set [there](https://github.com/goharbor/acceleration-service/blob/main/pkg/driver/nydus/nydus.go#L355).

I did test this by rebuilding nydusify using the fixed converter and tried to push both images to ECR, which worked.
Additionally, I made sure that the `merge-platform` field was still working:
```
./cmd/nydusify convert --source foo:bar --target-suffix -nydus-platform --merge-platform --platform "linux/amd64,linux/arm64"
INFO[2025-05-21T18:32:49+02:00] pulling image foo:bar  module=converter
INFO[2025-05-21T18:32:56+02:00] pulled image foo:bar , elapse 7.645556534s  module=converter
INFO[2025-05-21T18:32:56+02:00] converting image foo:bar  module=converter
INFO[2025-05-21T18:32:59+02:00] converted image foo:bar-nydus-platform , elapse 2.528599639s  module=converter
INFO[2025-05-21T18:32:59+02:00] pushing image foo:bar-nydus-platform  module=converter
INFO[2025-05-21T18:33:03+02:00] pushed image foo:bar-nydus-platform, elapse 4.147958056s  module=converter


crane manifest foo:bar-nydus-platform | jq
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:d794231637e1cb6b40d30712718b82e47a306350295bc349dc38ac96fe0c6958",
      "size": 721,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:821c0238e5f7d2f95d90b897872f4584e56c9d89fd582c7eb2562583164768dd",
      "size": 721,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:8b32e06f97f9c3423b0eea97b18946d11ca3a1fc86df5ce1339c4634465b2d05",
      "size": 1588,
      "platform": {
        "architecture": "amd64",
        "os": "linux",
        "os.features": [
          "nydus.remoteimage.v1"
        ]
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:8c087d44e299989ea4a68329141bfb771883b4442ce1997ed5794e8936c258ef",
      "size": 1588,
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "os.features": [
          "nydus.remoteimage.v1"
        ]
      }
    }
  ]
}
```