### PR TITLE
Add helm charts for nydus-snapshotter for convenient K8s deploytment 

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: nydus-snapshotter
+description: A Helm chart for nydus-snapshotter
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: v0.15.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: v0.15.2

--- a/charts/templates/cluster-role-binding.yaml
+++ b/charts/templates/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nydus-snapshotter-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: nydus-snapshotter-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: nydus-snapshotter-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/templates/cluster-role.yaml
+++ b/charts/templates/cluster-role.yaml
@@ -1,0 +1,5 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nydus-snapshotter-cluster-role
+rules: 

--- a/charts/templates/daemonset.yaml
+++ b/charts/templates/daemonset.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nydus-snapshotter
+  namespace: {{ .Release.Namespace }}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: nydus-snapshotter
+      app.kubernetes.io/name: nydus-snapshotter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: nydus-snapshotter
+        app.kubernetes.io/name: nydus-snapshotter
+    spec:
+      serviceAccountName: nydus-snapshotter-sa
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      hostNetwork: true
+      hostPID: true
+      {{- if .Values.snapshotter.daemonset.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.snapshotter.daemonset.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      tolerations:
+        {{- toYaml .Values.snapshotter.daemonset.tolerations | trim | nindent 8 }}
+      containers:
+        - name: nydus-snapshotter
+          args:
+            - "--root"
+            - "/var/lib/containerd/io.containerd.snapshotter.v1.nydus"
+            - "--config"
+            - "/nydus-snapshotter/configs/config.toml"
+          securityContext:
+            privileged: true
+          image: {{ .Values.image.repository }}/{{ .Values.snapshotter.daemonset.image.name }}:{{ .Values.snapshotter.daemonset.image.tag }}
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          {{- if .Values.snapshotter.daemonset.resources }}
+          resources:
+            {{- toYaml .Values.snapshotter.daemonset.resources | trim | nindent 12 }}
+          {{- end }}
+          startupProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - |-
+                  status=$(ctr plugin ls | grep nydus | awk '{print $4}')
+                  if [[ $status == "ok" ]]; then
+                    echo "nydus is healthy" && true;
+                  else
+                    echo "nydus is unhealthy" && false
+                  fi
+            failureThreshold: 10
+            initialDelaySeconds: 2
+            periodSeconds: 2
+          volumeMounts:
+            - name: dev
+              mountPath: /dev
+            - name: nydus
+              mountPath: /var/lib/containerd/io.containerd.snapshotter.v1.nydus
+              mountPropagation: Bidirectional
+            - name: etc-containerd
+              mountPath: /etc/containerd
+            - name: nydus-run
+              mountPath: /run/containerd-nydus/
+            - name: containerd-socket
+              mountPath: /run/containerd/containerd.sock
+            - name: nydus-bin
+              mountPath: /opt/nydus
+            - name: nydus-snapshotter-config
+              mountPath: /nydus-snapshotter/configs
+              readOnly: true
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: nydus
+          hostPath:
+            path: /var/lib/containerd/io.containerd.snapshotter.v1.nydus
+            type: DirectoryOrCreate
+        - name: nydus-run
+          hostPath:
+            path: /run/containerd-nydus/
+            type: DirectoryOrCreate
+        - name: etc-containerd
+          hostPath:
+            path: /etc/containerd
+            type: Directory
+        - name: containerd-socket
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
+        - name: nydus-bin
+          hostPath:
+            path: /opt/nydus
+            type: DirectoryOrCreate
+        - name: nydus-snapshotter-config
+          configMap:
+            name: nydus-snapshotter-config

--- a/charts/templates/runc-nydus.yaml
+++ b/charts/templates/runc-nydus.yaml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runc-nydus
+handler: runc-nydus

--- a/charts/templates/service-account.yaml
+++ b/charts/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nydus-snapshotter-sa
+  namespace: {{ .Release.Namespace }}

--- a/charts/templates/snapshotter-config.yaml
+++ b/charts/templates/snapshotter-config.yaml
@@ -1,0 +1,149 @@
+# templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nydus-snapshotter-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.toml: |
+    version = 1
+    # Snapshotter's own home directory where it stores and creates necessary resources
+    root = "/var/lib/containerd/io.containerd.snapshotter.v1.nydus"
+    # The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+    address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+    # The nydus daemon mode can be one of the following options: multiple, dedicated, shared, or none. 
+    # If `daemon_mode` option is not specified, the default value is multiple.
+    daemon_mode = "dedicated"
+    # Whether snapshotter should try to clean up resources when it is closed
+    cleanup_on_close = false
+    # Enable nydus-snapshotter to delegate nydusd creation and reaping membership to host.
+    # This is useful when nydus-snapshotter is running in a container deployed by Kubernetes, nydus-snapshotter must
+    # run in the host pid namespace and has privilege to enter the host mnt namespace.
+    delegate_nydusd = true
+
+    [system]
+    # Snapshotter's debug and trace HTTP server interface
+    enable = true
+    # Unix domain socket path where system controller is listening on
+    address = "/run/containerd-nydus/system.sock"
+
+    [system.debug]
+    # Snapshotter can profile the CPU utilization of each nydusd daemon when it is being started.
+    # This option specifies the profile duration when nydusd is downloading and uncompressing data.
+    daemon_cpu_profile_duration_secs = 5
+    # Enable by assigning an address, empty indicates pprof server is disabled
+    pprof_address = ""
+
+    [daemon]
+    # Specify a configuration file for nydusd
+    nydusd_config   = "/etc/nydus/nydusd-config.fusedev.json"
+    nydusd_path     = "/usr/local/bin/nydusd"
+    nydusimage_path = "/usr/local/bin/nydus-image"
+    # The fs driver can be one of the following options: fusedev, fscache, blockdev, proxy, or nodev. 
+    # If `fs_driver` option is not specified, the default value is fusedev.
+    fs_driver = "fusedev"
+    # How to process when daemon dies: "none", "restart" or "failover"
+    recover_policy = "restart"
+    # Nydusd worker thread number to handle FUSE or fscache requests, [0-1024].
+    # Setting to 0 will use the default configuration of nydusd.
+    threads_number = 4
+    # Log rotation size for nydusd, in unit MB(megabytes). (default 100MB)
+    log_rotation_size = 100
+
+    [cgroup]
+    # Whether to use separate cgroup for nydusd.
+    enable = false
+    # The memory limit for nydusd cgroup, which contains all nydusd processes.
+    # Percentage is supported as well, please ensure it is end with "%".
+    # The default unit is bytes. Acceptable values include "209715200", "200MiB", "200Mi" and "10%".
+    memory_limit = ""
+
+    [log]
+    # Print logs to stdout rather than logging files
+    log_to_stdout = false
+    # Snapshotter's log level
+    level                   = "info"
+    log_rotation_compress   = true
+    log_rotation_local_time = true
+    # Max number of days to retain logs
+    log_rotation_max_age     = 7
+    log_rotation_max_backups = 5
+    # In unit MB(megabytes)
+    log_rotation_max_size = 100
+
+    [metrics]
+    # Enable by assigning an address, empty indicates metrics server is disabled
+    address = ":9110"
+
+    [remote]
+    convert_vpc_registry = false
+
+    [remote.mirrors_config]
+    # Snapshotter will overwrite daemon's mirrors configuration
+    # if the values loaded from this directory are not null before starting a daemon.
+    # Set to "" or an empty directory to disable it.
+    #dir = "/etc/nydus/certs.d"
+
+    [remote.auth]
+    # Fetch the private registry auth by listening to K8s API server
+    enable_kubeconfig_keychain = false
+    # synchronize `kubernetes.io/dockerconfigjson` secret from kubernetes API server with specified kubeconfig (default `$KUBECONFIG` or `~/.kube/config`)
+    kubeconfig_path = ""
+    # Fetch the private registry auth as CRI image service proxy
+    enable_cri_keychain = false
+    # the target image service when using image proxy
+    #image_service_address = "/run/containerd/containerd.sock"
+
+    [snapshot]
+    # Let containerd use nydus-overlayfs mount helper
+    enable_nydus_overlayfs = false
+    # Path to the nydus-overlayfs binary or name of the binary in $PATH
+    nydus_overlayfs_path = "nydus-overlayfs"
+    # Insert Kata Virtual Volume option to `Mount.Options`
+    enable_kata_volume = false
+    # Whether to remove resources when a snapshot is removed
+    sync_remove = false
+
+    [cache_manager]
+    # Disable or enable recyclebin
+    disable = false
+    # How long to keep deleted files in recyclebin
+    gc_period = "24h"
+    # Directory to host cached files
+    cache_dir = ""
+
+    [image]
+    public_key_file    = ""
+    validate_signature = false
+
+    # The configurations for features that are not production ready
+    [experimental]
+    # Whether to enable stargz support
+    enable_stargz = false
+    # Whether to enable referrers support
+    # The option enables trying to fetch the Nydus image associated with the OCI image and run it.
+    # Also see https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
+    enable_referrer_detect = false
+    # Whether to enable authentication support
+    # The option enables nydus snapshot to provide backend information to nydusd.
+    enable_backend_source = false
+    [experimental.tarfs]
+    # Whether to enable nydus tarfs mode. Tarfs is supported by:
+    # - The EROFS filesystem driver since Linux 6.4
+    # - Nydus Image Service release v2.3
+    enable_tarfs = false
+    # Mount rafs on host by loopdev and EROFS
+    mount_tarfs_on_host = false
+    # Only enable nydus tarfs mode for images with `tarfs hint` label when true
+    tarfs_hint = false
+    # Maximum of concurrence to converting OCIv1 images to tarfs, 0 means default
+    max_concurrent_proc = 0
+    # Mode to export tarfs images:
+    # - "none" or "": do not export tarfs
+    # - "layer_verity_only": only generate disk verity information for a layer blob
+    # - "image_verity_only": only generate disk verity information for all blobs of an image
+    # - "layer_block": generate a raw block disk image with tarfs for a layer
+    # - "image_block": generate a raw block disk image with tarfs for an image
+    # - "layer_block_with_verity": generate a raw block disk image with tarfs for a layer with dm-verity info
+    # - "image_block_with_verity": generate a raw block disk image with tarfs for an image with dm-verity info
+    export_mode = ""

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,43 @@
+image:
+  repository: helm-cr-cn-guilin-boe.cr.volces.com/vke
+  imagePullPolicy: Always
+  imagePullSecret: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+rbac:
+  serviceAccount:
+    create: true
+    node:
+      name: csi-vepfs-node-sa
+    controller:
+      name: csi-vepfs-controller-sa
+
+snapshotter:
+  daemonset:
+    image:
+      name: nydus-snapshotter
+      tag: 0.15.2
+    resources:
+      limits:
+        cpu: 1
+        memory: 500Mi
+      requests:
+        cpu: 200m
+        memory: 200Mi
+    tolerations:
+      - operator: Exists
+    nodeSelector:
+
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity -- Affinity for pod assignment
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node.kubernetes.io/instance-type
+              operator: NotIn
+              values:
+                - virtual-node

--- a/config/config.go
+++ b/config/config.go
@@ -219,6 +219,10 @@ type SnapshotterConfig struct {
 	DaemonMode string `toml:"daemon_mode"`
 	// Clean up all the resources when snapshotter is closed
 	CleanupOnClose bool `toml:"cleanup_on_close"`
+	// Enable nydus-snapshotter to delegate nydusd creation and reaping membership to host.
+	// This is useful when nydus-snapshotter is running in a container deployed by Kubernetes, nydus-snapshotter must
+	// run in the host pid namespace and has privilege to enter the host mnt namespace.
+	DelegateNydusd bool `toml:"delegate_nydusd"`
 
 	SystemControllerConfig SystemControllerConfig `toml:"system"`
 	MetricsConfig          MetricsConfig          `toml:"metrics"`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM golang:1.24.3-bookworm AS builder
+ARG SOURCE_DIR=/nydus-snapshotter
+ARG BUILD_FLAGS
+ARG GOPROXY
+
+WORKDIR ${SOURCE_DIR}
+
+COPY . ${SOURCE_DIR}
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod/ make GOPROXY=${GOPROXY} && \
+GOPROXY=${GOPROXY} go install github.com/mikefarah/yq/v4@v4.44.3
+
+FROM debian:bookworm
+ARG NYDUS_VER=v2.3.0
+
+RUN apt update && apt -y install jq curl wget procps && \ 
+apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+COPY --from=builder /nydus-snapshotter/bin/containerd-nydus-grpc /nydus-snapshotter/containerd-nydus-grpc
+COPY --from=builder /go/bin/yq /usr/bin/yq
+
+RUN  wget https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VER/nydus-static-$NYDUS_VER-linux-amd64.tgz && \
+echo $NYDUS_VER > /.nydus_version && \
+mkdir -p /nydus-static && \
+tar xzf nydus-static-$NYDUS_VER-linux-amd64.tgz  && \
+rm nydus-static-$NYDUS_VER-linux-amd64.tgz
+
+RUN wget https://github.com/containerd/containerd/releases/download/v2.1.1/containerd-2.1.1-linux-amd64.tar.gz && \
+mkdir -p /tmp/containerd && \
+tar xzf containerd-2.1.1-linux-amd64.tar.gz -C /tmp/containerd && \
+install -D -m 755 /tmp/containerd/bin/ctr /usr/local/bin/ && \
+rm -rf containerd-2.1.1-linux-amd64.tar.gz /tmp/containerd
+
+RUN wget https://github.com/TomWright/dasel/releases/download/v2.8.1/dasel_linux_amd64 && install -D -m 755 dasel_linux_amd64 /usr/local/bin/dasel
+
+COPY misc/snapshotter/setup.sh /setup.sh
+RUN chmod +x /setup.sh
+
+WORKDIR /nydus-snapshotter
+ENTRYPOINT ["/setup.sh"]

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -17,15 +17,15 @@ address = "/run/containerd-nydus/system.sock"
 
 [system.debug]
 # Snapshotter can profile the CPU utilization of each nydusd daemon when it is being started.
-# This option specifies the profile duration when nydusd is downloading and uncomproessing data.
+# This option specifies the profile duration when nydusd is downloading and uncompressing data.
 daemon_cpu_profile_duration_secs = 5
 # Enable by assigning an address, empty indicates pprof server is disabled
 pprof_address = ""
 
 [daemon]
 # Specify a configuration file for nydusd
-nydusd_config = "/etc/nydus/nydusd-config.fusedev.json"
-nydusd_path = "/usr/local/bin/nydusd"
+nydusd_config   = "/etc/nydus/nydusd-config.fusedev.json"
+nydusd_path     = "/usr/local/bin/nydusd"
 nydusimage_path = "/usr/local/bin/nydus-image"
 # The fs driver can be one of the following options: fusedev, fscache, blockdev, proxy, or nodev. 
 # If `fs_driver` option is not specified, the default value is fusedev.
@@ -50,11 +50,11 @@ memory_limit = ""
 # Print logs to stdout rather than logging files
 log_to_stdout = false
 # Snapshotter's log level
-level = "info"
-log_rotation_compress = true
+level                   = "info"
+log_rotation_compress   = true
 log_rotation_local_time = true
 # Max number of days to retain logs
-log_rotation_max_age = 7
+log_rotation_max_age     = 7
 log_rotation_max_backups = 5
 # In unit MB(megabytes)
 log_rotation_max_size = 100
@@ -68,7 +68,7 @@ convert_vpc_registry = false
 
 [remote.mirrors_config]
 # Snapshotter will overwrite daemon's mirrors configuration
-# if the values loaded from this driectory are not null before starting a daemon.
+# if the values loaded from this directory are not null before starting a daemon.
 # Set to "" or an empty directory to disable it.
 #dir = "/etc/nydus/certs.d"
 
@@ -101,10 +101,10 @@ gc_period = "24h"
 cache_dir = ""
 
 [image]
-public_key_file = ""
+public_key_file    = ""
 validate_signature = false
 
-# The configuraions for features that are not production ready
+# The configurations for features that are not production ready
 [experimental]
 # Whether to enable stargz support
 enable_stargz = false

--- a/misc/snapshotter/setup.sh
+++ b/misc/snapshotter/setup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+ret=$(yq -oj '.proxy_plugins.nydus' /etc/containerd/config.toml)
+
+need_start_containerd=false
+
+ret=$(yq -oj '.plugins."io.containerd.grpc.v1.cri".containerd.disable_snapshot_annotations' /etc/containerd/config.toml)
+if [[ ${ret} == "null" || ${ret} == "true" ]]; then
+  echo "disable_snapshot_annotations is null or true, setting it to false"
+  dasel put -r toml -f /etc/containerd/config.toml -t bool -v false  'plugins.io\.containerd\.grpc\.v1\.cri.containerd.disable_snapshot_annotations'
+  need_start_containerd=true
+fi
+
+if [[ ${ret} != "null" ]]; then
+  echo "Nydus snapshotter has been configured!"
+else
+  echo "Added nydus-snapshotter to Containerd's configuration file"
+
+  echo '
+# Added by nydus-snapshotter automatically, nydus-snapshotter will not remove the table even being uninstalled!
+[proxy_plugins.nydus]
+  type = "snapshot"
+  # The "address" field specifies through which socket snapshotter and containerd communicate.
+  address = "/run/containerd-nydus/containerd-nydus-grpc.sock"' >> /etc/containerd/config.toml
+    
+  need_start_containerd=true
+fi
+
+ret=$(yq -oj '.plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-nydus' /etc/containerd/config.toml)
+if [[ ${ret} != "null" ]]; then
+    echo "Runtime handler has been configured!"
+else
+    echo "Added runc-nydus runtime handler to Containerd's configuration file"
+    
+    echo '
+# Added by nydus-snapshotter automatically, nydus-snapshotter will not remove the table even being uninstalled!
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-nydus]
+  runtime_type = "io.containerd.runc.v2"
+  snapshotter = "nydus"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-nydus.options]
+    NoPivotRoot = false
+    NoNewKeyring = false
+    SystemdCgroup = false' >> /etc/containerd/config.toml
+
+   need_start_containerd=true
+fi
+
+if [[ $need_start_containerd == "true" ]]; then
+  echo "Restart Containerd service" 
+  chroot /proc/1/root bash -c "systemctl restart containerd"
+else
+  echo "No need to restart containerd on host"
+fi
+
+pushd /nydus-static
+mkdir -p /opt/nydus/bin
+install -m 755 nydusd nydusctl nydus-image /opt/nydus/bin
+popd
+
+mkdir -p /etc/nydus && cp /nydus-static/configs/nydusd-config.json /etc/nydus/nydusd-config.json
+
+printf "Executing nydus-snapshotter...\n\n"
+exec ./containerd-nydus-grpc --nydusd-config /etc/nydus/nydusd-config.json --nydusd /opt/nydus/bin/nydusd --nydus-image /opt/nydus/bin/nydus-image --log-to-stdout "$@"

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -37,6 +37,8 @@ type Manager struct {
 	FsDriver string
 	store    Store
 
+	delegateNydusd bool
+
 	// Fields below are used to manage nydusd daemons.
 	//
 	// The `daemonCache` is cache for nydusd daemons stored in `store`.
@@ -59,6 +61,7 @@ type Opt struct {
 	FsDriver         string
 	NydusdBinaryPath string
 	RecoverPolicy    config.DaemonRecoverPolicy
+	DelegateNydusd   bool   // If true, the manager will not start nydusd daemons, but only manage them.
 	RootDir          string // Nydus-snapshotter work directory
 }
 
@@ -93,6 +96,7 @@ func NewManager(opt Opt) (*Manager, error) {
 		DaemonConfig:     opt.DaemonConfig,
 		CgroupMgr:        opt.CgroupMgr,
 		FsDriver:         opt.FsDriver,
+		delegateNydusd:   opt.DelegateNydusd,
 	}
 
 	// FIXME: How to get error if monitor goroutine terminates with error?

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -14,36 +14,33 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
+	"github.com/pkg/errors"
+
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
-	"github.com/containerd/nydus-snapshotter/pkg/rafs"
-
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
 	"github.com/containerd/nydus-snapshotter/pkg/cgroup"
 	v2 "github.com/containerd/nydus-snapshotter/pkg/cgroup/v2"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/containerd/nydus-snapshotter/pkg/filesystem"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
 	mgr "github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics"
 	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
 	"github.com/containerd/nydus-snapshotter/pkg/pprof"
+	"github.com/containerd/nydus-snapshotter/pkg/rafs"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
-	"github.com/containerd/nydus-snapshotter/pkg/system"
-	"github.com/containerd/nydus-snapshotter/pkg/tarfs"
-
-	"github.com/containerd/nydus-snapshotter/pkg/store"
-
-	"github.com/containerd/nydus-snapshotter/pkg/filesystem"
-	"github.com/containerd/nydus-snapshotter/pkg/label"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
 	"github.com/containerd/nydus-snapshotter/pkg/snapshot"
+	"github.com/containerd/nydus-snapshotter/pkg/store"
+	"github.com/containerd/nydus-snapshotter/pkg/system"
+	"github.com/containerd/nydus-snapshotter/pkg/tarfs"
 )
 
 var _ snapshots.Snapshotter = &snapshotter{}
@@ -154,6 +151,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 			FsDriver:         config.FsDriverFusedev,
 			DaemonConfig:     daemonConfig,
 			CgroupMgr:        cgroupMgr,
+			DelegateNydusd:   cfg.DelegateNydusd,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "create fusedev manager")


### PR DESCRIPTION
Address #612 

Currently nydus-snapshotter does not have an elegant method to be deployed to a productive **Kubernetes** cluster. Nydus-snapshotter only release binary artifacts w/o consideration for Kubernetes. So this PR tries to pack nydus-snapshotter together with necessary nydus node components and its configurations into a Helm Chart. It makes the nydus-snapshotter installation and deployment convenient for users even if the users only intends to give a quick trial and evaluation if nydus suites their business. It's totally a standard K8s fashion. The users don't have to scan tons of documents. Yes it is just packed as a whole.

The challenge  we have to solve first is that K8s applications/components(on top of DaemonSet) can be killed, rollout to upgrade, the progress should not affect any running nydusd as the user space fuse service. So we cant let nydus-snapshotter directly spawn a nydusd which is also running in the same Linux namespaces and cgroups with nydus-snapshotter. By design, nydus-snapshotter is a privileged container with host PID namespace, this means nydus-snapshotter can `nsenter` the host namespace and delegate nydusd creation to  `systemd` by its utility `systemd-run`. Nydus-snapshotter will enter host  mnt namespace and calls `systemd-run` to start nydusd as a transient service. So deleting nydus-snapshotter  daemonset and helm release, rollout daemonset, killing nydus-snapshotter won't affect running nydusd, which means user's business is continuous across those processes.

As for the details of the deployment architecture:
DaemonSet:
- nydus-snapshotter
- nydus node components: nydusd, nydus-image, nydusctl
ConfigMap:
- nydus-snapshotter config.toml

Besides, nydus-snapshotter will modify containerd config.toml to integrate with nydus-snapshotter and restart containerd if necessary.

To test and try, just at the root of the code project and perform
```
helm install nydus-snapshotter charts
```