### PR TITLE
[mountRemote] include intermediate snapshots in mount slice during referrer detection

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -905,6 +905,19 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 	}
 
 	lowerPaths := make([]string, 0, 8)
+	if o.fs.ReferrerDetectEnabled() {
+		// From the parent list, we want to add all the layers
+		// between the upmost snapshot and the nydus meta snapshot.
+		// On the other hand, we consider that all the layers below
+		// the nydus meta snapshot will be included in its mount.
+		for i := range s.ParentIDs {
+			if s.ParentIDs[i] == id {
+				break
+			}
+			lowerPaths = append(lowerPaths, o.upperPath(s.ParentIDs[i]))
+		}
+	}
+
 	lowerPathNydus, err := o.lowerPath(id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to locate overlay lowerdir")


### PR DESCRIPTION
This fixes #640. All the details to understand the bug are in the issue.

When the nydus-snapshotter returns the final mount slice for an image that is not nydus but shares layers with an images that is nydus, it currently doesn't include all the layers between the topmost and the nydus layer which causes missing files in the final running container. This commit attempts to fix the issue by adding all the missing layers to the final mount slice.