### PR TITLE
converter: fix trailing data after applying archive

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -117,6 +117,12 @@ func unpackOciTar(ctx context.Context, dst string, reader io.Reader) error {
 		return errors.Wrap(err, "apply with convert whiteout")
 	}
 
+	// Read any trailing data for some tar formats, in case the
+	// PipeWriter of opposite side gets stuck.
+	if _, err := io.Copy(io.Discard, ds); err != nil {
+		return errors.Wrap(err, "trailing data after applying archive")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Read any trailing data for some tar formats, in case the PipeWriter of opposite side gets stuck.

Reference: https://github.com/containerd/containerd/blob/6373c7b53b76db25365824d3c969c409e630cf02/core/diff/apply/apply.go#L99