### PR TITLE
[Fix] resolve clippy::uninlined_format_args warning in optimizer-server

### DIFF
--- a/tools/optimizer-server/src/main.rs
+++ b/tools/optimizer-server/src/main.rs
@@ -230,7 +230,7 @@ fn handle_fanotify_event(fd: i32) {
                 if e == nix::Error::EINTR {
                     continue;
                 }
-                eprintln!("Poll error {:?}", e);
+                eprintln!("Poll error {e:?}");
                 break;
             }
         }


### PR DESCRIPTION
This change fixes the compilation error in CI, allowing the  optimizer-server build to pass.