### PR TITLE
[Fix] proper handling of nydusd binary copies in hot upgrades

### DIFF
--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -345,14 +345,18 @@ func (sc *Controller) upgradeDaemons() func(w http.ResponseWriter, r *http.Reque
 				}
 			}
 
-			// TODO: why renaming?
-			err = os.Rename(c.NydusdPath, manager.NydusdBinaryPath)
-			if err != nil {
-				log.L.Errorf("Rename nydusd binary from %s to  %s failed, %v",
-					c.NydusdPath, manager.NydusdBinaryPath, err)
+			sourcePath := c.NydusdPath
+			destinationPath := manager.NydusdBinaryPath
+
+			if err = copyNydusdBinary(sourcePath, destinationPath); err != nil {
+				log.L.Errorf("Failed to copy nydusd binary from %s to %s: %v",
+					sourcePath, destinationPath, err)
 				statusCode = http.StatusInternalServerError
 				return
 			}
+
+			log.L.Infof("Successfully copy nydusd binary from %s to %s",
+				sourcePath, destinationPath)
 		}
 	}
 }
@@ -458,4 +462,38 @@ func buildNextAPISocket(cur string) (string, error) {
 
 	nextSocket := fmt.Sprintf("api%d.sock", num)
 	return nextSocket, nil
+}
+
+// copyNydusdBinary copies a file from sourcePath to destinationPath,
+// ensuring parent directories exist and setting 0755 permissions.
+// It overwrites the destination file if it already exists.
+func copyNydusdBinary(sourcePath, destinationPath string) error {
+	fileMode := os.FileMode(0755)
+
+	destDir := filepath.Dir(destinationPath)
+	if err := os.MkdirAll(destDir, fileMode); err != nil {
+		return fmt.Errorf("failed to create destination directory %s: %w", destDir, err)
+	}
+
+	sourceFile, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("failed to open source file %s: %w", sourcePath, err)
+	}
+	defer sourceFile.Close()
+
+	destinationFile, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file %s: %w", destinationPath, err)
+	}
+	defer destinationFile.Close()
+
+	if _, err := io.Copy(destinationFile, sourceFile); err != nil {
+		return fmt.Errorf("failed to copy file contents from %s to %s: %w", sourcePath, destinationPath, err)
+	}
+
+	if err := os.Chmod(destinationPath, fileMode); err != nil {
+		return fmt.Errorf("failed to set permissions for %s to %s: %w", destinationPath, fileMode.String(), err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
The use of os.Rename (which has mv semantics) would cause the file at the original source path (newNydusdPath) to no longer exist after the hot upgrade operation.