### PR TITLE
[Feature] add support for context-aware stream cancellation on convert

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -815,6 +815,10 @@ func makeBlobDesc(ctx context.Context, cs content.Store, opt PackOption, sourceD
 // a nydus blob layer, and set the media type to "application/vnd.oci.image.layer.nydus.blob.v1".
 func LayerConvertFunc(opt PackOption) converter.ConvertFunc {
 	return func(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
+		if ctx.Err() != nil {
+			// The context is already cancelled, no need to proceed.
+			return nil, ctx.Err()
+		}
 		if !images.IsLayerType(desc.MediaType) {
 			return nil, nil
 		}
@@ -864,13 +868,27 @@ func LayerConvertFunc(opt PackOption) converter.ConvertFunc {
 			return nil, errors.Wrap(err, "pack tar to nydus")
 		}
 
+		copyBufferDone := make(chan error, 1)
 		go func() {
 			defer pw.Close()
 			buffer := bufPool.Get().(*[]byte)
 			defer bufPool.Put(buffer)
-			if _, err := io.CopyBuffer(tw, tr, *buffer); err != nil {
-				pw.CloseWithError(err)
+			go func() {
+				_, err := io.CopyBuffer(tw, tr, *buffer)
+				copyBufferDone <- err
+			}()
+			select {
+			case <-ctx.Done():
+				// The context was cancelled!
+				// Close the pipe with the context's error to signal
+				// the reader to stop.
+				pw.CloseWithError(ctx.Err())
 				return
+			case err := <-copyBufferDone:
+				if err != nil {
+					pw.CloseWithError(err)
+					return
+				}
 			}
 			if err := tr.Close(); err != nil {
 				pw.CloseWithError(err)


### PR DESCRIPTION
Relevant Issue: https://github.com/dragonflyoss/nydus/issues/1734

Background: The previous implementation of convert did not handle context cancellation properly within the io.CopyBuffer operation. When one of the concurrent tasks failed, other io.CopyBuffer streams would continue to run to completion, leading to unnecessary resource consumption and a delayed errgroup.Wait() return.

Changes: This commit refactors the stream copying logic to be context-aware. A select statement is now used to listen for both the io.CopyBuffer completion and the ctx.Done() signal. This allows the goroutine to immediately stop the copy operation when the context is cancelled.

Impact: This change ensures that all convert tasks will fail fast when an error occurs in any one of them, significantly reducing resource waste and improving overall application performance in failure scenarios.