### PR TITLE
[Fix] increase registry healthcheck retries to improve CI stability

### DIFF
--- a/tests/helpers/kind.sh
+++ b/tests/helpers/kind.sh
@@ -53,7 +53,7 @@ configure::dockerd '{
   "cgroup-parent": "/actions_job",
   "insecure-registries" : [ "'"$registry_url"'" ]
 }'
-http::healthcheck "$registry_url"/v2/ 5 1 "$DOCKER_USER" "$DOCKER_PASSWORD"
+http::healthcheck "$registry_url"/v2/ 10 2 "$DOCKER_USER" "$DOCKER_PASSWORD"
 log::info "Login"
 docker::login "$DOCKER_USER" "$DOCKER_PASSWORD" "$registry_url"
 

--- a/tests/helpers/lib.sh
+++ b/tests/helpers/lib.sh
@@ -133,7 +133,7 @@ _http::get(){
   shift
 
   local header
-  local command=(curl -fsSL --retry "$retry" --retry-delay "$delay" -o "$output")
+  local command=(curl -fsSL --retry-connrefused --retry "$retry" --retry-delay "$delay" -o "$output")
   # Add a basic auth user if necessary
   [ "$user" == "" ] || command+=(--user "$user:$password")
   # Force tls v1.2 and no redirect to http if url scheme is https


### PR DESCRIPTION
## Background:
In the kind.sh script, after the local Docker registry container starts, the http::healthcheck function attempts to connect to the registry service. We've observed that in CI environments, the service within the registry container sometimes takes several seconds to start listening on the port, causing curl to return a "Connection refused" error on the first health check attempt.
By default, curl treats "Connection refused" as a non-retryable error and exits immediately, rather than waiting as specified by the --retry flag. This causes the CI process to fail prematurely before the service is ready, leading to instability.

## Solution:
To make the CI process more robust, this change :

- increases the number of retries and delay for the http::healthcheck function in the kind.sh script.
- added --retry-connrefused parameter to the curl command inside the http::healthcheck function.

This adjustment improving reliability and stability.I have tested it locally and the problem is solved.