### PR TITLE
[Feature] Support nydusd failover-policy config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,12 @@ const (
 	FsDriverProxy    string = constant.FsDriverProxy
 )
 
+const (
+	FailoverPolicyNone   string = constant.FailoverPolicyNone
+	FailoverPolicyResend string = constant.FailoverPolicyResend
+	FailoverPolicyFlush  string = constant.FailoverPolicyFlush
+)
+
 type Experimental struct {
 	EnableStargz         bool        `toml:"enable_stargz"`
 	EnableReferrerDetect bool        `toml:"enable_referrer_detect"`
@@ -136,6 +142,7 @@ type DaemonConfig struct {
 	FsDriver         string `toml:"fs_driver"`
 	ThreadsNumber    int    `toml:"threads_number"`
 	LogRotationSize  int    `toml:"log_rotation_size"`
+	FailoverPolicy   string `toml:"failover_policy"`
 }
 
 type LoggingConfig struct {
@@ -288,6 +295,11 @@ func ValidateConfig(c *SnapshotterConfig) error {
 	}
 	if c.DaemonConfig.ThreadsNumber > 1024 {
 		return errors.Errorf("nydusd worker thread number %d is too big, max 1024", c.DaemonConfig.ThreadsNumber)
+	}
+	if c.DaemonConfig.FailoverPolicy != FailoverPolicyNone &&
+		c.DaemonConfig.FailoverPolicy != FailoverPolicyResend &&
+		c.DaemonConfig.FailoverPolicy != FailoverPolicyFlush {
+		return errors.Errorf("invalid failover policy %q", c.DaemonConfig.FailoverPolicy)
 	}
 
 	if c.RemoteConfig.AuthConfig.EnableCRIKeychain && c.RemoteConfig.AuthConfig.EnableKubeconfigKeychain {

--- a/config/default.go
+++ b/config/default.go
@@ -44,6 +44,7 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 	daemonConfig.RecoverPolicy = RecoverPolicyRestart.String()
 	daemonConfig.FsDriver = constant.DefaultFsDriver
 	daemonConfig.LogRotationSize = constant.DefaultDaemonRotateLogMaxSize
+	daemonConfig.FailoverPolicy = constant.DefaultFailoverPolicy
 
 	// cache configuration
 	cacheConfig := &c.CacheManagerConfig

--- a/config/global.go
+++ b/config/global.go
@@ -92,6 +92,10 @@ func GetDaemonThreadsNumber() int {
 	return globalConfig.origin.DaemonConfig.ThreadsNumber
 }
 
+func GetDaemonFailoverPolicy() string {
+	return globalConfig.origin.DaemonConfig.FailoverPolicy
+}
+
 func GetLogToStdout() bool {
 	return globalConfig.origin.LoggingConfig.LogToStdout
 }

--- a/internal/constant/values.go
+++ b/internal/constant/values.go
@@ -53,3 +53,10 @@ const (
 	DefaultRotateLogLocalTime     = true
 	DefaultRotateLogCompress      = true
 )
+
+const (
+	FailoverPolicyNone    string = "none"
+	FailoverPolicyResend  string = "resend"
+	FailoverPolicyFlush   string = "flush"
+	DefaultFailoverPolicy string = FailoverPolicyNone
+)

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -37,6 +37,8 @@ recover_policy = "restart"
 threads_number = 4
 # Log rotation size for nydusd, in unit MB(megabytes). (default 100MB)
 log_rotation_size = 100
+# Nydusd failover policy, can be "none", "resend" or "flush"
+failover_policy = "none"
 
 [cgroup]
 # Whether to use separate cgroup for nydusd.

--- a/pkg/daemon/command/command.go
+++ b/pkg/daemon/command/command.go
@@ -37,6 +37,7 @@ type DaemonCommand struct {
 	LogFile         string `type:"param" name:"log-file"`
 	PrefetchFiles   string `type:"param" name:"prefetch-files"`
 	BackendSource   string `type:"param" name:"backend-source"`
+	FailoverPolicy  string `type:"param" name:"failover-policy"`
 }
 
 // Build exec style command line
@@ -194,5 +195,11 @@ func WithUpgrade() Opt {
 func WithBackendSource(source string) Opt {
 	return func(cmd *DaemonCommand) {
 		cmd.BackendSource = source
+	}
+}
+
+func WithFailoverPolicy(policy string) Opt {
+	return func(cmd *DaemonCommand) {
+		cmd.FailoverPolicy = policy
 	}
 }

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -106,6 +106,13 @@ func WithFsDriver(fsDriver string) NewDaemonOpt {
 	}
 }
 
+func WithFailoverPolicy(failoverPolicy string) NewDaemonOpt {
+	return func(d *Daemon) error {
+		d.States.FailoverPolicy = failoverPolicy
+		return nil
+	}
+}
+
 func WithDaemonMode(daemonMode config.DaemonMode) NewDaemonOpt {
 	return func(d *Daemon) error {
 		d.States.DaemonMode = daemonMode

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -53,6 +53,7 @@ type ConfigState struct {
 	Mountpoint      string
 	SupervisorPath  string
 	ThreadNum       int
+	FailoverPolicy  string
 	// Where the configuration file resides, all rafs instances share the same configuration template
 	ConfigDir string
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -630,6 +630,7 @@ func (fs *Filesystem) createDaemon(fsManager *manager.Manager, daemonMode config
 		daemon.WithLogToStdout(config.GetLogToStdout()),
 		daemon.WithNydusdThreadNum(config.GetDaemonThreadsNumber()),
 		daemon.WithFsDriver(fsManager.FsDriver),
+		daemon.WithFailoverPolicy(config.GetDaemonFailoverPolicy()),
 		daemon.WithDaemonMode(daemonMode),
 	}
 

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -200,6 +200,8 @@ func (m *Manager) BuildDaemonCommand(d *daemon.Daemon, bin string, upgrade bool)
 		cmdOpts = append(cmdOpts, command.WithLogFile(d.LogFile()))
 	}
 
+	cmdOpts = append(cmdOpts, command.WithFailoverPolicy(d.States.FailoverPolicy))
+
 	args, err := command.BuildCommand(cmdOpts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add a new option `failover-policy` in config.toml and support passing nydusd failover-policy
command line options when creating nydusd.