### PR TITLE
feat(merge): add blob.meta support in merge logic (v0.13.11)

### DIFF
--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
@@ -565,6 +566,11 @@ func Merge(ctx context.Context, layers []Layer, dest io.Writer, opt MergeOption)
 		return filepath.Join(workDir, digestHex)
 	}
 
+	getBlobMetaPath := func(layerIdx int, suffix string) string {
+		digestHex := layers[layerIdx].Digest.Hex()
+		return filepath.Join(workDir, digestHex+suffix)
+	}
+
 	eg, _ := errgroup.WithContext(ctx)
 	sourceBootstrapPaths := []string{}
 	rafsBlobDigests := []string{}
@@ -594,6 +600,17 @@ func Merge(ctx context.Context, layers []Layer, dest io.Writer, opt MergeOption)
 					return errors.Wrap(err, "unpack nydus tar")
 				}
 
+				blobMetaPath := getBlobMetaPath(idx, ".blob.meta")
+				blobMetaFile, err := os.Create(blobMetaPath)
+				if err != nil {
+					return errors.Wrap(err, "create blob.meta file")
+				}
+
+        		if _, err := UnpackEntry(layers[idx].ReaderAt,EntryBlobMeta, blobMetaFile); err != nil {
+            		return errors.Wrap(err, "unpack blob.meta using fixed algorithm")
+       	 		}
+
+				defer blobMetaFile.Close()
 				return nil
 			}
 		}(idx))
@@ -624,25 +641,63 @@ func Merge(ctx context.Context, layers []Layer, dest io.Writer, opt MergeOption)
 		return nil, errors.Wrap(err, "merge bootstrap")
 	}
 
+	bootstrapRa, err := local.OpenReader(targetBootstrapPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "open bootstrap reader")
+	}
+	defer bootstrapRa.Close()
+
+	files := []File{
+		{
+			Name:   EntryBootstrap,
+			Reader: content.NewReader(bootstrapRa),
+			Size:   bootstrapRa.Size(),
+		},
+	}
+
+	var metaRas []io.Closer
+
+	for idx := range layers {
+		digestHex := layers[idx].Digest.Hex()
+		blobMetaPath := getBlobMetaPath(idx, ".blob.meta")
+		if _, err := os.Stat(blobMetaPath); err == nil {
+			metaRa, err := local.OpenReader(blobMetaPath)
+			if err != nil {
+				return nil, errors.Wrap(err, "open blob.meta")
+			}
+
+			metaRas = append(metaRas, metaRa)
+
+			files = append(files, File{
+				Name:   fmt.Sprintf("%s.%s", digestHex, EntryBlobMeta),
+				Reader: content.NewReader(metaRa),
+				Size:   metaRa.Size(),
+			})
+		}
+	}
+	files = append(files, opt.AppendFiles...)
+
 	var rc io.ReadCloser
 
 	if opt.WithTar {
-		rc, err = packToTar(targetBootstrapPath, fmt.Sprintf("image/%s", EntryBootstrap), false)
-		if err != nil {
-			return nil, errors.Wrap(err, "pack bootstrap to tar")
-		}
+		rc = packToTar(files, false)
 	} else {
 		rc, err = os.Open(targetBootstrapPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "open targe bootstrap")
 		}
 	}
-	defer rc.Close()
 
 	buffer := bufPool.Get().(*[]byte)
 	defer bufPool.Put(buffer)
 	if _, err = io.CopyBuffer(dest, rc, *buffer); err != nil {
 		return nil, errors.Wrap(err, "copy merged bootstrap")
+	}
+
+	defer rc.Close()
+
+	for _, closer := range metaRas {
+		closer.Close()
 	}
 
 	return blobDigests, nil

--- a/pkg/converter/types.go
+++ b/pkg/converter/types.go
@@ -125,6 +125,8 @@ type MergeOption struct {
 	Timeout *time.Duration
 	// Encrypt encrypts the bootstrap layer if it's specified.
 	Encrypt Encrypter
+	// AppendFiles specifies the files that need to be appended to the bootstrap layer.
+	AppendFiles []File
 }
 
 type UnpackOption struct {

--- a/pkg/converter/utils.go
+++ b/pkg/converter/utils.go
@@ -14,13 +14,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 
 	"github.com/containerd/containerd/content"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+type File struct {
+	Name   string
+	Reader io.Reader
+	Size   int64
+}
 
 type writeCloser struct {
 	closed bool
@@ -83,39 +88,27 @@ func newSeekReader(ra io.ReaderAt) *seekReader {
 	}
 }
 
-// packToTar makes .tar(.gz) stream of file named `name` and return reader.
-func packToTar(src string, name string, compress bool) (io.ReadCloser, error) {
-	fi, err := os.Stat(src)
-	if err != nil {
-		return nil, err
-	}
-
+// packToTar packs files to .tar(.gz) stream then return reader.
+func packToTar(files []File, compress bool) io.ReadCloser {
 	dirHdr := &tar.Header{
-		Name:     filepath.Dir(name),
+		Name:     "image",
 		Mode:     0755,
 		Typeflag: tar.TypeDir,
 	}
 
-	hdr := &tar.Header{
-		Name: name,
-		Mode: 0444,
-		Size: fi.Size(),
-	}
-
-	reader, writer := io.Pipe()
+	pr, pw := io.Pipe()
 
 	go func() {
 		// Prepare targz writer
 		var tw *tar.Writer
 		var gw *gzip.Writer
 		var err error
-		var file *os.File
 
 		if compress {
-			gw = gzip.NewWriter(writer)
+			gw = gzip.NewWriter(pw)
 			tw = tar.NewWriter(gw)
 		} else {
-			tw = tar.NewWriter(writer)
+			tw = tar.NewWriter(pw)
 		}
 
 		defer func() {
@@ -137,30 +130,30 @@ func packToTar(src string, name string, compress bool) (io.ReadCloser, error) {
 				finalErr = err2
 			}
 
-			writer.CloseWithError(finalErr)
+			pw.CloseWithError(finalErr)
 		}()
-
-		file, err = os.Open(src)
-		if err != nil {
-			return
-		}
-		defer file.Close()
 
 		// Write targz stream
 		if err = tw.WriteHeader(dirHdr); err != nil {
 			return
 		}
 
-		if err = tw.WriteHeader(hdr); err != nil {
-			return
-		}
-
-		if _, err = io.Copy(tw, file); err != nil {
-			return
+		for _, file := range files {
+			hdr := tar.Header{
+				Name: filepath.Join("image", file.Name),
+				Mode: 0444,
+				Size: file.Size,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return
+			}
+			if _, err = io.Copy(tw, file.Reader); err != nil {
+				return
+			}
 		}
 	}()
 
-	return reader, nil
+	return pr
 }
 
 // Copied from containerd/containerd project, copyright The containerd Authors.


### PR DESCRIPTION
### Background
This patch optimizes the merge process for RAFS v6 by including the blob.meta file in the bootstrap tar archive during image build.

### Change Base
The modification is based on the nydus-snapshotter v0.13.11 release tag. In my deployment, the nydusify tool uses this specific version to convert and load container images.

### Optimization
The update modifies the merge logic to package the blob.meta file together with the bootstrap data, ensuring full metadata is available in the output tar archive.

### Result
This improves metadata handling for RAFS v6 images and simplifies loading for deployments based on v0.13.11.

Bootstrap tar with blob.meta (RAFS v6)
<img width="1405" height="358" alt="merge" src="https://github.com/user-attachments/assets/17e798f5-f29d-40c8-92cd-f98891feec62" />
