### PR TITLE
Add OCI index detection for Nydus alternatives

### DIFF
--- a/.github/workflows/k8s-e2e-run.yml
+++ b/.github/workflows/k8s-e2e-run.yml
@@ -19,3 +19,9 @@ jobs:
     uses: ./.github/workflows/k8s-e2e.yml
     with:
       auth-type: kubeconf
+
+  index_detect:
+    uses: ./.github/workflows/k8s-e2e.yml
+    with:
+      auth-type: kubeconf
+      index-detect: true

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -6,6 +6,9 @@ on:
       auth-type:
         required: true
         type: string
+      index-detect:
+        required: false
+        type: boolean
 
 env:
   DOCKER_USER: testuser
@@ -27,8 +30,10 @@ jobs:
           go-version-file: 'go.mod'
           cache-dependency-path: "go.sum"
       - name: Test
+        env:
+          AUTH_TYPE: ${{ inputs.auth-type }}
+          INDEX_DETECT: ${{ inputs.index-detect }}
         run: |
-          AUTH_TYPE='${{ inputs.auth-type }}'
           ./tests/helpers/kind.sh
       - name: Dump logs
         if: failure()

--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,7 @@ const (
 type Experimental struct {
 	EnableStargz         bool        `toml:"enable_stargz"`
 	EnableReferrerDetect bool        `toml:"enable_referrer_detect"`
+	EnableIndexDetect    bool        `toml:"enable_index_detect"`
 	TarfsConfig          TarfsConfig `toml:"tarfs"`
 	EnableBackendSource  bool        `toml:"enable_backend_source"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,6 +31,7 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 		Experimental: Experimental{
 			EnableStargz:         false,
 			EnableReferrerDetect: false,
+			EnableIndexDetect:    false,
 		},
 		CleanupOnClose: false,
 		SystemControllerConfig: SystemControllerConfig{

--- a/docs/index_detection.md
+++ b/docs/index_detection.md
@@ -1,0 +1,89 @@
+# Index Detection
+
+## Overview
+
+Index Detection is a feature that automatically discovers Nydus alternative manifests within OCI index manifests. This enables transparent fallback to optimized Nydus images when available while keeping the original index manifest OCI compliant, allowing non-Nydus clients to pull regular OCI images.
+
+## Motivation
+
+The Index Detection feature addresses several limitations of the existing Referrer API-based detection:
+
+- **Registry Support**: Not all registries support the Referrer API
+- **Supply Chain Security**: Referrer API relies on external changes to the manifest, creating potential supply chain risks
+- **Universal Compatibility**: Index detection works with all OCI-compliant registries
+
+Unlike referrer-based detection, Index Detection packages everything into a single manifest, eliminating supply chain concerns while maintaining universal registry support.
+
+## How It Works
+
+### Detection Process
+
+1. **Index Manifest Parsing**: When a manifest digest is encountered, the system fetches and parses the original OCI index manifest
+2. **Platform Matching**: The system finds the original manifest descriptor within the index
+3. **Nydus Alternative Search**: It searches for platform-compatible manifests that contain:
+   - `platform.os.features` containing `nydus.remoteimage.v1`, or
+   - `artifactType` set to `application/vnd.nydus.image.manifest.v1+json`
+4. **Validation**: The found manifest is validated to ensure it's a valid Nydus manifest with metadata layers
+5. **Caching**: Results are cached to avoid repeated API calls for the same digest
+
+Both `platform.os.features` and `artifactType` are looked at because index manifests built using `merge-platform` before acceleration-service: v0.2.19 or nydus: v2.3.5 will have `platform.os.features` configured while images built after will have `artifactType` configured.
+
+### Detection Priority
+
+When both Index Detection and Referrer Detection are available, Index Detection takes priority due to its superior supply chain security properties.
+
+## Configuration
+
+Index Detection is controlled by the `EnableIndexDetect` configuration option in the experimental features section:
+
+```toml
+[experimental]
+enable_index_detect = true
+```
+
+## Building Compatible Images
+
+To create images compatible with Index Detection, use the `nydusify convert` command with the `--merge-platform` flag:
+
+```bash
+nydusify convert --merge-platform <source-image> <target-image>
+```
+
+This creates an OCI index manifest containing both the original image and the Nydus alternative:
+
+```json
+{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:a63dfddecc661e4ad05896418b2f3774022269c3bf5b7e01baaa6e851a3a4a23",
+      "size": 2320,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:bb82dd8ee111bfe5fdf12145b6ed553da9c15de17f54b1f658d95ff26a65a01c",
+      "size": 3229,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      },
+      "artifactType": "application/vnd.nydus.image.manifest.v1+json"
+    }
+  ]
+}
+```
+
+## Comparison with Referrer Detection
+
+| Aspect | Index Detection | Referrer Detection |
+|--------|----------------|-------------------|
+| Registry Support | Universal | Limited |
+| Supply Chain Security | Secure (single manifest) | Potential risks (external refs) |
+| OCI Compliance | Full compliance | Requires Referrer API |
+| Cache Behavior | Immutable (digest-based) | May require invalidation |
+| Detection Priority | Higher | Lower |

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -3,7 +3,7 @@ version = 1
 root = "/var/lib/containerd/io.containerd.snapshotter.v1.nydus"
 # The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
 address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
-# The nydus daemon mode can be one of the following options: multiple, dedicated, shared, or none. 
+# The nydus daemon mode can be one of the following options: multiple, dedicated, shared, or none.
 # If `daemon_mode` option is not specified, the default value is multiple.
 daemon_mode = "dedicated"
 # Whether snapshotter should try to clean up resources when it is closed
@@ -27,7 +27,7 @@ pprof_address = ""
 nydusd_config = "/etc/nydus/nydusd-config.fusedev.json"
 nydusd_path = "/usr/local/bin/nydusd"
 nydusimage_path = "/usr/local/bin/nydus-image"
-# The fs driver can be one of the following options: fusedev, fscache, blockdev, proxy, or nodev. 
+# The fs driver can be one of the following options: fusedev, fscache, blockdev, proxy, or nodev.
 # If `fs_driver` option is not specified, the default value is fusedev.
 fs_driver = "fusedev"
 # How to process when daemon dies: "none", "restart" or "failover"
@@ -118,6 +118,10 @@ enable_stargz = false
 # The option enables trying to fetch the Nydus image associated with the OCI image and run it.
 # Also see https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
 enable_referrer_detect = false
+# Whether to enable index detection support
+# The option enables trying to fetch the Nydus image present in the same OCI index as the original OCI image and run it.
+# Also see https://github.com/containerd/nydus-snapshotter/blob/main/docs/index-detection.md
+enable_index_detect = false
 # Whether to enable authentication support
 # The option enables nydus snapshot to provide backend information to nydusd.
 enable_backend_source = false

--- a/pkg/converter/constant.go
+++ b/pkg/converter/constant.go
@@ -7,10 +7,11 @@
 package converter
 
 const (
-	ManifestOSFeatureNydus   = "nydus.remoteimage.v1"
-	ManifestConfigNydus      = "application/vnd.nydus.image.config.v1+json"
-	MediaTypeNydusBlob       = "application/vnd.oci.image.layer.nydus.blob.v1"
-	BootstrapFileNameInLayer = "image/image.boot"
+	ManifestOSFeatureNydus    = "nydus.remoteimage.v1"
+	ManifestConfigNydus       = "application/vnd.nydus.image.config.v1+json"
+	ManifestArtifactTypeNydus = "application/vnd.nydus.image.manifest.v1+json"
+	MediaTypeNydusBlob        = "application/vnd.oci.image.layer.nydus.blob.v1"
+	BootstrapFileNameInLayer  = "image/image.boot"
 
 	ManifestNydusCache = "containerd.io/snapshot/nydus-cache"
 

--- a/pkg/filesystem/config.go
+++ b/pkg/filesystem/config.go
@@ -9,6 +9,7 @@ package filesystem
 
 import (
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
+	"github.com/containerd/nydus-snapshotter/pkg/index"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
@@ -56,6 +57,17 @@ func WithReferrerManager(rm *referrer.Manager) NewFSOpt {
 		}
 
 		fs.referrerMgr = rm
+		return nil
+	}
+}
+
+func WithIndexManager(im *index.Manager) NewFSOpt {
+	return func(fs *Filesystem) error {
+		if im == nil {
+			return errors.New("index manager cannot be nil")
+		}
+
+		fs.indexMgr = im
 		return nil
 	}
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -18,15 +18,14 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/log"
 	"github.com/mohae/deepcopy"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/core/snapshots/storage"
-	"github.com/containerd/log"
 
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
@@ -34,6 +33,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/containerd/nydus-snapshotter/pkg/index"
 	"github.com/containerd/nydus-snapshotter/pkg/label"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	racache "github.com/containerd/nydus-snapshotter/pkg/rafs"
@@ -49,6 +49,7 @@ type Filesystem struct {
 	enabledManagers     map[string]*manager.Manager
 	cacheMgr            *cache.Manager
 	referrerMgr         *referrer.Manager
+	indexMgr            *index.Manager
 	stargzResolver      *stargz.Resolver
 	tarfsMgr            *tarfs.Manager
 	verifier            *signature.Verifier

--- a/pkg/filesystem/index_adaptor.go
+++ b/pkg/filesystem/index_adaptor.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package filesystem
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+func (fs *Filesystem) IndexDetectEnabled() bool {
+	return fs.indexMgr != nil
+}
+
+// CheckIndexAlternative attempts to find a nydus alternative manifest in the original OCI index manifest
+func (fs *Filesystem) CheckIndexAlternative(ctx context.Context, labels map[string]string) bool {
+	if !fs.IndexDetectEnabled() {
+		return false
+	}
+
+	ref, ok := labels[snpkg.TargetRefLabel]
+	if !ok {
+		return false
+	}
+
+	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
+	if manifestDigest.Validate() != nil {
+		return false
+	}
+
+	logger := log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String())
+	logger.Debug("attempting index-based nydus detection")
+
+	// Early exit if the labels explicitly indicate the presence of a nydus index alternative
+	hasIndexAlternative, ok := labels[label.NydusIndexAlternative]
+	if ok && hasIndexAlternative == "true" {
+		logger.Debug("detected nydus alternative via label")
+		return true
+	}
+
+	if _, err := fs.indexMgr.CheckIndexAlternative(ctx, ref, manifestDigest); err != nil {
+		return false
+	}
+	logger.Debug("detected nydus alternative via index manifest")
+
+	return true
+}
+
+// TryFetchMetadataFromIndex attempts to fetch metadata from the nydus index alternative
+func (fs *Filesystem) TryFetchMetadataFromIndex(ctx context.Context, labels map[string]string, metadataPath string) error {
+	ref, ok := labels[snpkg.TargetRefLabel]
+	if !ok {
+		return fmt.Errorf("empty label %s", snpkg.TargetRefLabel)
+	}
+
+	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
+	if err := manifestDigest.Validate(); err != nil {
+		return fmt.Errorf("invalid label %s=%s", snpkg.TargetManifestDigestLabel, manifestDigest)
+	}
+
+	// Early exit if the file already exists
+	if _, err := os.Stat(metadataPath); err == nil {
+		log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String()).WithField("metadataPath", metadataPath).Debugf("metadata file already exists")
+		return nil
+	}
+
+	if err := fs.indexMgr.TryFetchMetadata(ctx, ref, manifestDigest, metadataPath); err != nil {
+		return errors.Wrap(err, "try fetch metadata")
+	}
+
+	return nil
+}

--- a/pkg/index/detector.go
+++ b/pkg/index/detector.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+
+	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/containerd/nydus-snapshotter/pkg/converter"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
+	"github.com/containerd/nydus-snapshotter/pkg/remote"
+)
+
+// Containerd restricts the max size of manifest index to 8M, follow it.
+const maxManifestIndexSize = 0x800000
+
+type detector struct {
+	remote *remote.Remote
+}
+
+func newDetector(keyChain *auth.PassKeyChain, insecure bool) *detector {
+	return &detector{
+		remote: remote.New(keyChain, insecure),
+	}
+}
+
+// checkIndexAlternative attempts to find a nydus alternative manifest
+// within an OCI index manifest for the specified manifest digest.
+func (d *detector) checkIndexAlternative(ctx context.Context, ref string, manifestDigest digest.Digest) (*ocispec.Descriptor, error) {
+	handle := func() (*ocispec.Descriptor, error) {
+		// Create a new fetcher to request.
+		fetcher, err := d.remote.Fetcher(ctx, ref)
+		if err != nil {
+			return nil, errors.Wrap(err, "get fetcher")
+		}
+
+		resolver := d.remote.Resolve(ctx, ref)
+		_, desc, err := resolver.Resolve(ctx, ref)
+		if err != nil {
+			return nil, errors.Wrapf(err, "resolve reference %s", ref)
+		}
+
+		rc, err := fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetch index manifest")
+		}
+		defer rc.Close()
+
+		// Parse image manifest list from index.
+		var index ocispec.Index
+		bytes, err := io.ReadAll(io.LimitReader(rc, maxManifestIndexSize))
+		if err != nil {
+			return nil, errors.Wrap(err, "read index manifest")
+		}
+		if err := json.Unmarshal(bytes, &index); err != nil {
+			return nil, errors.Wrap(err, "unmarshal index manifest")
+		}
+
+		nydusDesc, err := d.findNydusManifestInIndex(index, manifestDigest)
+		if err != nil {
+			return nil, err
+		}
+
+		rc, err = fetcher.Fetch(ctx, *nydusDesc)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetch nydus image manifest")
+		}
+		defer rc.Close()
+
+		var manifest ocispec.Manifest
+		bytes, err = io.ReadAll(rc)
+		if err != nil {
+			return nil, errors.Wrap(err, "read manifest")
+		}
+		if err := json.Unmarshal(bytes, &manifest); err != nil {
+			return nil, errors.Wrap(err, "unmarshal manifest")
+		}
+		if len(manifest.Layers) < 1 {
+			return nil, fmt.Errorf("invalid manifest")
+		}
+		metaLayer := manifest.Layers[len(manifest.Layers)-1]
+		if !label.IsNydusMetaLayer(metaLayer.Annotations) {
+			return nil, fmt.Errorf("invalid nydus manifest")
+		}
+
+		return &metaLayer, nil
+	}
+
+	desc, err := handle()
+	if err != nil && d.remote.RetryWithPlainHTTP(ref, err) {
+		return handle()
+	}
+
+	return desc, err
+}
+
+// findNydusManifestInIndex finds a nydus alternative manifest within an OCI index
+// for the specified manifest digest. It returns the nydus manifest descriptor.
+func (d *detector) findNydusManifestInIndex(index ocispec.Index, originalDigest digest.Digest) (*ocispec.Descriptor, error) {
+	var originalDesc *ocispec.Descriptor
+	for _, manifest := range index.Manifests {
+		if manifest.Digest == originalDigest {
+			originalDesc = &manifest
+			break
+		}
+	}
+	if originalDesc == nil {
+		return nil, fmt.Errorf("original manifest %s not found in index", originalDigest)
+	}
+
+	pMatcher := platforms.NewMatcher(*originalDesc.Platform)
+	for _, manifest := range index.Manifests {
+		if pMatcher.Match(*manifest.Platform) &&
+			(d.hasNydusFeatures(manifest.Platform) || d.hasNydusArtifactType(&manifest)) {
+			return &manifest, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no nydus alternative found in index for %s", originalDigest)
+}
+
+// hasNydusFeatures checks if the platform descriptor contains nydus features.
+func (d *detector) hasNydusFeatures(platform *ocispec.Platform) bool {
+	if platform == nil {
+		return false
+	}
+
+	return slices.Contains(platform.OSFeatures, converter.ManifestOSFeatureNydus)
+}
+
+// hasNydusArtifactType checks if the descriptor is of nydus artifact type.
+func (d *detector) hasNydusArtifactType(desc *ocispec.Descriptor) bool {
+	if desc == nil {
+		return false
+	}
+	return desc.ArtifactType == converter.ManifestArtifactTypeNydus
+}
+
+// fetchMetadata fetches and unpacks nydus metadata file to specified path.
+func (d *detector) fetchMetadata(ctx context.Context, ref string, desc ocispec.Descriptor, metadataPath string) error {
+	handle := func() error {
+		resolver := d.remote.Resolve(ctx, ref)
+		fetcher, err := resolver.Fetcher(ctx, ref)
+		if err != nil {
+			return errors.Wrap(err, "get fetcher")
+		}
+
+		rc, err := fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return errors.Wrap(err, "fetch nydus metadata")
+		}
+		defer rc.Close()
+
+		// Unpack nydus metadata file to specified path.
+		if err := remote.Unpack(rc, converter.BootstrapFileNameInLayer, metadataPath); err != nil {
+			os.Remove(metadataPath)
+			return errors.Wrap(err, "unpack metadata from layer")
+		}
+
+		return nil
+	}
+
+	err := handle()
+	if err != nil && d.remote.RetryWithPlainHTTP(ref, err) {
+		return handle()
+	}
+
+	return err
+}

--- a/pkg/index/detector_test.go
+++ b/pkg/index/detector_test.go
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasNydusFeatures(t *testing.T) {
+	d := &detector{}
+
+	tests := []struct {
+		name     string
+		platform *ocispec.Platform
+		expected bool
+	}{
+		{
+			name:     "nil platform",
+			platform: nil,
+			expected: false,
+		},
+		{
+			name: "platform without os features",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			},
+			expected: false,
+		},
+		{
+			name: "platform with nydus features",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+				OSFeatures:   []string{"nydus.remoteimage.v1"},
+			},
+			expected: true,
+		},
+		{
+			name: "platform with multiple features including nydus",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+				OSFeatures:   []string{"feature1", "nydus.remoteimage.v1", "feature2"},
+			},
+			expected: true,
+		},
+		{
+			name: "platform with non-nydus features",
+			platform: &ocispec.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+				OSFeatures:   []string{"feature1", "feature2"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := d.hasNydusFeatures(tt.platform)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindNydusManifestInIndex(t *testing.T) {
+	d := &detector{}
+
+	manifestDigest := digest.FromString("test-manifest")
+	nydusManifestDigest := digest.FromString("nydus-manifest")
+
+	tests := []struct {
+		name           string
+		index          ocispec.Index
+		manifestDigest digest.Digest
+		expectedDigest *digest.Digest
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name: "original manifest not found in index",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{},
+			},
+			manifestDigest: manifestDigest,
+			expectError:    true,
+			errorContains:  "not found in index",
+		},
+		{
+			name: "no nydus alternative found",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: digest.FromString("other-manifest"),
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectError:    true,
+			errorContains:  "no nydus alternative found",
+		},
+		{
+			name: "nydus alternative found",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: nydusManifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectedDigest: &nydusManifestDigest,
+			expectError:    false,
+		},
+		{
+			name: "multiple nydus alternatives, returns first match",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: nydusManifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+					{
+						Digest: digest.FromString("second-nydus-manifest"),
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectedDigest: &nydusManifestDigest,
+			expectError:    false,
+		},
+		{
+			name: "nydus alternative with different architecture ignored",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: digest.FromString("nydus-arm64"),
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "arm64",
+							OSFeatures:   []string{"nydus.remoteimage.v1"},
+						},
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectError:    true,
+			errorContains:  "no nydus alternative found",
+		},
+		{
+			name: "nydus alternative found with artifact type",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: nydusManifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+						ArtifactType: "application/vnd.nydus.image.manifest.v1+json",
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectedDigest: &nydusManifestDigest,
+			expectError:    false,
+		},
+		{
+			name: "different artifact type is ignored",
+			index: ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: manifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					},
+					{
+						Digest: nydusManifestDigest,
+						Platform: &ocispec.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+						ArtifactType: "application/foo+bar",
+					},
+				},
+			},
+			manifestDigest: manifestDigest,
+			expectError:    true,
+			errorContains:  "no nydus alternative found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := d.findNydusManifestInIndex(tt.index, tt.manifestDigest)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, *tt.expectedDigest, result.Digest)
+			}
+		})
+	}
+}

--- a/pkg/index/manager.go
+++ b/pkg/index/manager.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"context"
+
+	"github.com/containerd/log"
+	"github.com/golang/groupcache/lru"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/containerd/nydus-snapshotter/pkg/auth"
+)
+
+var ErrNoNydusAlternative = errors.New("no alternative nydus descriptor found in index")
+
+type Manager struct {
+	insecure bool
+	cache    *lru.Cache
+	sg       singleflight.Group
+}
+
+func NewManager(insecure bool) *Manager {
+	manager := Manager{
+		insecure: insecure,
+		cache:    lru.New(500),
+		sg:       singleflight.Group{},
+	}
+
+	return &manager
+}
+
+// CheckIndexAlternative attempts to find a nydus alternative manifest
+// within an OCI index manifest for the specified manifest digest.
+func (manager *Manager) CheckIndexAlternative(ctx context.Context, ref string, manifestDigest digest.Digest) (*ocispec.Descriptor, error) {
+	nydusDesc, err, _ := manager.sg.Do(manifestDigest.String(), func() (interface{}, error) {
+		// Try to get nydus metadata layer descriptor from LRU cache.
+		desc, ok := manager.cache.Get(manifestDigest)
+		if ok {
+			metaLayer, ok := desc.(ocispec.Descriptor)
+			if ok {
+				return &metaLayer, nil
+			}
+			return nil, ErrNoNydusAlternative
+		}
+
+		keyChain, err := auth.GetKeyChainByRef(ref, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "get key chain")
+		}
+
+		// No LRU cache found, try to detect nydus alternative in index manifest.
+		detector := newDetector(keyChain, manager.insecure)
+		metaLayer, err := detector.checkIndexAlternative(ctx, ref, manifestDigest)
+		if err != nil {
+			// Cache empty result to avoid repeated failures.
+			// The index manifest can't change as it would change its digest so checking once is enough
+			manager.cache.Add(manifestDigest, nil)
+			return nil, errors.Wrap(err, "check index alternative")
+		}
+
+		// Cache the result for future use
+		manager.cache.Add(manifestDigest, *metaLayer)
+
+		return metaLayer, nil
+	})
+
+	logger := log.G(ctx).WithField("ref", ref).WithField("digest", manifestDigest.String())
+	if err == ErrNoNydusAlternative {
+		return nil, err
+	} else if err != nil {
+		logger.WithError(err).Warn("index detection failed")
+		return nil, err
+	}
+
+	return nydusDesc.(*ocispec.Descriptor), nil
+}
+
+// TryFetchMetadata try to fetch and unpack nydus metadata file to specified path.
+func (manager *Manager) TryFetchMetadata(ctx context.Context, ref string, manifestDigest digest.Digest, metadataPath string) error {
+	metaLayer, err := manager.CheckIndexAlternative(ctx, ref, manifestDigest)
+	if err != nil {
+		return errors.Wrap(err, "check index alternative")
+	}
+
+	keyChain, err := auth.GetKeyChainByRef(ref, nil)
+	if err != nil {
+		return errors.Wrap(err, "get key chain")
+	}
+
+	detector := newDetector(keyChain, manager.insecure)
+	return detector.fetchMetadata(ctx, ref, *metaLayer, metadataPath)
+}

--- a/pkg/index/manager_test.go
+++ b/pkg/index/manager_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckIndexAlternative(t *testing.T) {
+	manifestDigest := digest.FromString("test-manifest")
+	ref := "registry.example.com/test/repo:latest"
+
+	expectedDesc := &ocispec.Descriptor{
+		Digest: digest.FromString("meta-layer"),
+	}
+
+	t.Run("cache hit, nydus present", func(t *testing.T) {
+		manager := NewManager(false)
+		manager.cache.Add(manifestDigest, *expectedDesc)
+
+		result, err := manager.CheckIndexAlternative(context.Background(), ref, manifestDigest)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDesc, result)
+	})
+
+	t.Run("cache hit, no nydus", func(t *testing.T) {
+		manager := NewManager(false)
+		manager.cache.Add(manifestDigest, nil)
+
+		_, err := manager.CheckIndexAlternative(context.Background(), ref, manifestDigest)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no alternative nydus descriptor found in index")
+	})
+}

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -60,6 +60,9 @@ const (
 	// A bool flag to mark it is recommended to run this image with tarfs mode, set by image builders.
 	// runtime can decide whether to rely on this annotation
 	TarfsHint = "containerd.io/snapshot/tarfs-hint"
+
+	// An alternative nydus index manifest exists in the original OCI index manifest for this snapshot
+	NydusIndexAlternative = "containerd.io/snapshot/nydus-index-alternative"
 )
 
 func IsNydusDataLayer(labels map[string]string) bool {

--- a/tests/e2e/k8s/snapshotter-kubeconf.yaml
+++ b/tests/e2e/k8s/snapshotter-kubeconf.yaml
@@ -23,9 +23,9 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - ""
-    resources: 
+    resources:
     - nodes
     verbs:
     - get
@@ -200,6 +200,7 @@ data:
     [experimental]
     # Whether tp enable stargz support
     enable_stargz = false
+    enable_index_detect = true
     
     [daemon]
     nydusd_path = "/usr/local/bin/nydusd"


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

Implement index detection feature that automatically discovers Nydus alternative manifests within OCI index manifests, similar to what SOCI snashotter is able to do. This enables transparent fallback to optimized Nydus images when available while keeping the original index manifest OCI compliant as non-nydus client can simply pull the regular OCI image. The feature is heavily based on the already existing ReferrerDetect feature which looks for nydus manifests using the referrer API. However, the referrer API is not supported by all registries and as it relies on changes happening outside the manifest being pulled it's a bit dangerous from a supply chain perspective. On the other hand, this new IndexDetect feature is supported everywhere and does not have the supply chain issue as everyting is packed in a single manifest. Building a manifest compatible with this feature can be easily done with the `--merge-platform` flag in `nydusify convert`.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

Comes from discussions we had in https://github.com/dragonflyoss/nydus/issues/1692#issuecomment-3144921344. Additionally, this will help with https://github.com/dragonflyoss/nydus/issues/463 since it will be easier to have OCI-compliant nydus images

## Change Details
_Please describe your changes in detail:_

Key changes:
- Add EnableIndexDetect config option to experimental features
- Implement index package with manifest finding logic. Very similar to referrer package. The detection is based on the `platform.os.feature` (nydus.remoteimage.v1) or the `artifactType` (application/vnd.nydus.image.manifest.v1+json) field in the index manifest
- Result is cached to avoid multiple API calls for the same digest
- Integrate index detection into filesystem and snapshot layers. The index detection is done before the referrer detection: if both exist, we prefer to use the index detection for the supply chain issues mentionned above.
- Add e2e test for index detection
- Add documentation for the new feature

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

Added an e2e test and some unit tests to cover this new feature.

I have not added a test in the `integration/` directory mainly because there is no image built with `merge-platform` in `ghcr.io/dragonflyoss/image-service/wordpress`. If one is added, I can add an integration test as well.

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.