### PR TITLE
Add configurable checksum for s3 backend to enable cloudflare r2 support

### DIFF
--- a/pkg/backend/s3.go
+++ b/pkg/backend/s3.go
@@ -159,14 +159,12 @@ func (b *S3Backend) Push(ctx context.Context, cs content.Store, desc ocispec.Des
 	uploader := manager.NewUploader(client, func(u *manager.Uploader) {
 		u.PartSize = MultipartChunkSize
 	})
-	putObjectInput := &s3.PutObjectInput{
+	if _, err := uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket:            aws.String(b.bucketName),
 		Key:               aws.String(blobObjectKey),
 		Body:              reader,
 		ChecksumAlgorithm: b.checksumAlgorithm,
-	}
-
-	if _, err := uploader.Upload(ctx, putObjectInput); err != nil {
+	}); err != nil {
 		return errors.Wrap(err, "push blob to s3 backend")
 	}
 

--- a/pkg/backend/s3_test.go
+++ b/pkg/backend/s3_test.go
@@ -9,6 +9,8 @@ package backend
 import (
 	"reflect"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 func Test_newS3Backend(t *testing.T) {
@@ -42,6 +44,32 @@ func Test_newS3Backend(t *testing.T) {
 				region:             "us-east-1",
 				accessKeySecret:    "minio123",
 				accessKeyID:        "minio",
+				checksumAlgorithm:  types.ChecksumAlgorithmCrc32,
+			},
+			wantErr: false,
+		},
+		{
+			name: "test2, set checksum algorithm",
+			args: args{
+				rawConfig: []byte(`{
+					"endpoint": "localhost:9000",
+					"scheme": "http",
+					"bucket_name": "nydus",
+					"region": "us-east-1",
+					"object_prefix": "path/to/my-registry/",
+					"access_key_id": "minio",
+					"access_key_secret": "minio123",
+					"checksum_algorithm": "SHA256"
+				}`),
+			},
+			want: &S3Backend{
+				objectPrefix:       "path/to/my-registry/",
+				bucketName:         "nydus",
+				endpointWithScheme: "http://localhost:9000",
+				region:             "us-east-1",
+				accessKeySecret:    "minio123",
+				accessKeyID:        "minio",
+				checksumAlgorithm:  types.ChecksumAlgorithmSha256,
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Overview
This PR adds a configuration option to set the checksum algorithm for S3-compatible backends, specifically to resolve 500 errors when uploading to Cloudflare R2.

## Change Details
Add a new parameter "checksum_algorithm" to the json config for the s3backend. This enables using different checksum algorithms or to disable checksums entirely by passing "". This is needed for multipart uploads to work with cloudflare r2 since they don't support the `x-amz-checksum-algorithm` parameter in UpdatePart messages.

## Test Results
=== RUN   Test_newS3Backend
=== RUN   Test_newS3Backend/test1,_no_error
=== RUN   Test_newS3Backend/test2,_set_checksum_algorithm
--- PASS: Test_newS3Backend (0.00s)
    --- PASS: Test_newS3Backend/test1,_no_error (0.00s)
    --- PASS: Test_newS3Backend/test2,_set_checksum_algorithm (0.00s)
PASS
ok      github.com/containerd/nydus-snapshotter/pkg/backend     0.005s

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.