### PR TITLE
[converter] Add MergeManifest option to tell converter when manifests are merged

### DIFF
--- a/pkg/converter/constant.go
+++ b/pkg/converter/constant.go
@@ -8,6 +8,7 @@ package converter
 
 const (
 	ManifestOSFeatureNydus   = "nydus.remoteimage.v1"
+	ManifestConfigNydus      = "application/vnd.nydus.image.config.v1+json"
 	MediaTypeNydusBlob       = "application/vnd.oci.image.layer.nydus.blob.v1"
 	BootstrapFileNameInLayer = "image/image.boot"
 

--- a/pkg/converter/convert_unix.go
+++ b/pkg/converter/convert_unix.go
@@ -1041,6 +1041,12 @@ func convertManifest(ctx context.Context, cs content.Store, oldDesc ocispec.Desc
 	if err != nil {
 		return nil, errors.Wrap(err, "write image config")
 	}
+	// When manifests are merged, we need to put a special value for the config mediaType.
+	// This values must be one that containerd doesn't understand to ensure it doesn't try tu pull the nydus image
+	// but use the OCI one instead. And then if the nydus-snapshotter is used, it can pull the nydus image instead.
+	if opt.MergeManifest {
+		newConfigDesc.MediaType = ManifestConfigNydus
+	}
 	manifest.Config = *newConfigDesc
 	// Update the config gc label
 	manifestLabels[configGCLabelKey] = newConfigDesc.Digest.String()

--- a/pkg/converter/types.go
+++ b/pkg/converter/types.go
@@ -127,6 +127,9 @@ type MergeOption struct {
 	Encrypt Encrypter
 	// AppendFiles specifies the files that need to be appended to the bootstrap layer.
 	AppendFiles []File
+	// MergeManifest indicates that the resulting nydus manifest will be merged with the original
+	// OCI one into a single index manifest.
+	MergeManifest bool
 }
 
 type UnpackOption struct {


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

When both the OCI and nydus manifests are merged with `nydusify --merge-platform` for instance, containerd will try to pull an unpack both images even if it doesn't have a nydus-snapshotter. Which results in the nydus image failing to be unpacked and a global image pull failure. One way to fix this issue is to use a config mediaType that containerd doesn't understand in the nydus image. This way it won't attempt to unpack it while the nydus snapshotter can still discover the image and pull it.

We use `application/vnd.nydus.image.config.v1+json` as the new config value only used if MergeManifest is set in the MergeOption.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

See https://github.com/containerd/nydus-snapshotter/pull/669#issuecomment-3254616180 for context

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

When propagating the change up to nydusify (see all the changes [done](https://github.com/DataDog/nydus/pull/5) in nydusify directly), this will result in an artifact as follow (note the config mediaType):
```
crane manifest localhost:5000/image:v1.3.0-nydus-platform-config@sha256:4aaffab81483a36fa808f16c0476c6968ce042e6ad7fd734b79f497a0591730d
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.nydus.image.config.v1+json",
    "digest": "sha256:3c374743d776cfe42e92a6795e788ec9d3bf2ec7a30dc3a263b37ee433045083",
    "size": 8712
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.nydus.blob.v1",
      "digest": "sha256:a2fec6caf440b76f26fa3366fa2f4e4b31af4e27572acc8d571afc244dd01c5d",
      "size": 8389,
      "annotations": {
        "containerd.io/snapshot/nydus-blob": "true"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.nydus.blob.v1",
      "digest": "sha256:78b1c6220ef98ad2518018d11f35dd391e186f7efc48ac7fa1946278b9334aff",
      "size": 56627718,
      "annotations": {
        "containerd.io/snapshot/nydus-blob": "true"
      }
    },
...
```

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.