### PR TITLE
[Fix] use atomic symlink for nydusd binary upgrades

### DIFF
--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	metrics "github.com/containerd/nydus-snapshotter/pkg/metrics/tool"
 	"github.com/containerd/nydus-snapshotter/pkg/prefetch"
+	"github.com/rs/xid"
 )
 
 const (
@@ -348,15 +349,12 @@ func (sc *Controller) upgradeDaemons() func(w http.ResponseWriter, r *http.Reque
 			sourcePath := c.NydusdPath
 			destinationPath := manager.NydusdBinaryPath
 
-			if err = copyNydusdBinary(sourcePath, destinationPath); err != nil {
+			if err = upgradeNydusdWithSymlink(sourcePath, destinationPath); err != nil {
 				log.L.Errorf("Failed to copy nydusd binary from %s to %s: %v",
 					sourcePath, destinationPath, err)
 				statusCode = http.StatusInternalServerError
 				return
 			}
-
-			log.L.Infof("Successfully copy nydusd binary from %s to %s",
-				sourcePath, destinationPath)
 		}
 	}
 }
@@ -470,35 +468,73 @@ func buildNextAPISocket(cur string) (string, error) {
 	return nextSocket, nil
 }
 
-// copyNydusdBinary copies a file from sourcePath to destinationPath,
-// ensuring parent directories exist and setting 0755 permissions.
-// It overwrites the destination file if it already exists.
-func copyNydusdBinary(sourcePath, destinationPath string) error {
-	fileMode := os.FileMode(0755)
-
-	destDir := filepath.Dir(destinationPath)
-	if err := os.MkdirAll(destDir, fileMode); err != nil {
-		return fmt.Errorf("failed to create destination directory %s: %w", destDir, err)
+// upgradeNydusdWithSymlink atomically upgrades the nydusd binary using a symbolic link strategy.
+// It copies the new binary to a permanent, versioned directory and then atomically updates a symlink
+// to point to the new version. This allows for zero-downtime upgrades and avoids "text file busy" errors.
+func upgradeNydusdWithSymlink(newBinaryPath, symlinkPath string) error {
+	// Determine the directory for storing all actual binary files.
+	// This is typically a subdirectory within the same directory as the symlink.
+	symlinkDir := filepath.Dir(symlinkPath)
+	versionsDir := filepath.Join(symlinkDir, "nydusd-versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create versions directory %s: %w", versionsDir, err)
 	}
 
-	sourceFile, err := os.Open(sourcePath)
+	// Generate a unique name for the new binary file
+	// and determine its final destination path inside the versions directory.
+	versionedFileName := fmt.Sprintf("nydusd-%d", time.Now().UnixNano())
+	versionedBinaryPath := filepath.Join(versionsDir, versionedFileName)
+
+	// Copy the new binary file to its destination in the versions directory.
+	if err := copyFile(newBinaryPath, versionedBinaryPath); err != nil {
+		return fmt.Errorf("failed to copy new binary to versions directory: %w", err)
+	}
+	log.L.Infof("Successfully copied new binary to %s", versionedBinaryPath)
+
+	// Atomically update the symbolic link.
+	// To do this safely, we first create a temporary symlink and then use an atomic rename
+	// operation to replace the old symlink with the new one.
+	tempSymlinkPath := symlinkPath + ".tmp-" + xid.New().String()
+	if err := os.Symlink(versionedBinaryPath, tempSymlinkPath); err != nil {
+		return fmt.Errorf("failed to create temporary symlink %s: %w", tempSymlinkPath, err)
+	}
+
+	// os.Rename provides an atomic replacement of the symlink.
+	if err := os.Rename(tempSymlinkPath, symlinkPath); err != nil {
+		// Clean up the temporary symlink if the rename fails.
+		os.Remove(tempSymlinkPath)
+		return fmt.Errorf("failed to atomically update symlink %s: %w", symlinkPath, err)
+	}
+
+	log.L.Infof("Successfully updated symlink %s to point to %s", symlinkPath, versionedBinaryPath)
+	return nil
+}
+
+// copyFile is a utility function that copies a file from a source path to a destination path.
+// It ensures the destination directory exists and sets the destination file's permissions to 0755.
+// If the destination file already exists, it will be overwritten.
+func copyFile(src, dst string) error {
+	fileMode := os.FileMode(0755)
+
+	sourceFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed to open source file %s: %w", sourcePath, err)
+		return fmt.Errorf("failed to open source file %s: %w", src, err)
 	}
 	defer sourceFile.Close()
 
-	destinationFile, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
+	destinationFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
 	if err != nil {
-		return fmt.Errorf("failed to create destination file %s: %w", destinationPath, err)
+		return fmt.Errorf("failed to create destination file %s: %w", dst, err)
 	}
 	defer destinationFile.Close()
 
 	if _, err := io.Copy(destinationFile, sourceFile); err != nil {
-		return fmt.Errorf("failed to copy file contents from %s to %s: %w", sourcePath, destinationPath, err)
+		return fmt.Errorf("failed to copy file contents from %s to %s: %w", src, dst, err)
 	}
 
-	if err := os.Chmod(destinationPath, fileMode); err != nil {
-		return fmt.Errorf("failed to set permissions for %s to %s: %w", destinationPath, fileMode.String(), err)
+	// Set permissions after copying, as the file mode in OpenFile can be affected by umask.
+	if err := os.Chmod(dst, fileMode); err != nil {
+		return fmt.Errorf("failed to set permissions for %s: %w", dst, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

use atomic symlink for nydusd binary upgrades

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._
fix ci https://github.com/dragonflyoss/nydus/actions/runs/17766964640/job/50549977874?pr=1765
## Change Details
_Please describe your changes in detail:_

The previous method of directly overwriting the nydusd binary could cause "text file busy" errors if the daemon was running during a hot upgrade. This led to unreliable updates and failing tests.

This commit refactors the upgrade logic to use a safer, atomic symlink switching strategy. New binaries are copied to a permanent, versioned directory, and the main symlink is then atomically updated to point to the new version.

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._
<img width="2780" height="546" alt="image" src="https://github.com/user-attachments/assets/6eeaf3c8-3577-434b-acff-bd39f2bf556b" />

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.