### PR TITLE
Fix #681: Enable failover-policy option only in Fusedev mode

### DIFF
--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -669,8 +669,11 @@ func (fs *Filesystem) createDaemon(fsManager *manager.Manager, daemonMode config
 		daemon.WithLogToStdout(config.GetLogToStdout()),
 		daemon.WithNydusdThreadNum(config.GetDaemonThreadsNumber()),
 		daemon.WithFsDriver(fsManager.FsDriver),
-		daemon.WithFailoverPolicy(config.GetDaemonFailoverPolicy()),
 		daemon.WithDaemonMode(daemonMode),
+	}
+
+	if fsManager.FsDriver == config.FsDriverFusedev {
+		opts = append(opts, daemon.WithFailoverPolicy(config.GetDaemonFailoverPolicy()))
 	}
 
 	// For fscache driver, no need to provide mountpoint to nydusd daemon.

--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -200,7 +200,9 @@ func (m *Manager) BuildDaemonCommand(d *daemon.Daemon, bin string, upgrade bool)
 		cmdOpts = append(cmdOpts, command.WithLogFile(d.LogFile()))
 	}
 
-	cmdOpts = append(cmdOpts, command.WithFailoverPolicy(d.States.FailoverPolicy))
+	if d.States.FsDriver == config.FsDriverFusedev {
+		cmdOpts = append(cmdOpts, command.WithFailoverPolicy(d.States.FailoverPolicy))
+	}
 
 	args, err := command.BuildCommand(cmdOpts)
 	if err != nil {


### PR DESCRIPTION
## Overview
Enable failover-policy option only in Fusedev mode.

## Related Issues
Fix #681.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)