### PR TITLE
[metrics] Make collect interval configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ package config
 
 import (
 	"os"
+	"time"
 
 	"dario.cat/mergo"
 	"github.com/pelletier/go-toml"
@@ -213,7 +214,9 @@ type MirrorsConfig struct {
 }
 
 type MetricsConfig struct {
-	Address string `toml:"address"`
+	Address         string        `toml:"address"`
+	CollectInterval time.Duration `toml:"collect_interval"`
+	HungIOInterval  time.Duration `toml:"hung_io_interval"`
 }
 
 type DebugConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -84,7 +84,9 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 			LogToStdout:         false,
 		},
 		MetricsConfig: MetricsConfig{
-			Address: ":9110",
+			Address:         ":9110",
+			CollectInterval: 2 * time.Minute,
+			HungIOInterval:  15 * time.Second,
 		},
 		CgroupConfig: CgroupConfig{
 			Enable:      true,
@@ -201,6 +203,10 @@ func TestMergeConfig(t *testing.T) {
 	A.Equal(snapshotterConfig1.DaemonConfig.NydusdConfigPath, constant.DefaultNydusDaemonConfigPath)
 	A.Equal(snapshotterConfig1.DaemonConfig.RecoverPolicy, RecoverPolicyRestart.String())
 	A.Equal(snapshotterConfig1.CacheManagerConfig.GCPeriod, constant.DefaultGCPeriod)
+
+	A.Equal(snapshotterConfig1.MetricsConfig.Address, "")
+	A.Equal(snapshotterConfig1.MetricsConfig.CollectInterval, constant.DefaultCollectInterval)
+	A.Equal(snapshotterConfig1.MetricsConfig.HungIOInterval, constant.DefaultHungIOInterval)
 
 	var snapshotterConfig2 SnapshotterConfig
 	snapshotterConfig2.Root = "/snapshotter/root"

--- a/config/default.go
+++ b/config/default.go
@@ -52,6 +52,11 @@ func (c *SnapshotterConfig) FillUpWithDefaults() error {
 		cacheConfig.GCPeriod = constant.DefaultGCPeriod
 	}
 
+	// metrics configuration
+	metricsConfig := &c.MetricsConfig
+	metricsConfig.CollectInterval = constant.DefaultCollectInterval
+	metricsConfig.HungIOInterval = constant.DefaultHungIOInterval
+
 	return c.SetupNydusBinaryPaths()
 }
 

--- a/internal/constant/values.go
+++ b/internal/constant/values.go
@@ -8,6 +8,8 @@
 
 package constant
 
+import "time"
+
 const (
 	DaemonModeMultiple  string = "multiple"
 	DaemonModeDedicated string = "dedicated"
@@ -59,4 +61,11 @@ const (
 	FailoverPolicyResend  string = "resend"
 	FailoverPolicyFlush   string = "flush"
 	DefaultFailoverPolicy string = FailoverPolicyResend
+)
+
+const (
+	// Default interval to determine a hung IO.
+	DefaultHungIOInterval = 10 * time.Second
+	// Default interval for collecting metrics.
+	DefaultCollectInterval = 1 * time.Minute
 )

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -3,7 +3,7 @@ version = 1
 root = "/var/lib/containerd/io.containerd.snapshotter.v1.nydus"
 # The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
 address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
-# The nydus daemon mode can be one of the following options: multiple, dedicated, shared, or none. 
+# The nydus daemon mode can be one of the following options: multiple, dedicated, shared, or none.
 # If `daemon_mode` option is not specified, the default value is multiple.
 daemon_mode = "dedicated"
 # Whether snapshotter should try to clean up resources when it is closed
@@ -27,7 +27,7 @@ pprof_address = ""
 nydusd_config = "/etc/nydus/nydusd-config.fusedev.json"
 nydusd_path = "/usr/local/bin/nydusd"
 nydusimage_path = "/usr/local/bin/nydus-image"
-# The fs driver can be one of the following options: fusedev, fscache, blockdev, proxy, or nodev. 
+# The fs driver can be one of the following options: fusedev, fscache, blockdev, proxy, or nodev.
 # If `fs_driver` option is not specified, the default value is fusedev.
 fs_driver = "fusedev"
 # How to process when daemon dies: "none", "restart" or "failover"
@@ -64,6 +64,10 @@ log_rotation_max_size = 100
 [metrics]
 # Enable by assigning an address, empty indicates metrics server is disabled
 address = ":9110"
+# How often to collect metrics
+collect_interval = "2m"
+# Minimum duration to consider an IO as hung
+hung_io_interval = "15s"
 
 [remote]
 convert_vpc_registry = false

--- a/pkg/metrics/serve_test.go
+++ b/pkg/metrics/serve_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/containerd/nydus-snapshotter/internal/constant"
+	"github.com/containerd/nydus-snapshotter/pkg/manager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	tests := []struct {
+		name                    string
+		collectInterval         time.Duration
+		hungIOInterval          time.Duration
+		managers                []*manager.Manager
+		expectedCollectInterval time.Duration
+		expectedHungIOInterval  time.Duration
+		expectErr               bool
+	}{
+		{
+			name:                    "defaults when no options provided",
+			expectedCollectInterval: constant.DefaultCollectInterval,
+			expectedHungIOInterval:  constant.DefaultHungIOInterval,
+		},
+		{
+			name:                    "positive collect interval sets value",
+			collectInterval:         5 * time.Minute,
+			expectedCollectInterval: 5 * time.Minute,
+			expectedHungIOInterval:  constant.DefaultHungIOInterval,
+		},
+		{
+			name:            "negative collect interval returns error",
+			collectInterval: -1 * time.Minute,
+			hungIOInterval:  0,
+			expectErr:       true,
+		},
+		{
+			name:                    "positive hung IO interval sets value",
+			collectInterval:         0,
+			hungIOInterval:          30 * time.Second,
+			expectedCollectInterval: constant.DefaultCollectInterval,
+			expectedHungIOInterval:  30 * time.Second,
+		},
+		{
+			name:            "negative hung IO interval returns error",
+			collectInterval: 0,
+			hungIOInterval:  -5 * time.Second,
+			expectErr:       true,
+		},
+		{
+			name:                    "both custom positive intervals",
+			collectInterval:         3 * time.Minute,
+			hungIOInterval:          20 * time.Second,
+			expectedCollectInterval: 3 * time.Minute,
+			expectedHungIOInterval:  20 * time.Second,
+		},
+		{
+			name:                    "both negative intervals return error",
+			collectInterval:         -2 * time.Minute,
+			hungIOInterval:          -10 * time.Second,
+			expectedCollectInterval: constant.DefaultCollectInterval,
+			expectedHungIOInterval:  constant.DefaultHungIOInterval,
+			expectErr:               true,
+		},
+		{
+			name:                    "with process manager",
+			managers:                []*manager.Manager{&manager.Manager{}},
+			expectedCollectInterval: constant.DefaultCollectInterval,
+			expectedHungIOInterval:  constant.DefaultHungIOInterval,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Build options based on test case
+			var opts []ServerOpt
+			if tt.managers != nil {
+				opts = append(opts, WithProcessManagers(tt.managers))
+			}
+			if tt.collectInterval != 0 {
+				opts = append(opts, WithCollectInterval(tt.collectInterval))
+			}
+			if tt.hungIOInterval != 0 {
+				opts = append(opts, WithHungIOInterval(tt.hungIOInterval))
+			}
+
+			srv, err := NewServer(ctx, opts...)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, srv)
+
+			// Verify managers
+			assert.Equal(t, tt.managers, srv.managers, "managers mismatch")
+
+			// Verify intervals
+			assert.Equal(t, tt.expectedCollectInterval, srv.collectInterval, "collect interval mismatch")
+			assert.Equal(t, tt.expectedHungIOInterval, srv.hungIOInterval, "hung IO interval mismatch")
+
+			// Verify collectors are always initialized
+			assert.NotNil(t, srv.fsCollector, "fsCollector should be initialized")
+			assert.NotNil(t, srv.inflightCollector, "inflightCollector should be initialized")
+		})
+	}
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -181,6 +181,8 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	metricServer, err := metrics.NewServer(
 		ctx,
 		metrics.WithProcessManagers(fsManagers),
+		metrics.WithCollectInterval(cfg.MetricsConfig.CollectInterval),
+		metrics.WithHungIOInterval(cfg.MetricsConfig.HungIOInterval),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "create metrics server")


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

This handles 2 of the TODOs that were present in metrics/serve.go to make the various intervals used as collect timers configurable. The default values aren't changed (1min for the global collect interval and 10s for the hung io interval)

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

unit tests are green:
```
$ go test ./config/
ok  	github.com/containerd/nydus-snapshotter/config	(cached)

$ go test ./pkg/metrics
ok  	github.com/containerd/nydus-snapshotter/pkg/metrics	(cached)
```

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.