### PR TITLE
Allow to configure the socket uid and gid

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -222,8 +222,12 @@ type DebugConfig struct {
 }
 
 type SystemControllerConfig struct {
-	Enable      bool        `toml:"enable"`
-	Address     string      `toml:"address"`
+	Enable  bool   `toml:"enable"`
+	Address string `toml:"address"`
+	// UID to set on the system controller socket
+	UID int `toml:"uid"`
+	// GID to set on the system controller socket
+	GID         int         `toml:"gid"`
 	DebugConfig DebugConfig `toml:"debug"`
 }
 
@@ -231,8 +235,12 @@ type SnapshotterConfig struct {
 	// Configuration format version
 	Version int `toml:"version"`
 	// Snapshotter's root work directory
-	Root       string `toml:"root"`
-	Address    string `toml:"address"`
+	Root    string `toml:"root"`
+	Address string `toml:"address"`
+	// UID to set on the snapshotter socket
+	UID int `toml:"uid"`
+	// GID to set on the snapshotter socket
+	GID        int    `toml:"gid"`
 	DaemonMode string `toml:"daemon_mode"`
 	// Clean up all the resources when snapshotter is closed
 	CleanupOnClose bool `toml:"cleanup_on_close"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,8 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 		Version:    1,
 		Root:       "/var/lib/containerd/io.containerd.snapshotter.v1.nydus",
 		Address:    "/run/containerd-nydus/containerd-nydus-grpc.sock",
+		UID:        0,
+		GID:        0,
 		DaemonMode: "dedicated",
 		Experimental: Experimental{
 			EnableStargz:         false,
@@ -35,6 +37,8 @@ func TestLoadSnapshotterTOMLConfig(t *testing.T) {
 		SystemControllerConfig: SystemControllerConfig{
 			Enable:  true,
 			Address: "/run/containerd-nydus/system.sock",
+			UID:     0,
+			GID:     0,
 			DebugConfig: DebugConfig{
 				ProfileDuration: 5,
 				PprofAddress:    "",

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -238,7 +238,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 
 	if config.IsSystemControllerEnabled() {
-		systemController, err := system.NewSystemController(nydusFs, fsManagers, config.SystemControllerAddress())
+		systemController, err := system.NewSystemController(nydusFs, fsManagers, config.SystemControllerAddress(), cfg.SystemControllerConfig.UID, cfg.SystemControllerConfig.GID)
 		if err != nil {
 			return nil, errors.Wrap(err, "create system controller")
 		}


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

Similar to what [containerd](https://github.com/containerd/containerd/blob/870bb7c80de5f4f69952b0188154ce61dbd4115a/integration/client/testdata/default-1.7.toml#L30) allows, the socket will be chowned to a different user. The main benefit is that is makes the socket callable by users other than root.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

I started the snapshotter from this branch:
```
sudo ./containerd-nydus-grpc --config ./nydus.toml
INFO[2025-10-30T17:45:12.958791294+01:00] Start nydus-snapshotter. Version: v0.15.4-10-gf6677ba.m, PID: 204002, FsDriver: fusedev, DaemonMode: multiple
INFO[2025-10-30T17:45:12.963653295+01:00] Run daemons monitor...
INFO[2025-10-30T17:45:12.967405469+01:00] Started system controller on "/containerd-local/sock/nydus-system.sock"
INFO[2025-10-30T17:45:12.967501568+01:00] Start system controller API server on /containerd-local/sock/nydus-system.sock
INFO[2025-10-30T17:45:12.968131017+01:00] setup image proxy keychain                    target-image-service=/containerd-local/sock/containerd.sock
DEBU[2025-10-30T17:45:12.968258712+01:00] Waiting for CRI service is started...
INFO[2025-10-30T17:45:12.968614159+01:00] connected to backend CRI service
```

using the following config
```
version = 1

root = "/containerd-local/io.containerd.snapshotter.v1.nydus"
# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
address = "/containerd-local/sock/image-service.sock"
uid = 1000
gid = 1000

[system]
# Snapshotter's debug and trace HTTP server interface
enable = true
uid = 1000
gid = 1000
address = "/containerd-local/sock/nydus-system.sock"
```

which resulted in both the snapshotter and the system socket to be created under my user:
```
ls /containerd-local/sock/
srwxr-x--- 0 baptiste.girardcarrabin 30 oct.  17:45 image-service.sock
srwxr-x--- 0 baptiste.girardcarrabin 30 oct.  17:45 nydus-system.sock
```

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.