### PR TITLE
fix: add per-snapshot mutex to prevent Mount() race condition

### DIFF
--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -306,6 +306,9 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 
 	defer func() {
 		if err != nil {
+			if umountErr := fs.Umount(ctx, snapshotID); umountErr != nil {
+				log.L.WithError(umountErr).Warnf("failed to umount snapshot %s during cleanup", snapshotID)
+			}
 			racache.RafsGlobalCache.Remove(snapshotID)
 		}
 	}()
@@ -433,11 +436,6 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 			}
 			return errors.Wrapf(err, "create instance %s", snapshotID)
 		}
-	}
-
-	if err != nil {
-		_ = fs.Umount(ctx, snapshotID)
-		return err
 	}
 
 	return nil


### PR DESCRIPTION


## Overview
_Please briefly describe the changes your pull request makes._
Prevent concurrent Mount() calls for the same snapshot from causing cache/DB state inconsistency that leads to 'snapshot not ready' errors.
## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._
Fixes #688
## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.