### PR TITLE
[snasphot] Bind mount parent in single parent mount case

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -971,7 +971,10 @@ func (o *snapshotter) mountNative(ctx context.Context, labels map[string]string,
 			options = append(options, "volatile")
 		}
 	} else if len(s.ParentIDs) == 1 {
-		return bindMount(o.upperPath(s.ID), "ro"), nil
+		parentPath := o.upperPath(s.ParentIDs[0])
+		// if we only have one parent then just return a bind mount
+		log.G(ctx).Debugf("bind mount on %s", parentPath)
+		return bindMount(parentPath, "ro"), nil
 	}
 
 	parentPaths := make([]string, len(s.ParentIDs))

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/nydus-snapshotter/pkg/label"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMountNative(t *testing.T) {
+	// Create a minimal snapshotter instance for testing
+	snapshotterRoot := "/var/lib/containerd/snapshotter"
+	s := &snapshotter{
+		root: snapshotterRoot,
+	}
+
+	tests := []struct {
+		name           string
+		snapshot       storage.Snapshot
+		labels         map[string]string
+		expectedMounts []mount.Mount
+
+		validate func(t *testing.T, mounts []mount.Mount, s *snapshotter)
+	}{
+		{
+			name: "no parents, active snapshot - rw bind mount",
+			snapshot: storage.Snapshot{
+				ID:        "snap1",
+				Kind:      snapshots.KindActive,
+				ParentIDs: []string{},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: s.upperPath("snap1"),
+					Options: []string{
+						"rw",
+						"rbind",
+					},
+				},
+			},
+		},
+		{
+			name: "no parents, view snapshot - ro bind mount",
+			snapshot: storage.Snapshot{
+				ID:        "snap2",
+				Kind:      snapshots.KindView,
+				ParentIDs: []string{},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: s.upperPath("snap2"),
+					Options: []string{
+						"ro",
+						"rbind",
+					},
+				},
+			},
+		},
+		{
+			name: "one parent, committed snapshot - ro bind mount of parent",
+			snapshot: storage.Snapshot{
+				ID:        "snap3",
+				Kind:      snapshots.KindCommitted,
+				ParentIDs: []string{"parent1"},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: s.upperPath("parent1"),
+					Options: []string{
+						"ro",
+						"rbind",
+					},
+				},
+			},
+		},
+		{
+			name: "one parent, view snapshot - ro bind mount of parent",
+			snapshot: storage.Snapshot{
+				ID:        "snap4",
+				Kind:      snapshots.KindView,
+				ParentIDs: []string{"parent1"},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: s.upperPath("parent1"),
+					Options: []string{
+						"ro",
+						"rbind",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple parents, active snapshot - overlay with work and upper dirs",
+			snapshot: storage.Snapshot{
+				ID:        "snap5",
+				Kind:      snapshots.KindActive,
+				ParentIDs: []string{"parent1", "parent2"},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						fmt.Sprintf("workdir=%s", s.workPath("snap5")),
+						fmt.Sprintf("upperdir=%s", s.upperPath("snap5")),
+						fmt.Sprintf("lowerdir=%s:%s", s.upperPath("parent1"), s.upperPath("parent2")),
+					},
+				},
+			},
+		},
+		{
+			name: "multiple parents, active snapshot with volatile option",
+			snapshot: storage.Snapshot{
+				ID:        "snap6",
+				Kind:      snapshots.KindActive,
+				ParentIDs: []string{"parent1", "parent2"},
+			},
+			labels: map[string]string{
+				label.OverlayfsVolatileOpt: "true",
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						fmt.Sprintf("workdir=%s", s.workPath("snap6")),
+						fmt.Sprintf("upperdir=%s", s.upperPath("snap6")),
+						fmt.Sprintf("lowerdir=%s:%s", s.upperPath("parent1"), s.upperPath("parent2")),
+						"volatile",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple parents, committed snapshot - overlay with only lowerdir",
+			snapshot: storage.Snapshot{
+				ID:        "snap7",
+				Kind:      snapshots.KindCommitted,
+				ParentIDs: []string{"parent1", "parent2", "parent3"},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						fmt.Sprintf("lowerdir=%s:%s:%s", s.upperPath("parent1"), s.upperPath("parent2"), s.upperPath("parent3")),
+					},
+				},
+			},
+		},
+		{
+			name: "multiple parents, view snapshot - overlay with only lowerdir",
+			snapshot: storage.Snapshot{
+				ID:        "snap8",
+				Kind:      snapshots.KindView,
+				ParentIDs: []string{"parent1", "parent2"},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						fmt.Sprintf("lowerdir=%s:%s", s.upperPath("parent1"), s.upperPath("parent2")),
+					},
+				},
+			},
+		},
+		{
+			name: "no parents, committed snapshot - rw bind mount",
+			snapshot: storage.Snapshot{
+				ID:        "snap9",
+				Kind:      snapshots.KindCommitted,
+				ParentIDs: []string{},
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: filepath.Join(s.root, "snapshots", "snap9", "fs"),
+					Options: []string{
+						"rw",
+						"rbind",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Call the mountNative function
+			mounts, err := s.mountNative(ctx, tt.labels, tt.snapshot)
+
+			// Verify no error occurred
+			require.NoError(t, err)
+
+			// Verify expected number of mounts
+			require.Len(t, mounts, len(tt.expectedMounts))
+			for i, expectedMount := range tt.expectedMounts {
+				// Verify expected mount
+				assert.Equal(t, expectedMount.Type, mounts[i].Type)
+				assert.Equal(t, expectedMount.Source, mounts[i].Source)
+				assert.ElementsMatch(t, expectedMount.Options, mounts[i].Options)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

Snapshots mounts were not working as expected in the case where the snapshot being mounted had a single parent. The result was that the mounted snapshot was empty instead of having the content of its parent.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

The code was creating a bind mount of the new snapshot (which is empty) instead of doing a bind on the parent snapshot (with content)

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

```
go test -v -timeout 30s -run ^TestMountNative$ github.com/containerd/nydus-snapshotter/snapshot
=== RUN   TestMountNative
=== RUN   TestMountNative/no_parents,_active_snapshot_-_rw_bind_mount
=== RUN   TestMountNative/no_parents,_view_snapshot_-_ro_bind_mount
=== RUN   TestMountNative/one_parent,_committed_snapshot_-_ro_bind_mount_of_parent
=== RUN   TestMountNative/one_parent,_view_snapshot_-_ro_bind_mount_of_parent
=== RUN   TestMountNative/multiple_parents,_active_snapshot_-_overlay_with_work_and_upper_dirs
=== RUN   TestMountNative/multiple_parents,_active_snapshot_with_volatile_option
=== RUN   TestMountNative/multiple_parents,_committed_snapshot_-_overlay_with_only_lowerdir
=== RUN   TestMountNative/multiple_parents,_view_snapshot_-_overlay_with_only_lowerdir
=== RUN   TestMountNative/no_parents,_committed_snapshot_-_rw_bind_mount
--- PASS: TestMountNative (0.00s)
    --- PASS: TestMountNative/no_parents,_active_snapshot_-_rw_bind_mount (0.00s)
    --- PASS: TestMountNative/no_parents,_view_snapshot_-_ro_bind_mount (0.00s)
    --- PASS: TestMountNative/one_parent,_committed_snapshot_-_ro_bind_mount_of_parent (0.00s)
    --- PASS: TestMountNative/one_parent,_view_snapshot_-_ro_bind_mount_of_parent (0.00s)
    --- PASS: TestMountNative/multiple_parents,_active_snapshot_-_overlay_with_work_and_upper_dirs (0.00s)
    --- PASS: TestMountNative/multiple_parents,_active_snapshot_with_volatile_option (0.00s)
    --- PASS: TestMountNative/multiple_parents,_committed_snapshot_-_overlay_with_only_lowerdir (0.00s)
    --- PASS: TestMountNative/multiple_parents,_view_snapshot_-_overlay_with_only_lowerdir (0.00s)
    --- PASS: TestMountNative/no_parents,_committed_snapshot_-_rw_bind_mount (0.00s)
PASS
ok  	github.com/containerd/nydus-snapshotter/snapshot	0.011s
```

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.