### PR TITLE
pkg/remote/remotes/docker: remove uses of HTTPStatusCodeAttributes

### DIFF
--- a/pkg/remote/remotes/docker/resolver.go
+++ b/pkg/remote/remotes/docker/resolver.go
@@ -38,6 +38,7 @@ import (
 	remoteerrors "github.com/containerd/nydus-snapshotter/pkg/remote/remotes/errors"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var (
@@ -595,7 +596,10 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 		httpSpan.SetStatus(err)
 		return nil, fmt.Errorf("failed to do request: %w", err)
 	}
-	httpSpan.SetAttributes(tracing.HTTPStatusCodeAttributes(resp.StatusCode)...)
+	httpSpan.SetAttributes(
+		attribute.Int("http.response.status_code", resp.StatusCode),
+		attribute.Int("http.status_code", resp.StatusCode), // Deprecated: SemConv <= v1.21
+	)
 	log.G(ctx).WithFields(responseFields(resp)).Debug("fetch response received")
 	return resp, nil
 }


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/12605/files#r2577846463

This was a shallow wrapper around semconv.HTTPStatusCodeKey, which is deprecated in current semconv versions.

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [x] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.