### PR TITLE
fix: add missing PrefetchAll field to BlobPrefetchConfig struct

### DIFF
--- a/config/daemonconfig/fscache.go
+++ b/config/daemonconfig/fscache.go
@@ -28,6 +28,7 @@ type BlobPrefetchConfig struct {
 	ThreadsCount  int  `json:"threads_count"`
 	MergingSize   int  `json:"merging_size"`
 	BandwidthRate int  `json:"bandwidth_rate"`
+	PrefetchAll   bool `json:"prefetch_all"`
 }
 
 type FscacheDaemonConfig struct {


### PR DESCRIPTION
The BlobPrefetchConfig struct was missing the prefetch_all field, which caused the prefetch_all setting from nydusd-config.json to be dropped when loading fscache daemon configuration. This prevented users from enabling prefetch_all in their configurations.

Added PrefetchAll bool field with json tag to allow unmarshaling the prefetch_all setting from the configuration file.

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.