### PR TITLE
[bug] Configure omitempty for FSPrefetch fields

### DIFF
--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -37,9 +37,9 @@ type FuseDaemonConfig struct {
 type FSPrefetch struct {
 	Enable        bool `json:"enable"`
 	PrefetchAll   bool `json:"prefetch_all"`
-	ThreadsCount  int  `json:"threads_count"`
-	MergingSize   int  `json:"merging_size"`
-	BandwidthRate int  `json:"bandwidth_rate"`
+	ThreadsCount  int  `json:"threads_count,omitempty"`
+	MergingSize   int  `json:"merging_size,omitempty"`
+	BandwidthRate int  `json:"bandwidth_rate,omitempty"`
 }
 
 // Load fuse daemon configuration from template file


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

I've noticed that running the nydus-snapshotter with the following nydusd config:

```
{
  "device": {
    "backend": {
      "type": "registry"
    },
    "cache": {
      "type": "blobcache",
      "config": {
        "work_dir": "cache"
      }
    }
  },
  "mode": "direct",
  "fs_prefetch": {
    "enable": true
  }
}
```

causes nydusd to fail with 

```
[2026-01-12 15:12:28.945869 +01:00] ERROR [/service/src/fusedev.rs:753] service mount error: RAFS failed to handle request, Failed to load config: failed to parse configuration information`
[2026-01-12 15:12:28.945896 +01:00] ERROR [/api/src/error.rs:23] Error:
	Rafs(LoadConfig(Custom { kind: InvalidInput,error: "failed to parse configuration information" }))
	at service/src/fusedev.rs:754
	note: enable `RUST_BACKTRACE=1` env to display a backtrace
```

Looking at the nydusd config that was used exactly, it looked like this:
```
{
  "device": {
    "backend": {
      "type": "registry",
      "config": {
        "readahead": false,
        "host": "localhost:5050",
        "repo": "image",
        "proxy": {
          "fallback": false
        },
        "timeout": 15,
        "connect_timeout": 15,
        "retry_limit": 5
      }
    },
    "cache": {
      "type": "blobcache",
      "config": {
        "work_dir": "/containerd-local/io.containerd.snapshotter.v1.nydus/cache",
        "disable_indexed_map": false
      }
    }
  },
  "mode": "direct",
  "digest_validate": false,
  "enable_xattr": true,
  "fs_prefetch": {
    "enable": true,
    "prefetch_all": false,
    "threads_count": 0,
    "merging_size": 0,
    "bandwidth_rate": 0
  }
}

```

We can see that `threads_count`, `merging_size` and `bandwidth_rate` are set to 0 when the nydusd config struct is marshaled to json.

Looking at nydusd code, I've traced the failure to [this](https://github.com/dragonflyoss/nydus/blob/master/api/src/config.rs#L687) since the thread_count would be 0 at that point. And this despite the [serde default which is 8](https://github.com/dragonflyoss/nydus/blob/master/api/src/config.rs#L875). Since the value is set a 0 explicitly, the serde default isn't used.

So I think that when the FSPrefetch struct is marshaled to json some values shouldn't be outputed if they are empty. In particular, setting `threads_count` or `merging_size` to their zero values in the json will prevent nydusd from using its default values for those (4 and 1024*1024 respectively) because it will consider that the fields are set to 0 explicitly.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

Configure `omitempty` for the above mentioned fields

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

I've checked the ouptut of a snapshotter-generated nydusd config file with the change:

```
{
  "device": {
    "backend": {
      "type": "registry",
      "config": {
        "readahead": false,
        "host": "localhost:5050",
        "repo": "image",
        "proxy": {
          "fallback": false
        },
        "timeout": 15,
        "connect_timeout": 15,
        "retry_limit": 5
      }
    },
    "cache": {
      "type": "blobcache",
      "config": {
        "work_dir": "/containerd-local/io.containerd.snapshotter.v1.nydus/cache",
        "disable_indexed_map": false
      }
    }
  },
  "mode": "direct",
  "digest_validate": false,
  "enable_xattr": true,
  "amplify_io": 524288,
  "fs_prefetch": {
    "enable": true,
    "prefetch_all": false
  }
}
```

And we can see the 0 fields are missing now.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.