### PR TITLE
[metrics] Collect cache metrics

### DIFF
--- a/pkg/daemon/types/types.go
+++ b/pkg/daemon/types/types.go
@@ -93,8 +93,12 @@ type CacheMetrics struct {
 	PrefetchDataAmount           uint64   `json:"prefetch_data_amount"`
 	PrefetchRequestsCount        uint64   `json:"prefetch_requests_count"`
 	PrefetchWorkers              uint     `json:"prefetch_workers"`
+	PrefetchUnmergedChunks       uint64   `json:"prefetch_unmerged_chunks"`
 	PrefetchCumulativeTimeMillis uint64   `json:"prefetch_cumulative_time_millis"`
 	PrefetchBeginTimeSecs        uint64   `json:"prefetch_begin_time_secs"`
+	PrefetchBeginTimeMillis      uint64   `json:"prefetch_begin_time_millis"`
 	PrefetchEndTimeSecs          uint64   `json:"prefetch_end_time_secs"`
+	PrefetchEndTimeMillis        uint64   `json:"prefetch_end_time_millis"`
 	BufferedBackendSize          uint64   `json:"buffered_backend_size"`
+	DataAllReady                 bool     `json:"data_all_ready"`
 }

--- a/pkg/metrics/collector/cache.go
+++ b/pkg/metrics/collector/cache.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package collector
+
+import (
+	"github.com/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
+	"github.com/containerd/nydus-snapshotter/pkg/metrics/data"
+)
+
+type CacheMetricsCollector struct {
+	Metrics  *types.CacheMetrics
+	ImageRef string
+	DaemonID string
+}
+
+type CacheMetricsVecCollector struct {
+	MetricsVec []CacheMetricsCollector
+}
+
+func (c *CacheMetricsCollector) Collect() {
+	if c.Metrics == nil {
+		log.L.Warnf("can not collect cache metrics: Metrics is nil")
+		return
+	}
+
+	prefetchTotalDuration := (c.Metrics.PrefetchEndTimeSecs*1000 +
+		c.Metrics.PrefetchCumulativeTimeMillis) -
+		(c.Metrics.PrefetchBeginTimeSecs*1000 +
+			c.Metrics.PrefetchCumulativeTimeMillis)
+
+	data.CachePartialHits.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.PartialHits))
+	data.CacheWholeHits.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.WholeHits))
+	data.CacheTotalRequests.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.Total))
+	data.CacheEntriesCount.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.EntriesCount))
+	data.CachePrefetchDataBytes.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.PrefetchDataAmount))
+	data.CachePrefetchRequestsCount.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.PrefetchRequestsCount))
+	data.CachePrefetchWorkers.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.PrefetchWorkers))
+	data.CachePrefetchUnmergedChunks.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.PrefetchUnmergedChunks))
+	data.CachePrefetchCumulativeTimeMillis.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.PrefetchCumulativeTimeMillis))
+	data.CachePrefetchTotalDurationMillis.WithLabelValues(c.ImageRef).Set(float64(prefetchTotalDuration))
+	data.CacheBufferedBackendSize.WithLabelValues(c.ImageRef).Set(float64(c.Metrics.BufferedBackendSize))
+}
+
+func (c *CacheMetricsVecCollector) Collect() {
+	for _, cacheMetrics := range c.MetricsVec {
+		cacheMetrics.Collect()
+	}
+}

--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -56,3 +56,11 @@ func NewSnapshotterMetricsCollector(ctx context.Context, cacheDir string, pid in
 func NewSnapshotMetricsTimer(method SnapshotMethod) *prometheus.Timer {
 	return CollectSnapshotMetricsTimer(data.SnapshotEventElapsedHists, method)
 }
+
+func NewCacheMetricsCollector(m *types.CacheMetrics, imageRef, daemonID string) *CacheMetricsCollector {
+	return &CacheMetricsCollector{m, imageRef, daemonID}
+}
+
+func NewCacheMetricsVecCollector() *CacheMetricsVecCollector {
+	return &CacheMetricsVecCollector{}
+}

--- a/pkg/metrics/data/cache.go
+++ b/pkg/metrics/data/cache.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package data
+
+import (
+	"github.com/containerd/nydus-snapshotter/pkg/metrics/types/ttl"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	CachePartialHits = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_partial_hits",
+			Help: "Number of partial cache hits (IO needs a part of the chunk)",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CacheWholeHits = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_whole_hits",
+			Help: "Number of whole cache hits (IO needs the entire chunk)",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CacheTotalRequests = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_total_requests",
+			Help: "Total number of cache read requests. Cache hit percentage = (partial_hits + whole_hits) / total",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CacheEntriesCount = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_entries_count",
+			Help: "Number of chunks in ready status",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CachePrefetchDataBytes = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_prefetch_data_bytes",
+			Help: "Total amount of data prefetched, in bytes",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CachePrefetchRequestsCount = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_prefetch_requests_count",
+			Help: "Total prefetch requests issued from storage/blobs or rafs filesystem layer for each file that needs prefetch",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CachePrefetchWorkers = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_prefetch_workers",
+			Help: "Number of prefetch workers",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CachePrefetchUnmergedChunks = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_prefetch_unmerged_chunks",
+			Help: "Number of unmerged chunks",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CachePrefetchCumulativeTimeMillis = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_prefetch_cumulative_time_millis",
+			Help: "Cumulative time latencies in milliseconds of each prefetch request which can be handled in parallel. It starts when the request is born including nydusd processing and schedule and end when the chunk is downloaded and stored. The average prefetch latency can be calculated by `prefetch_cumulative_time_millis / prefetch_requests_count`",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CachePrefetchTotalDurationMillis = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_prefetch_duration_millis",
+			Help: "Total wall clock duration of the prefetch, in milliseconds",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+
+	CacheBufferedBackendSize = ttl.NewGaugeVecWithTTL(
+		prometheus.GaugeOpts{
+			Name: "nydusd_cache_buffered_backend_size",
+			Help: "Size of the buffered backend, in bytes",
+		},
+		[]string{imageRefLabel},
+		ttl.DefaultTTL,
+	)
+)

--- a/pkg/metrics/data/daemon.go
+++ b/pkg/metrics/data/daemon.go
@@ -12,12 +12,6 @@ import (
 )
 
 var (
-	nydusdEventLabel   = "nydusd_event"
-	nydusdVersionLabel = "version"
-	daemonIDLabel      = "daemon_id"
-)
-
-var (
 	NydusdEventCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "nydusd_lifetime_event_counts",

--- a/pkg/metrics/data/fs.go
+++ b/pkg/metrics/data/fs.go
@@ -15,10 +15,6 @@ import (
 )
 
 var (
-	imageRefLabel = "image_ref"
-)
-
-var (
 	FsTotalRead = ttl.NewGaugeVecWithTTL(
 		prometheus.GaugeOpts{
 			Name: "nydusd_total_read_bytes",

--- a/pkg/metrics/data/labels.go
+++ b/pkg/metrics/data/labels.go
@@ -1,0 +1,9 @@
+package data
+
+const (
+	imageRefLabel      = "image_ref"
+	nydusdEventLabel   = "nydusd_event"
+	nydusdVersionLabel = "version"
+	daemonIDLabel      = "daemon_id"
+	snapshotEventLabel = "snapshot_operation"
+)

--- a/pkg/metrics/data/snapshotter.go
+++ b/pkg/metrics/data/snapshotter.go
@@ -12,7 +12,6 @@ import (
 
 var (
 	defaultDurationBuckets = []float64{.5, 1, 5, 10, 50, 100, 150, 200, 250, 300, 350, 400, 600, 1000}
-	snapshotEventLabel     = "snapshot_operation"
 )
 
 var (

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -33,6 +33,17 @@ func init() {
 		data.Fds,
 		data.RunTime,
 		data.Thread,
+		data.CachePartialHits,
+		data.CacheWholeHits,
+		data.CacheTotalRequests,
+		data.CacheEntriesCount,
+		data.CachePrefetchDataBytes,
+		data.CachePrefetchRequestsCount,
+		data.CachePrefetchWorkers,
+		data.CachePrefetchUnmergedChunks,
+		data.CachePrefetchCumulativeTimeMillis,
+		data.CachePrefetchTotalDurationMillis,
+		data.CacheBufferedBackendSize,
 	)
 
 	for _, m := range data.MetricHists {


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

Add a prometheus collector to collect cache metrics exposed by each nydusd daemon. This will bring a better observability into the cache performances and the prefetch happening in the background.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

The collector is implemented very similarly to the existing metrics collector like the backend one.

Metrics descriptions are based on my understanding of nydusd + the discussions that happened in https://github.com/dragonflyoss/nydus/issues/1803.

The only metric not outputted as-is is the prefetch total duration which is computed from the prefetch_begin/prefetch_end attributes in nydusd response

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

Started a nydus container locally with the snapshotter. Then curled the metrics endpoint:
```
$ curl -s http://localhost:9110/v1/metrics
# HELP nydusd_cache_buffered_backend_size Size of the buffered backend, in bytes
# TYPE nydusd_cache_buffered_backend_size gauge
nydusd_cache_buffered_backend_size{image_ref="localhost:5000/my-image:nydus"} 0
# HELP nydusd_cache_entries_count Number of chunks in ready status
# TYPE nydusd_cache_entries_count gauge
nydusd_cache_entries_count{image_ref="localhost:5000/my-image:nydus"} 25190
# HELP nydusd_cache_partial_hits Number of partial cache hits (IO needs a part of the chunk)
# TYPE nydusd_cache_partial_hits gauge
nydusd_cache_partial_hits{image_ref="localhost:5000/my-image:nydus"} 30
# HELP nydusd_cache_prefetch_cumulative_time_millis Cumulative time latencies in milliseconds of each prefetch request which can be handled in parallel. It starts when the request is born including nydusd processing and schedule and end when the chunk is downloaded and stored. The average prefetch latency can be calculated by `prefetch_cumulative_time_millis / prefetch_requests_count`
# TYPE nydusd_cache_prefetch_cumulative_time_millis gauge
nydusd_cache_prefetch_cumulative_time_millis{image_ref="localhost:5000/my-image:nydus"} 1.0607515e+07
# HELP nydusd_cache_prefetch_data_bytes Total amount of data prefetched, in bytes
# TYPE nydusd_cache_prefetch_data_bytes gauge
nydusd_cache_prefetch_data_bytes{image_ref="localhost:5000/my-image:nydus"} 5.18481446e+08
# HELP nydusd_cache_prefetch_duration_millis Total wall clock duration of the prefetch, in milliseconds
# TYPE nydusd_cache_prefetch_duration_millis gauge
nydusd_cache_prefetch_duration_millis{image_ref="localhost:5000/my-image:nydus"} 41000
# HELP nydusd_cache_prefetch_requests_count Total prefetch requests issued from storage/blobs or rafs filesystem layer for each file that needs prefetch
# TYPE nydusd_cache_prefetch_requests_count gauge
nydusd_cache_prefetch_requests_count{image_ref="localhost:5000/my-image:nydus"} 500
# HELP nydusd_cache_prefetch_unmerged_chunks Number of unmerged chunks
# TYPE nydusd_cache_prefetch_unmerged_chunks gauge
nydusd_cache_prefetch_unmerged_chunks{image_ref="localhost:5000/my-image:nydus"} 0
# HELP nydusd_cache_prefetch_workers Number of prefetch workers
# TYPE nydusd_cache_prefetch_workers gauge
nydusd_cache_prefetch_workers{image_ref="localhost:5000/my-image:nydus"} 4
# HELP nydusd_cache_total_requests Total number of cache read requests. Cache hit percentage = (partial_hits + whole_hits) / total
# TYPE nydusd_cache_total_requests gauge
nydusd_cache_total_requests{image_ref="localhost:5000/my-image:nydus"} 41
# HELP nydusd_cache_whole_hits Number of whole cache hits (IO needs the entire chunk)
# TYPE nydusd_cache_whole_hits gauge
nydusd_cache_whole_hits{image_ref="localhost:5000/my-image:nydus"} 0
```

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.