### PR TITLE
snapshot: fix proxy mode mounting for snapshots without nydus-proxy mode label

### DIFF
--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -58,7 +58,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 	}
 
 	proxyHandler := func() (bool, []mount.Mount, error) {
-		mounts, err := sn.mountProxy(ctx, s)
+		mounts, err := sn.mountProxy(ctx, labels, s)
 		return false, mounts, err
 	}
 


### PR DESCRIPTION
## Overview

When containerd unpacks an image for a remote snapshotter like nydus in proxy mode, it passes the CRIImageRef label via snapshots.WithLabels during the Prepare/Unpack flow. This label contains the image reference needed by nydus to construct the kata virtual volume metadata.

The mountProxy() function was being called without passing the available labels, creating a rafs.Rafs{} with an empty Annotations map. This caused nydus to fall back to using "dummy-image-reference" as the source, breaking guest-side image pulling. The fix passes the labels through to mountProxy() so CRIImageRef is available when constructing the kata virtual volume.

Additionally, snapshots may have CRIImageRef but lack the nydus-proxy-mode label. This happens when an image was unpacked before containerd properly set all labels, or when labels were updated via containerd's fixSnapshotLabels after the initial unpack. In these cases the code would incorrectly call mountNative() instead of mountProxy(), causing mount failures because proxy mode directories don't contain actual content (content is pulled inside the guest). The fix adds a fallback check before mountNative: if we're in proxy driver mode and the snapshot or its parent chain has CRIImageRef, use mountProxy instead.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)