### PR TITLE
Skip HTTP fallback unless skip_verify is set

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -47,6 +47,10 @@ type Remote struct {
 	// withPlainHTTP attempts to request the remote registry using http instead
 	// of https.
 	withPlainHTTP bool
+	// insecure indicates that the registry is explicitly configured as insecure.
+	// HTTP fallback is only allowed when insecure is true,
+	// matching Docker's --insecure-registry semantics.
+	insecure bool
 }
 
 func New(keyChain *auth.PassKeyChain, insecure bool) *Remote {
@@ -90,10 +94,15 @@ func New(keyChain *auth.PassKeyChain, insecure bool) *Remote {
 	return &Remote{
 		resolverFunc:  resolverFunc,
 		withPlainHTTP: false,
+		insecure:      insecure,
 	}
 }
 
 func (remote *Remote) RetryWithPlainHTTP(ref string, err error) bool {
+	if !remote.insecure {
+		return false
+	}
+
 	retry := err != nil && (isErrHTTPResponseToHTTPSClient(err) || isErrConnectionRefused(err))
 	if !retry {
 		return false

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package remote
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryWithPlainHTTP(t *testing.T) {
+	const host = "myregistry.example.com"
+	ref := fmt.Sprintf("%s/repo/image:latest", host)
+	httpResponseErr := fmt.Errorf("Get https://%s/v2/: server gave HTTP response to HTTPS client", host)
+	connRefusedErr := fmt.Errorf("Get https://%s/v2/: connect: connection refused", host)
+	otherErr := fmt.Errorf("some unrelated error")
+
+	tests := []struct {
+		name     string
+		insecure bool
+		err      error
+		want     bool
+	}{
+		{
+			name:     "insecure allows HTTP fallback on HTTP response error",
+			insecure: true,
+			err:      httpResponseErr,
+			want:     true,
+		},
+		{
+			name:     "insecure allows HTTP fallback on connection refused",
+			insecure: true,
+			err:      connRefusedErr,
+			want:     true,
+		},
+		{
+			name:     "insecure does not fallback on unrelated error",
+			insecure: true,
+			err:      otherErr,
+			want:     false,
+		},
+		{
+			name:     "secure blocks HTTP fallback on HTTP response error",
+			insecure: false,
+			err:      httpResponseErr,
+			want:     false,
+		},
+		{
+			name:     "secure blocks HTTP fallback on connection refused",
+			insecure: false,
+			err:      connRefusedErr,
+			want:     false,
+		},
+		{
+			name:     "nil error returns false",
+			insecure: true,
+			err:      nil,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Remote{insecure: tt.insecure}
+			got := r.RetryWithPlainHTTP(ref, tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Overview

When `skip_verify` is false (the default), `RetryWithPlainHTTP` now returns false immediately, preventing silent HTTPS-to-HTTP downgrades. HTTP fallback is only permitted when the registry is explicitly configured as insecure, matching Docker's `--insecure-registry` semantics.

## Related Issues

Related https://github.com/dragonflyoss/nydus/issues/1910

## Change Details

- Store the `insecure` flag in the `Remote` struct (already passed to `New()` but previously unused beyond TLS config).
- Gate `RetryWithPlainHTTP` on `insecure`: when false, return early before checking error strings.
- Add table-driven unit tests for `RetryWithPlainHTTP` covering all combinations of insecure/secure and error types.

## Test Results

```
=== RUN   TestRetryWithPlainHTTP
--- PASS: TestRetryWithPlainHTTP (0.00s)
    --- PASS: TestRetryWithPlainHTTP/insecure_allows_HTTP_fallback_on_HTTP_response_error (0.00s)
    --- PASS: TestRetryWithPlainHTTP/insecure_allows_HTTP_fallback_on_connection_refused (0.00s)
    --- PASS: TestRetryWithPlainHTTP/insecure_does_not_fallback_on_unrelated_error (0.00s)
    --- PASS: TestRetryWithPlainHTTP/secure_blocks_HTTP_fallback_on_HTTP_response_error (0.00s)
    --- PASS: TestRetryWithPlainHTTP/secure_blocks_HTTP_fallback_on_connection_refused (0.00s)
    --- PASS: TestRetryWithPlainHTTP/nil_error_returns_false (0.00s)
PASS
```

## Change Type

- [x] Feature Addition

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.