### PR TITLE
fix: handle pod concurrency issues with daemon readiness check and bootstrap validation

### DIFF
--- a/pkg/filesystem/bootstrap.go
+++ b/pkg/filesystem/bootstrap.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package filesystem
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/layout"
+)
+
+const (
+	defaultBootstrapReadyAttempts = 20
+	defaultBootstrapReadyInterval = 50 * time.Millisecond
+	v6BlockBitsOffset             = layout.RafsV6SuperBlockOffset + 12
+	v6BlockBits512                = 9
+	v6BlockBits4096               = 12
+)
+
+func waitForReadyBootstrap(path string) error {
+	return waitForReadyBootstrapWithRetry(path, defaultBootstrapReadyAttempts, defaultBootstrapReadyInterval)
+}
+
+func waitForReadyBootstrapWithRetry(path string, attempts int, interval time.Duration) error {
+	var (
+		lastSize int64 = -1
+		lastErr  error
+	)
+
+	for idx := 0; idx < attempts; idx++ {
+		size, err := validateBootstrap(path)
+		if err == nil {
+			if size == lastSize {
+				return nil
+			}
+			lastSize = size
+			lastErr = fmt.Errorf("bootstrap size %d is still changing", size)
+		} else {
+			log.L.WithError(err).Warnf("bootstrap %s validation attempt %d/%d failed", path, idx+1, attempts)
+			lastErr = err
+		}
+
+		if idx+1 < attempts {
+			time.Sleep(interval)
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("bootstrap is not ready")
+	}
+
+	return fmt.Errorf("bootstrap %s is not ready: %w", path, lastErr)
+}
+
+func validateBootstrap(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if !info.Mode().IsRegular() {
+		return 0, fmt.Errorf("bootstrap is not a regular file")
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	headSize := int(info.Size())
+	if headSize > layout.MaxSuperBlockSize {
+		headSize = layout.MaxSuperBlockSize
+	}
+	if headSize < 8 {
+		return 0, fmt.Errorf("bootstrap is too small: %d", info.Size())
+	}
+
+	head := make([]byte, headSize)
+	if _, err := io.ReadFull(file, head); err != nil {
+		return 0, err
+	}
+
+	version, err := layout.DetectFsVersion(head)
+	if err != nil {
+		return 0, err
+	}
+
+	if version == layout.RafsV6 {
+		blockSize, err := detectV6BlockSize(head)
+		if err != nil {
+			return 0, err
+		}
+		if info.Size()%int64(blockSize) != 0 {
+			return 0, fmt.Errorf("v6 bootstrap size %d is not aligned to %d", info.Size(), blockSize)
+		}
+	}
+
+	return info.Size(), nil
+}
+
+func detectV6BlockSize(head []byte) (int, error) {
+	if len(head) <= int(v6BlockBitsOffset) {
+		return 0, fmt.Errorf("v6 bootstrap header is too small")
+	}
+
+	switch head[v6BlockBitsOffset] {
+	case v6BlockBits512:
+		return 512, nil
+	case v6BlockBits4096:
+		return 4096, nil
+	default:
+		return 0, fmt.Errorf("unknown v6 block bits %d", head[v6BlockBitsOffset])
+	}
+}

--- a/pkg/filesystem/bootstrap.go
+++ b/pkg/filesystem/bootstrap.go
@@ -53,13 +53,13 @@ func waitForReadyBootstrapWithRetry(path string, attempts int, interval time.Dur
 
 		return nil
 	},
-	retry.Attempts(uint(attempts)),
-	retry.Delay(interval),
-	retry.DelayType(retry.FixedDelay),
-	retry.LastErrorOnly(true),
-	retry.OnRetry(func(n uint, err error) {
-		log.L.Warnf("bootstrap is not ready, retrying... attempt: %d, error: %v", n+1, err)
-	}),
+		retry.Attempts(uint(attempts)),
+		retry.Delay(interval),
+		retry.DelayType(retry.FixedDelay),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			log.L.Warnf("bootstrap is not ready, retrying... attempt: %d, error: %v", n+1, err)
+		}),
 	)
 
 	if err != nil {

--- a/pkg/filesystem/bootstrap.go
+++ b/pkg/filesystem/bootstrap.go
@@ -10,18 +10,24 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/containerd/log"
 	"github.com/containerd/nydus-snapshotter/pkg/layout"
+	"github.com/containerd/nydus-snapshotter/pkg/utils/retry"
 )
 
 const (
 	defaultBootstrapReadyAttempts = 20
 	defaultBootstrapReadyInterval = 50 * time.Millisecond
-	v6BlockBitsOffset             = layout.RafsV6SuperBlockOffset + 12
-	v6BlockBits512                = 9
-	v6BlockBits4096               = 12
+
+	v6BlockBitsOffset = layout.RafsV6SuperBlockOffset + 12
+	v6BlockBits512    = 9
+	v6BlockBits4096   = 12
 )
 
 func waitForReadyBootstrap(path string) error {
@@ -30,37 +36,61 @@ func waitForReadyBootstrap(path string) error {
 
 func waitForReadyBootstrapWithRetry(path string, attempts int, interval time.Duration) error {
 	var (
-		lastSize int64 = -1
-		lastErr  error
+		lastState *string
 	)
 
-	for idx := 0; idx < attempts; idx++ {
-		size, err := validateBootstrap(path)
-		if err == nil {
-			if size == lastSize {
-				return nil
-			}
-			lastSize = size
-			lastErr = fmt.Errorf("bootstrap size %d is still changing", size)
-		} else {
-			log.L.WithError(err).Warnf("bootstrap %s validation attempt %d/%d failed", path, idx+1, attempts)
-			lastErr = err
+	err := retry.Do(func() error {
+		state, err := validateBootstrapAndBlobMeta(path)
+		if err != nil {
+			return err
 		}
 
-		if idx+1 < attempts {
-			time.Sleep(interval)
+		// Require two consecutive "ready" states to reading unready bootstrap
+		if lastState == nil || state != *lastState {
+			lastState = &state
+			return fmt.Errorf("bootstrap is not ready, current state: %s", state)
 		}
+
+		return nil
+	},
+	retry.Attempts(uint(attempts)),
+	retry.Delay(interval),
+	retry.DelayType(retry.FixedDelay),
+	retry.LastErrorOnly(true),
+	retry.OnRetry(func(n uint, err error) {
+		log.L.Warnf("bootstrap is not ready, retrying... attempt: %d, error: %v", n+1, err)
+	}),
+	)
+
+	if err != nil {
+		return fmt.Errorf("bootstrap is not ready after %d attempts, last error: %w", attempts, err)
 	}
 
-	if lastErr == nil {
-		lastErr = fmt.Errorf("bootstrap is not ready")
+	return nil
+}
+
+func validateBootstrapAndBlobMeta(path string) (string, error) {
+	bootstrapSize, err := validateBootstrap(path)
+	if err != nil {
+		return "", err
 	}
 
-	return fmt.Errorf("bootstrap %s is not ready: %w", path, lastErr)
+	blobMetaState, err := validateBlobMetaFiles(path)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("bootstrap=%d;%s", bootstrapSize, blobMetaState), nil
 }
 
 func validateBootstrap(path string) (int64, error) {
-	info, err := os.Stat(path)
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
 	if err != nil {
 		return 0, err
 	}
@@ -68,18 +98,13 @@ func validateBootstrap(path string) (int64, error) {
 		return 0, fmt.Errorf("bootstrap is not a regular file")
 	}
 
-	file, err := os.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer file.Close()
-
-	headSize := int(info.Size())
+	size := info.Size()
+	headSize := int(size)
 	if headSize > layout.MaxSuperBlockSize {
 		headSize = layout.MaxSuperBlockSize
 	}
 	if headSize < 8 {
-		return 0, fmt.Errorf("bootstrap is too small: %d", info.Size())
+		return 0, fmt.Errorf("bootstrap is too small: %d", size)
 	}
 
 	head := make([]byte, headSize)
@@ -97,12 +122,66 @@ func validateBootstrap(path string) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		if info.Size()%int64(blockSize) != 0 {
-			return 0, fmt.Errorf("v6 bootstrap size %d is not aligned to %d", info.Size(), blockSize)
+		if size%int64(blockSize) != 0 {
+			return 0, fmt.Errorf("v6 bootstrap size %d is not aligned to %d", size, blockSize)
 		}
 	}
 
-	return info.Size(), nil
+	return size, nil
+}
+
+func validateBlobMetaFiles(bootstrapPath string) (string, error) {
+	pattern := filepath.Join(filepath.Dir(bootstrapPath), "*.blob.meta")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", err
+	}
+
+	sort.Strings(matches)
+
+	if len(matches) == 0 {
+		return "blobmeta=none", nil
+	}
+
+	var b strings.Builder
+	b.WriteString("blobmeta=")
+
+	for i, p := range matches {
+		file, err := os.Open(p)
+		if err != nil {
+			return "", err
+		}
+
+		info, err := file.Stat()
+		if err != nil {
+			file.Close()
+			return "", err
+		}
+		if !info.Mode().IsRegular() {
+			file.Close()
+			return "", fmt.Errorf("blob.meta %s is not a regular file", p)
+		}
+		if info.Size() <= 0 {
+			file.Close()
+			return "", fmt.Errorf("blob.meta %s is empty", p)
+		}
+
+		var buf [1]byte
+		if _, err := io.ReadFull(file, buf[:]); err != nil {
+			file.Close()
+			return "", fmt.Errorf("read blob.meta %s: %w", p, err)
+		}
+		file.Close()
+
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(filepath.Base(p))
+		b.WriteByte(':')
+		b.WriteString(strconv.FormatInt(info.Size(), 10))
+	}
+
+	return b.String(), nil
 }
 
 func detectV6BlockSize(head []byte) (int, error) {

--- a/pkg/filesystem/bootstrap.go
+++ b/pkg/filesystem/bootstrap.go
@@ -12,8 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/containerd/log"
@@ -30,57 +28,89 @@ const (
 	v6BlockBits4096   = 12
 )
 
+type blobMetaState struct {
+	Name string
+	Size int64
+}
+
+type bootstrapState struct {
+	BootstrapSize int64
+	BlobMetaFiles []blobMetaState
+}
+
+func (s bootstrapState) Equal(previous bootstrapState) bool {
+	if s.BootstrapSize != previous.BootstrapSize {
+		return false
+	}
+	if len(s.BlobMetaFiles) != len(previous.BlobMetaFiles) {
+		return false
+	}
+	for i := range s.BlobMetaFiles {
+		if s.BlobMetaFiles[i] != previous.BlobMetaFiles[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func waitForReadyBootstrap(path string) error {
 	return waitForReadyBootstrapWithRetry(path, defaultBootstrapReadyAttempts, defaultBootstrapReadyInterval)
 }
 
+// Wait for the bootstrap and its related blob meta files to become valid and stable
 func waitForReadyBootstrapWithRetry(path string, attempts int, interval time.Duration) error {
 	var (
-		lastState *string
+		lastState bootstrapState
+		haveState bool
 	)
 
-	err := retry.Do(func() error {
-		state, err := validateBootstrapAndBlobMeta(path)
-		if err != nil {
-			return err
-		}
+	err := retry.Do(
+		func() error {
+			state, err := validateBootstrapAndBlobMeta(path)
+			if err != nil {
+				return err
+			}
 
-		// Require two consecutive "ready" states to reading unready bootstrap
-		if lastState == nil || state != *lastState {
-			lastState = &state
-			return fmt.Errorf("bootstrap is not ready, current state: %s", state)
-		}
+			// Require two consecutive "ready" states to avoid reading partially-written bootstrap
+			if !haveState || !state.Equal(lastState) {
+				lastState = state
+				haveState = true
+				return fmt.Errorf("bootstrap is not ready, current state: %v", state)
+			}
 
-		return nil
-	},
+			return nil
+		},
 		retry.Attempts(uint(attempts)),
 		retry.Delay(interval),
 		retry.DelayType(retry.FixedDelay),
 		retry.LastErrorOnly(true),
 		retry.OnRetry(func(n uint, err error) {
-			log.L.Warnf("bootstrap is not ready, retrying... attempt: %d, error: %v", n+1, err)
+			log.L.Warnf("bootstrap is not ready, retrying... attempt=%d/%d error=%v", n+1, attempts, err)
 		}),
 	)
 
 	if err != nil {
-		return fmt.Errorf("bootstrap is not ready after %d attempts, last error: %w", attempts, err)
+		return fmt.Errorf("bootstrap is not ready after %d attempts: %w", attempts, err)
 	}
 
 	return nil
 }
 
-func validateBootstrapAndBlobMeta(path string) (string, error) {
+func validateBootstrapAndBlobMeta(path string) (bootstrapState, error) {
 	bootstrapSize, err := validateBootstrap(path)
 	if err != nil {
-		return "", err
+		return bootstrapState{}, err
 	}
 
-	blobMetaState, err := validateBlobMetaFiles(path)
+	blobMetaFiles, err := validateBlobMetaFiles(path)
 	if err != nil {
-		return "", err
+		return bootstrapState{}, err
 	}
 
-	return fmt.Sprintf("bootstrap=%d;%s", bootstrapSize, blobMetaState), nil
+	return bootstrapState{
+		BootstrapSize: bootstrapSize,
+		BlobMetaFiles: blobMetaFiles,
+	}, nil
 }
 
 func validateBootstrap(path string) (int64, error) {
@@ -130,58 +160,54 @@ func validateBootstrap(path string) (int64, error) {
 	return size, nil
 }
 
-func validateBlobMetaFiles(bootstrapPath string) (string, error) {
+func validateBlobMetaFiles(bootstrapPath string) ([]blobMetaState, error) {
 	pattern := filepath.Join(filepath.Dir(bootstrapPath), "*.blob.meta")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	sort.Strings(matches)
 
 	if len(matches) == 0 {
-		return "blobmeta=none", nil
+		return nil, nil
 	}
 
-	var b strings.Builder
-	b.WriteString("blobmeta=")
-
-	for i, p := range matches {
+	files := make([]blobMetaState, 0, len(matches))
+	for _, p := range matches {
 		file, err := os.Open(p)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		info, err := file.Stat()
 		if err != nil {
 			file.Close()
-			return "", err
+			return nil, err
 		}
 		if !info.Mode().IsRegular() {
 			file.Close()
-			return "", fmt.Errorf("blob.meta %s is not a regular file", p)
+			return nil, fmt.Errorf("blob.meta %s is not a regular file", p)
 		}
 		if info.Size() <= 0 {
 			file.Close()
-			return "", fmt.Errorf("blob.meta %s is empty", p)
+			return nil, fmt.Errorf("blob.meta %s is empty", p)
 		}
 
 		var buf [1]byte
 		if _, err := io.ReadFull(file, buf[:]); err != nil {
 			file.Close()
-			return "", fmt.Errorf("read blob.meta %s: %w", p, err)
+			return nil, fmt.Errorf("read blob.meta %s: %w", p, err)
 		}
 		file.Close()
 
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		b.WriteString(filepath.Base(p))
-		b.WriteByte(':')
-		b.WriteString(strconv.FormatInt(info.Size(), 10))
+		files = append(files, blobMetaState{
+			Name: filepath.Base(p),
+			Size: info.Size(),
+		})
 	}
 
-	return b.String(), nil
+	return files, nil
 }
 
 func detectV6BlockSize(head []byte) (int, error) {

--- a/pkg/filesystem/bootstrap.go
+++ b/pkg/filesystem/bootstrap.go
@@ -175,39 +175,43 @@ func validateBlobMetaFiles(bootstrapPath string) ([]blobMetaState, error) {
 
 	files := make([]blobMetaState, 0, len(matches))
 	for _, p := range matches {
-		file, err := os.Open(p)
+		state, err := validateBlobMetaFile(p)
 		if err != nil {
 			return nil, err
 		}
-
-		info, err := file.Stat()
-		if err != nil {
-			file.Close()
-			return nil, err
-		}
-		if !info.Mode().IsRegular() {
-			file.Close()
-			return nil, fmt.Errorf("blob.meta %s is not a regular file", p)
-		}
-		if info.Size() <= 0 {
-			file.Close()
-			return nil, fmt.Errorf("blob.meta %s is empty", p)
-		}
-
-		var buf [1]byte
-		if _, err := io.ReadFull(file, buf[:]); err != nil {
-			file.Close()
-			return nil, fmt.Errorf("read blob.meta %s: %w", p, err)
-		}
-		file.Close()
-
-		files = append(files, blobMetaState{
-			Name: filepath.Base(p),
-			Size: info.Size(),
-		})
+		files = append(files, state)
 	}
 
 	return files, nil
+}
+
+func validateBlobMetaFile(path string) (blobMetaState, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return blobMetaState{}, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return blobMetaState{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return blobMetaState{}, fmt.Errorf("blob.meta %s is not a regular file", path)
+	}
+	if info.Size() <= 0 {
+		return blobMetaState{}, fmt.Errorf("blob.meta %s is empty", path)
+	}
+
+	var buf [1]byte
+	if _, err := io.ReadFull(file, buf[:]); err != nil {
+		return blobMetaState{}, fmt.Errorf("read blob.meta %s: %w", path, err)
+	}
+
+	return blobMetaState{
+		Name: filepath.Base(path),
+		Size: info.Size(),
+	}, nil
 }
 
 func detectV6BlockSize(head []byte) (int, error) {

--- a/pkg/filesystem/bootstrap_test.go
+++ b/pkg/filesystem/bootstrap_test.go
@@ -52,7 +52,12 @@ func TestWaitForReadyBootstrapWaitsForStableBlobMeta(t *testing.T) {
 
 	state, err := validateBootstrapAndBlobMeta(bootstrap)
 	require.NoError(t, err)
-	require.Equal(t, "bootstrap=8192;blobmeta=a.blob.meta:3", state)
+	require.Equal(t, bootstrapState{
+		BootstrapSize: 8192,
+		BlobMetaFiles: []blobMetaState{
+			{Name: "a.blob.meta", Size: 3},
+		},
+	}, state)
 }
 
 func TestWaitForReadyBootstrapRejectsStableMisalignedV6(t *testing.T) {
@@ -105,7 +110,10 @@ func TestValidateBlobMetaFilesReturnsSortedState(t *testing.T) {
 
 	state, err := validateBlobMetaFiles(bootstrap)
 	require.NoError(t, err)
-	require.Equal(t, "blobmeta=a.blob.meta:1,z.blob.meta:2", state)
+	require.Equal(t, []blobMetaState{
+		{Name: "a.blob.meta", Size: 1},
+		{Name: "z.blob.meta", Size: 2},
+	}, state)
 }
 
 func TestValidateBlobMetaFilesRejectsEmptyFile(t *testing.T) {
@@ -128,7 +136,12 @@ func TestValidateBootstrapAndBlobMetaReturnsCombinedState(t *testing.T) {
 
 	state, err := validateBootstrapAndBlobMeta(bootstrap)
 	require.NoError(t, err)
-	require.Equal(t, "bootstrap=8192;blobmeta=layer.blob.meta:4", state)
+	require.Equal(t, bootstrapState{
+		BootstrapSize: 8192,
+		BlobMetaFiles: []blobMetaState{
+			{Name: "layer.blob.meta", Size: 4},
+		},
+	}, state)
 }
 
 func TestDetectV6BlockSize(t *testing.T) {
@@ -153,6 +166,43 @@ func TestDetectV6BlockSizeRejectsShortHeader(t *testing.T) {
 	require.Contains(t, err.Error(), "header is too small")
 }
 
+func TestBootstrapStateEqual(t *testing.T) {
+	a := bootstrapState{
+		BootstrapSize: 8192,
+		BlobMetaFiles: []blobMetaState{
+			{Name: "a.blob.meta", Size: 1},
+			{Name: "b.blob.meta", Size: 2},
+		},
+	}
+
+	b := bootstrapState{
+		BootstrapSize: 8192,
+		BlobMetaFiles: []blobMetaState{
+			{Name: "a.blob.meta", Size: 1},
+			{Name: "b.blob.meta", Size: 2},
+		},
+	}
+
+	c := bootstrapState{
+		BootstrapSize: 8193,
+		BlobMetaFiles: []blobMetaState{
+			{Name: "a.blob.meta", Size: 1},
+			{Name: "b.blob.meta", Size: 2},
+		},
+	}
+
+	d := bootstrapState{
+		BootstrapSize: 8192,
+		BlobMetaFiles: []blobMetaState{
+			{Name: "a.blob.meta", Size: 1},
+		},
+	}
+
+	require.True(t, a.Equal(b))
+	require.False(t, a.Equal(c))
+	require.False(t, a.Equal(d))
+}
+
 func writeFakeV5Bootstrap(path string, size int) error {
 	buf := make([]byte, size)
 	binary.LittleEndian.PutUint32(buf[0:4], layout.RafsV5SuperMagic)
@@ -162,7 +212,10 @@ func writeFakeV5Bootstrap(path string, size int) error {
 
 func writeFakeV6Bootstrap(path string, size int, blockBits byte) error {
 	buf := make([]byte, size)
-	binary.LittleEndian.PutUint32(buf[layout.RafsV6SuperBlockOffset:layout.RafsV6SuperBlockOffset+4], layout.RafsV6SuperMagic)
+	binary.LittleEndian.PutUint32(
+		buf[layout.RafsV6SuperBlockOffset:layout.RafsV6SuperBlockOffset+4],
+		layout.RafsV6SuperMagic,
+	)
 	buf[v6BlockBitsOffset] = blockBits
 	return os.WriteFile(path, buf, 0644)
 }

--- a/pkg/filesystem/bootstrap_test.go
+++ b/pkg/filesystem/bootstrap_test.go
@@ -35,6 +35,26 @@ func TestWaitForReadyBootstrapWaitsForStableV6(t *testing.T) {
 	require.EqualValues(t, 393216, info.Size())
 }
 
+func TestWaitForReadyBootstrapWaitsForStableBlobMeta(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+	blobMeta := filepath.Join(dir, "a.blob.meta")
+
+	require.NoError(t, writeFakeV5Bootstrap(bootstrap, 8192))
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		_ = os.WriteFile(blobMeta, []byte{1, 2, 3}, 0644)
+	}()
+
+	err := waitForReadyBootstrapWithRetry(bootstrap, 5, 10*time.Millisecond)
+	require.NoError(t, err)
+
+	state, err := validateBootstrapAndBlobMeta(bootstrap)
+	require.NoError(t, err)
+	require.Equal(t, "bootstrap=8192;blobmeta=a.blob.meta:3", state)
+}
+
 func TestWaitForReadyBootstrapRejectsStableMisalignedV6(t *testing.T) {
 	dir := t.TempDir()
 	bootstrap := filepath.Join(dir, "image.boot")
@@ -52,6 +72,85 @@ func TestWaitForReadyBootstrapAcceptsStableV5(t *testing.T) {
 
 	err := waitForReadyBootstrapWithRetry(bootstrap, 3, 5*time.Millisecond)
 	require.NoError(t, err)
+}
+
+func TestValidateBootstrapRejectsTooSmall(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+
+	require.NoError(t, os.WriteFile(bootstrap, make([]byte, 7), 0644))
+
+	_, err := validateBootstrap(bootstrap)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bootstrap is too small")
+}
+
+func TestValidateBootstrapRejectsUnknownV6BlockBits(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+
+	require.NoError(t, writeFakeV6Bootstrap(bootstrap, 393216, 10))
+
+	_, err := validateBootstrap(bootstrap)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown v6 block bits")
+}
+
+func TestValidateBlobMetaFilesReturnsSortedState(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "z.blob.meta"), []byte{1, 2}, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.blob.meta"), []byte{9}, 0644))
+
+	state, err := validateBlobMetaFiles(bootstrap)
+	require.NoError(t, err)
+	require.Equal(t, "blobmeta=a.blob.meta:1,z.blob.meta:2", state)
+}
+
+func TestValidateBlobMetaFilesRejectsEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.blob.meta"), nil, 0644))
+
+	_, err := validateBlobMetaFiles(bootstrap)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is empty")
+}
+
+func TestValidateBootstrapAndBlobMetaReturnsCombinedState(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+
+	require.NoError(t, writeFakeV5Bootstrap(bootstrap, 8192))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "layer.blob.meta"), []byte{1, 2, 3, 4}, 0644))
+
+	state, err := validateBootstrapAndBlobMeta(bootstrap)
+	require.NoError(t, err)
+	require.Equal(t, "bootstrap=8192;blobmeta=layer.blob.meta:4", state)
+}
+
+func TestDetectV6BlockSize(t *testing.T) {
+	head := make([]byte, v6BlockBitsOffset+1)
+
+	head[v6BlockBitsOffset] = v6BlockBits512
+	size, err := detectV6BlockSize(head)
+	require.NoError(t, err)
+	require.Equal(t, 512, size)
+
+	head[v6BlockBitsOffset] = v6BlockBits4096
+	size, err = detectV6BlockSize(head)
+	require.NoError(t, err)
+	require.Equal(t, 4096, size)
+}
+
+func TestDetectV6BlockSizeRejectsShortHeader(t *testing.T) {
+	head := make([]byte, v6BlockBitsOffset)
+
+	_, err := detectV6BlockSize(head)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header is too small")
 }
 
 func writeFakeV5Bootstrap(path string, size int) error {

--- a/pkg/filesystem/bootstrap_test.go
+++ b/pkg/filesystem/bootstrap_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package filesystem
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/containerd/nydus-snapshotter/pkg/layout"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForReadyBootstrapWaitsForStableV6(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+	require.NoError(t, writeFakeV6Bootstrap(bootstrap, 392192, v6BlockBits4096))
+
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		_ = writeFakeV6Bootstrap(bootstrap, 393216, v6BlockBits4096)
+	}()
+
+	err := waitForReadyBootstrapWithRetry(bootstrap, 20, 10*time.Millisecond)
+	require.NoError(t, err)
+
+	info, err := os.Stat(bootstrap)
+	require.NoError(t, err)
+	require.EqualValues(t, 393216, info.Size())
+}
+
+func TestWaitForReadyBootstrapRejectsStableMisalignedV6(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+	require.NoError(t, writeFakeV6Bootstrap(bootstrap, 392192, v6BlockBits4096))
+
+	err := waitForReadyBootstrapWithRetry(bootstrap, 3, 5*time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not aligned")
+}
+
+func TestWaitForReadyBootstrapAcceptsStableV5(t *testing.T) {
+	dir := t.TempDir()
+	bootstrap := filepath.Join(dir, "image.boot")
+	require.NoError(t, writeFakeV5Bootstrap(bootstrap, 8192))
+
+	err := waitForReadyBootstrapWithRetry(bootstrap, 3, 5*time.Millisecond)
+	require.NoError(t, err)
+}
+
+func writeFakeV5Bootstrap(path string, size int) error {
+	buf := make([]byte, size)
+	binary.LittleEndian.PutUint32(buf[0:4], layout.RafsV5SuperMagic)
+	binary.LittleEndian.PutUint32(buf[4:8], layout.RafsV5SuperVersion)
+	return os.WriteFile(path, buf, 0644)
+}
+
+func writeFakeV6Bootstrap(path string, size int, blockBits byte) error {
+	buf := make([]byte, size)
+	binary.LittleEndian.PutUint32(buf[layout.RafsV6SuperBlockOffset:layout.RafsV6SuperBlockOffset+4], layout.RafsV6SuperMagic)
+	buf[v6BlockBitsOffset] = blockBits
+	return os.WriteFile(path, buf, 0644)
+}

--- a/pkg/filesystem/bootstrap_test.go
+++ b/pkg/filesystem/bootstrap_test.go
@@ -116,13 +116,27 @@ func TestValidateBlobMetaFilesReturnsSortedState(t *testing.T) {
 	}, state)
 }
 
-func TestValidateBlobMetaFilesRejectsEmptyFile(t *testing.T) {
+func TestValidateBlobMetaFileReturnsState(t *testing.T) {
 	dir := t.TempDir()
-	bootstrap := filepath.Join(dir, "image.boot")
+	blobMeta := filepath.Join(dir, "a.blob.meta")
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.blob.meta"), nil, 0644))
+	require.NoError(t, os.WriteFile(blobMeta, []byte{1, 2, 3}, 0644))
 
-	_, err := validateBlobMetaFiles(bootstrap)
+	state, err := validateBlobMetaFile(blobMeta)
+	require.NoError(t, err)
+	require.Equal(t, blobMetaState{
+		Name: "a.blob.meta",
+		Size: 3,
+	}, state)
+}
+
+func TestValidateBlobMetaFileRejectsEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	blobMeta := filepath.Join(dir, "empty.blob.meta")
+
+	require.NoError(t, os.WriteFile(blobMeta, nil, 0644))
+
+	_, err := validateBlobMetaFile(blobMeta)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "is empty")
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -471,6 +471,13 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 		err = errors.Errorf("unknown filesystem driver %s for snapshot %s", fsDriver, snapshotID)
 	}
 
+	// Wait for the daemon to be ready before persisting the RAFS instance
+	if err == nil && (fsDriver == config.FsDriverFscache || fsDriver == config.FsDriverFusedev) {
+		if err := d.WaitUntilState(types.DaemonStateRunning); err != nil {
+			return errors.Wrapf(err, "daemon %s failed to reach RUNNING for snapshot %s", d.ID(), snapshotID)
+		}
+	}
+
 	// Persist it after associate instance after all the states are calculated.
 	if err == nil {
 		if err := fsManager.AddRafsInstance(rafs); err != nil {

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -371,6 +371,9 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 		if err != nil {
 			return errors.Wrapf(err, "find bootstrap file snapshot %s", snapshotID)
 		}
+		if err := waitForReadyBootstrap(bootstrap); err != nil {
+			return errors.Wrapf(err, "wait for bootstrap file snapshot %s", snapshotID)
+		}
 
 		// Nydusd uses cache manager's directory to store blob caches. So cache
 		// manager knows where to find those blobs.


### PR DESCRIPTION
## Overview
We see a concurrency issue under these conditions:
- Greater than 1 pod schedules onto a node at exactly the same time
- Both attempt to use the same image
- The image has not been pulled on the node before

This throws the following errors (or similar errors):
```
 [2026-04-09 15:41:15.200253 +00:00] ERROR [/api/src/error.rs:23] Error:
         "invalid Rafs v6 metadata size: bootstrap size 523264 is not aligned"
         at rafs/src/metadata/layout/v6.rs:171
         note: enable `RUST_BACKTRACE=1` env to display a backtrace
...
...
 [2026-04-09 15:41:15.327559 +00:00] ERROR [/api/src/error.rs:23] Error:
         "failed to get blob size, Request(ErrorWithMsg(\"\"))"
         at storage/src/meta/toc.rs:426
         note: enable `RUST_BACKTRACE=1` env to display a backtrace
 [2026-04-09 15:41:15.329073 +00:00] DEBUG [/src/metadata/mod.rs:782] failed to load inlined RAFS meta, I/O error (os error 5)
 [2026-04-09 15:41:15.329096 +00:00] ERROR [/service/src/fusedev.rs:753] service mount error: RAFS failed to handle request, Failed to fill superBlock: Invalid argument (os error 22)`
 ERROR [/api/src/error.rs:23] Error:
         Rafs(FillSuperBlock(Os { code: 22, kind: InvalidInput, message: "Invalid argument" }))
         at service/src/fusedev.rs:754
         note: enable `RUST_BACKTRACE=1` env to display a backtrace
 [2026-04-09 15:41:15.329132 +00:00] ERROR [src/bin/nydusd/main.rs:535] Failed in starting daemon:
 Error: Custom { kind: Other, error: "" }
```

This results in a zombie process, the daemon does not start successfully. Both pods fail with this error, as well as any subsequent pods which try to use the same image.
```
Error: failed to create containerd container: wait until daemon is RUNNING: get daemon state: daemon socket /var/lib/containerd/io.containerd.snapshotter.v1.nydus/socket/d7bsh6oob1lavl67ajtg/api.sock: not found
```

The root cause seems to be the snapshotter attempting to read the `image.boot`/`blob.meta` files before they are fully initialized, but only when multiple pods schedule at the same time.

This leaves behind a broken/failed snapshot which subsequent pods attempt to use since the rafs instance is persisted to cache regardless of if it is healthy or not.

## Related Issues
N/A

## Change Details
This PR provides two ways of preventing this issue:
- Prevents persistence of rafs instance to cache until the daemon has reached a `running` state
- Adds validation for bootstrap and `blob.meta` files during Mount() to ensure they are not read before the files are fully written/ready

The file validation checks the following:
- Bootstrap and `blob.meta` files exist and are readable
- RAFS version can be detected from the header
- Bootstrap size is aligned to block size
- State of both files are identical across two consecutive checks to ensure they are not still changing


## Test Results
Tested in large enterprise-scale AWS EKS cluster and promoted to production with thousands of pods scheduled daily. This issue no longer causes pod failures and instead logs the following and waits for readiness.
```
containerd-nydus-grpc[3490]: time="2026-04-14T15:41:13.357600693Z" level=warning msg="bootstrap is not ready, retrying... attempt: 1, error: bootstrap is not ready, current state: bootstrap=39370752;blobmeta=none"
```

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.