### PR TITLE
remote: allow localhost HTTP retry for k3s local registry

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -53,6 +53,11 @@ type Remote struct {
 	insecure bool
 }
 
+func isLocalRegistryHost(host string) bool {
+	match, err := docker.MatchLocalhost(host)
+	return err == nil && match
+}
+
 func New(keyChain *auth.PassKeyChain, insecure bool) *Remote {
 	// nolint:unparam
 	credFunc := func(string) (string, string, error) {
@@ -99,7 +104,16 @@ func New(keyChain *auth.PassKeyChain, insecure bool) *Remote {
 }
 
 func (remote *Remote) RetryWithPlainHTTP(ref string, err error) bool {
-	if !remote.insecure {
+	parsed, _ := reference.ParseNormalizedNamed(ref)
+	host := ""
+	if parsed != nil {
+		host = reference.Domain(parsed)
+	}
+
+	// Keep secure default for remote registries. For loopback/localhost
+	// registries, allow retrying over plain HTTP to align with common local
+	// development setups (for example k3s + local registry on localhost:5000).
+	if !remote.insecure && !isLocalRegistryHost(host) {
 		return false
 	}
 
@@ -108,9 +122,7 @@ func (remote *Remote) RetryWithPlainHTTP(ref string, err error) bool {
 		return false
 	}
 
-	parsed, _ := reference.ParseNormalizedNamed(ref)
-	if parsed != nil {
-		host := reference.Domain(parsed)
+	if host != "" {
 		// If the error message includes the current registry host string, it
 		// implies that we can retry the request with plain HTTP.
 		if strings.Contains(err.Error(), fmt.Sprintf("/%s/", host)) {

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -14,60 +14,91 @@ import (
 )
 
 func TestRetryWithPlainHTTP(t *testing.T) {
-	const host = "myregistry.example.com"
-	ref := fmt.Sprintf("%s/repo/image:latest", host)
-	httpResponseErr := fmt.Errorf("Get https://%s/v2/: server gave HTTP response to HTTPS client", host)
-	connRefusedErr := fmt.Errorf("Get https://%s/v2/: connect: connection refused", host)
+	const (
+		remoteHost = "myregistry.example.com"
+		localHost  = "localhost:5000"
+		localIP    = "127.0.0.1:5000"
+	)
+
+	remoteRef := fmt.Sprintf("%s/repo/image:latest", remoteHost)
+	localRef := fmt.Sprintf("%s/repo/image:latest", localHost)
+	localIPRef := fmt.Sprintf("%s/repo/image:latest", localIP)
+
+	remoteHTTPResponseErr := fmt.Errorf("Get https://%s/v2/: server gave HTTP response to HTTPS client", remoteHost)
+	remoteConnRefusedErr := fmt.Errorf("Get https://%s/v2/: connect: connection refused", remoteHost)
+	localHTTPResponseErr := fmt.Errorf("Get https://%s/v2/: server gave HTTP response to HTTPS client", localHost)
+	localIPHTTPResponseErr := fmt.Errorf("Get https://%s/v2/: server gave HTTP response to HTTPS client", localIP)
 	otherErr := fmt.Errorf("some unrelated error")
 
 	tests := []struct {
 		name     string
+		ref      string
 		insecure bool
 		err      error
 		want     bool
 	}{
 		{
 			name:     "insecure allows HTTP fallback on HTTP response error",
+			ref:      remoteRef,
 			insecure: true,
-			err:      httpResponseErr,
+			err:      remoteHTTPResponseErr,
 			want:     true,
 		},
 		{
 			name:     "insecure allows HTTP fallback on connection refused",
+			ref:      remoteRef,
 			insecure: true,
-			err:      connRefusedErr,
+			err:      remoteConnRefusedErr,
 			want:     true,
 		},
 		{
 			name:     "insecure does not fallback on unrelated error",
+			ref:      remoteRef,
 			insecure: true,
 			err:      otherErr,
 			want:     false,
 		},
 		{
 			name:     "secure blocks HTTP fallback on HTTP response error",
+			ref:      remoteRef,
 			insecure: false,
-			err:      httpResponseErr,
+			err:      remoteHTTPResponseErr,
 			want:     false,
 		},
 		{
 			name:     "secure blocks HTTP fallback on connection refused",
+			ref:      remoteRef,
 			insecure: false,
-			err:      connRefusedErr,
+			err:      remoteConnRefusedErr,
 			want:     false,
 		},
 		{
 			name:     "nil error returns false",
+			ref:      remoteRef,
 			insecure: true,
 			err:      nil,
 			want:     false,
+		},
+		{
+			name:     "secure allows localhost HTTP fallback on HTTP response error",
+			ref:      localRef,
+			insecure: false,
+			err:      localHTTPResponseErr,
+			want:     true,
+		},
+		{
+			name:     "secure allows loopback IP HTTP fallback on HTTP response error",
+			ref:      localIPRef,
+			insecure: false,
+			err:      localIPHTTPResponseErr,
+			want:     true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Remote{insecure: tt.insecure}
-			got := r.RetryWithPlainHTTP(ref, tt.err)
+			got := r.RetryWithPlainHTTP(tt.ref, tt.err)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary
- allow HTTP fallback for loopback registries (localhost, 127.0.0.1, ::1) even when global insecure is disabled
- keep secure default for non-local registries
- add unit tests for secure+localhost fallback and existing secure/insecure paths

## Why
In k3s + containerd setups with local HTTP registry (localhost:5000), index detection for nydus native OCI-ref images can fail after commit fd9dc41 because HTTPS->HTTP retry is fully gated by insecure mode.

## Validation
- go test ./pkg/remote
- go test ./pkg/index
- manual k3s verification on 165.154.147.192:
  - before fix (secure defaults): index detection failed seen for localhost:5000
  - after fix: logs show retrying with http for localhost:5000, Found nydus alternative image in index, Nydus remote snapshot ... is ready