### PR TITLE
Move the deprecated mirror logic from nydusd to snapshotter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Dragonfly supports both **mirror** mode and HTTP **proxy** mode to boost the con
 
 ### Hot updating mirror configurations
 
-In addition to setting the registry mirror in nydusd's json configuration file, `nydus-snapshotter` also supports hot updating mirror configurations. You can set the configuration directory in nudus-snapshotter's toml configuration file with `remote.mirrors_config.dir`. The empty `remote.mirrors_config.dir` means disabling it.
+`nydus-snapshotter` supports hot updating mirror configurations. You can set the configuration directory in nydus-snapshotter's toml configuration file with `remote.mirrors_config.dir`. The empty `remote.mirrors_config.dir` means disabling it.
 
 ```toml
 [remote.mirrors_config]
@@ -177,12 +177,12 @@ Configuration file is compatible with containerd's configuration file in toml fo
 ```toml
 [host]
   [host."http://127.0.0.1:65001"]
-    [host."http://127.0.0.1:65001".header]
-      # NOTE: For Dragonfly, the HTTP scheme must be explicitly specified.
-      X-Dragonfly-Registry = ["https://p2p-nydus.com"]
+    # Optional: health check URL. If set, the mirror is only used when this URL returns HTTP 2xx.
+    # If not set, the mirror is used unconditionally.
+    ping_url = "http://127.0.0.1:65001/ping"
 ```
 
-Mirror configurations loaded from nydusd's json file will be overwritten before pulling image if the valid mirror configuration items loaded from `remote.mirrors_config.dir` are greater than 0.
+Before each mount, the snapshotter reads the mirror configuration for the target registry host and rewrites nydusd's backend `host` to the first reachable mirror. If a mirror has no `ping_url` it is selected immediately. If all mirrors fail their health check, the original registry host is used as fallback.
 
 ## Community
 

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -9,10 +9,14 @@ package daemonconfig
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
+	"github.com/containerd/log"
 	"github.com/pkg/errors"
 
 	"github.com/containerd/nydus-snapshotter/config"
@@ -35,7 +39,6 @@ type DaemonConfig interface {
 	// Provide auth
 	FillAuth(kc *auth.PassKeyChain)
 	StorageBackend() (StorageBackendType, *BackendConfig)
-	UpdateMirrors(mirrorsConfigDir, registryHost string) error
 	DumpString() (string, error)
 	DumpFile(path string) error
 }
@@ -60,14 +63,6 @@ func NewDaemonConfig(fsDriver, path string) (DaemonConfig, error) {
 	}
 }
 
-type MirrorConfig struct {
-	Host                string            `json:"host,omitempty"`
-	Headers             map[string]string `json:"headers,omitempty"`
-	HealthCheckInterval int               `json:"health_check_interval,omitempty"`
-	FailureLimit        uint8             `json:"failure_limit,omitempty"`
-	PingURL             string            `json:"ping_url,omitempty"`
-}
-
 type BackendConfig struct {
 	// Localfs backend configs
 	BlobFile     string `json:"blob_file,omitempty"`
@@ -76,13 +71,12 @@ type BackendConfig struct {
 	ReadAheadSec int    `json:"readahead_sec,omitempty"`
 
 	// Registry backend configs
-	Host               string         `json:"host,omitempty"`
-	Repo               string         `json:"repo,omitempty"`
-	Auth               string         `json:"auth,omitempty" secret:"true"`
-	RegistryToken      string         `json:"registry_token,omitempty" secret:"true"`
-	BlobURLScheme      string         `json:"blob_url_scheme,omitempty"`
-	BlobRedirectedHost string         `json:"blob_redirected_host,omitempty"`
-	Mirrors            []MirrorConfig `json:"mirrors,omitempty"`
+	Host               string `json:"host,omitempty"`
+	Repo               string `json:"repo,omitempty"`
+	Auth               string `json:"auth,omitempty" secret:"true"`
+	RegistryToken      string `json:"registry_token,omitempty" secret:"true"`
+	BlobURLScheme      string `json:"blob_url_scheme,omitempty"`
+	BlobRedirectedHost string `json:"blob_redirected_host,omitempty"`
 
 	// Shared by oss and s3 backend configs
 	EndPoint        string `json:"endpoint,omitempty"`
@@ -169,16 +163,24 @@ func SupplementDaemonConfig(c DaemonConfig, imageID, snapshotID string,
 			registryHost = "index.docker.io"
 		}
 
-		if err := c.UpdateMirrors(config.GetMirrorsConfigDir(), registryHost); err != nil {
-			return errors.Wrap(err, "update mirrors config")
+		effectiveScheme, effectiveHost, caCerts := selectMirrorHost(config.GetMirrorsConfigDir(), registryHost)
+		// No mirror configured use the original registry host
+		if effectiveHost == "" {
+			effectiveHost = registryHost
 		}
-
 		// If no auth is provided, don't touch auth from provided nydusd configuration file.
 		// We don't validate the original nydusd auth from configuration file since it can be empty
 		// when repository is public.
 		keyChain := auth.GetRegistryKeyChain(imageID, labels)
-		c.Supplement(registryHost, image.Repo, snapshotID, params)
+		c.Supplement(effectiveHost, image.Repo, snapshotID, params)
 		c.FillAuth(keyChain)
+		_, bc := c.StorageBackend()
+		if len(caCerts) > 0 {
+			bc.CACertFiles = caCerts
+		}
+		if effectiveScheme != "" {
+			bc.Scheme = effectiveScheme
+		}
 
 	// For Localfs, OSS, and S3 backends, only the WorkDir needs to be supplemented.
 	case backendTypeLocalfs, backendTypeOss, backendTypeS3:
@@ -188,6 +190,53 @@ func SupplementDaemonConfig(c DaemonConfig, imageID, snapshotID string,
 	}
 
 	return nil
+}
+
+// selectMirrorHost loads mirror configs for the given registry host and returns the host and
+// scheme of the first reachable mirror. If a mirror has no PingURL it is used unconditionally.
+// Falls back to (registryHost, "") when no mirror is configured or reachable.
+func selectMirrorHost(mirrorsConfigDir, registryHost string) (scheme string, host string, caCerts []string) {
+	mirrors, caCerts, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	if err != nil {
+		log.L.Warnf("Failed to load mirrors config for %s: %v, falling back to origin", registryHost, err)
+		return "", registryHost, caCerts
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	for _, mirror := range mirrors {
+		scheme, host, err = splitMirrorURL(mirror.Host)
+		if err != nil {
+			log.L.Warnf("Skipping due to Failing to split mirror host %s: %v", mirror.Host, err)
+			continue
+		}
+		if mirror.PingURL == "" {
+			return scheme, host, caCerts
+		}
+		resp, pingErr := client.Get(mirror.PingURL)
+		if pingErr == nil {
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return scheme, host, caCerts
+			}
+		}
+		log.L.Warnf("Mirror %s ping URL %s check failed, trying next mirror", mirror.Host, mirror.PingURL)
+	}
+
+	return "", registryHost, caCerts
+}
+
+// splitMirrorURL splits a mirror host URL (e.g. "http://mirror:5000") into scheme and bare host.
+// Scheme is forced to be https if not present.
+func splitMirrorURL(mirrorHost string) (scheme, host string, err error) {
+	// url.Parse requires a scheme to properly works even if it doesn't returns an error
+	if !strings.HasPrefix(mirrorHost, "http://") && !strings.HasPrefix(mirrorHost, "https://") {
+		mirrorHost = "https://" + mirrorHost
+	}
+	value, err := url.Parse(mirrorHost)
+	if err != nil {
+		return "", "", err
+	}
+	return value.Scheme, value.Host, nil
 }
 
 func serializeWithSecretFilter(obj interface{}) map[string]interface{} {

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -9,6 +9,7 @@ package daemonconfig
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -199,7 +200,7 @@ func selectMirrorHost(mirrorsConfigDir, registryHost string) (scheme string, hos
 	mirrors, caCerts, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	if err != nil {
 		log.L.Warnf("Failed to load mirrors config for %s: %v, falling back to origin", registryHost, err)
-		return "", registryHost, caCerts
+		return "", registryHost, nil
 	}
 
 	client := &http.Client{Timeout: 3 * time.Second}
@@ -219,10 +220,26 @@ func selectMirrorHost(mirrorsConfigDir, registryHost string) (scheme string, hos
 				return scheme, host, caCerts
 			}
 		}
-		log.L.Warnf("Mirror %s ping URL %s check failed, trying next mirror", mirror.Host, mirror.PingURL)
+
+		if resp != nil {
+			pingBody, _ := io.ReadAll(resp.Body)
+			log.L.Warnf("Mirror %s ping URL %s check failed with error %v, statusCode %d, response '%s', trying next mirror",
+				mirror.Host,
+				mirror.PingURL,
+				err,
+				resp.StatusCode,
+				string(pingBody),
+			)
+		} else {
+			log.L.Warnf("Mirror %s ping URL %s check failed with error %v, trying next mirror",
+				mirror.Host,
+				mirror.PingURL,
+				err,
+			)
+		}
 	}
 
-	return "", registryHost, caCerts
+	return "", registryHost, nil
 }
 
 // splitMirrorURL splits a mirror host URL (e.g. "http://mirror:5000") into scheme and bare host.

--- a/config/daemonconfig/fscache.go
+++ b/config/daemonconfig/fscache.go
@@ -69,20 +69,6 @@ func LoadFscacheConfig(p string) (*FscacheDaemonConfig, error) {
 	return &cfg, nil
 }
 
-func (c *FscacheDaemonConfig) UpdateMirrors(mirrorsConfigDir, registryHost string) error {
-	mirrors, caCerts, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
-	if err != nil {
-		return err
-	}
-	if len(mirrors) > 0 {
-		c.Config.BackendConfig.Mirrors = mirrors
-	}
-	if len(caCerts) > 0 {
-		c.Config.BackendConfig.CACertFiles = caCerts
-	}
-	return nil
-}
-
 func (c *FscacheDaemonConfig) StorageBackend() (string, *BackendConfig) {
 	return c.Config.BackendType, &c.Config.BackendConfig
 }

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -84,20 +84,6 @@ func (c *FuseDaemonConfig) FillAuth(kc *auth.PassKeyChain) {
 	}
 }
 
-func (c *FuseDaemonConfig) UpdateMirrors(mirrorsConfigDir, registryHost string) error {
-	mirrors, caCerts, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
-	if err != nil {
-		return err
-	}
-	if len(mirrors) > 0 {
-		c.Device.Backend.Config.Mirrors = mirrors
-	}
-	if len(caCerts) > 0 {
-		c.Device.Backend.Config.CACertFiles = caCerts
-	}
-	return nil
-}
-
 func (c *FuseDaemonConfig) StorageBackend() (string, *BackendConfig) {
 	return c.Device.Backend.BackendType, &c.Device.Backend.Config
 }

--- a/config/daemonconfig/mirror_select_test.go
+++ b/config/daemonconfig/mirror_select_test.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package daemonconfig
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testRegistryHost = "fake-test.registry.com"
+
+func writeMirrorHostsToml(t *testing.T, dir, content string) {
+	t.Helper()
+	hostDir := filepath.Join(dir, testRegistryHost)
+	require.NoError(t, os.MkdirAll(hostDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(content), 0600))
+}
+
+func TestSplitMirrorURL(t *testing.T) {
+	cases := []struct {
+		name           string
+		input          string
+		expectedScheme string
+		expectedHost   string
+		expectErr      bool
+	}{
+		{
+			name:           "http with port",
+			input:          "http://mirror:5000",
+			expectedScheme: "http",
+			expectedHost:   "mirror:5000",
+		},
+		{
+			name:           "https without port",
+			input:          "https://mirror.example.com",
+			expectedScheme: "https",
+			expectedHost:   "mirror.example.com",
+		},
+		{
+			name:           "no scheme, host only",
+			input:          "mirror.example.com",
+			expectedScheme: "https",
+			expectedHost:   "mirror.example.com",
+		},
+		{
+			name:           "no scheme, host with port",
+			input:          "mirror:5000",
+			expectedScheme: "https",
+			expectedHost:   "mirror:5000",
+		},
+		{
+			name:           "https with port",
+			input:          "https://mirror.example.com:5000",
+			expectedScheme: "https",
+			expectedHost:   "mirror.example.com:5000",
+		},
+		{
+			name:           "http with path",
+			input:          "http://mirror.example.com/v2",
+			expectedScheme: "http",
+			expectedHost:   "mirror.example.com",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme, host, err := splitMirrorURL(tc.input)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedScheme, scheme, "scheme for %s", tc.input)
+			require.Equal(t, tc.expectedHost, host, "host for %s", tc.input)
+		})
+	}
+}
+
+func TestSelectMirrorHost_NoConfig(t *testing.T) {
+	scheme, host, _ := selectMirrorHost("", testRegistryHost)
+	require.Equal(t, testRegistryHost, host)
+	require.Equal(t, "", scheme)
+}
+
+func TestSelectMirrorHost_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheme, host, _ := selectMirrorHost(tmpDir, testRegistryHost)
+	require.Equal(t, testRegistryHost, host)
+	require.Equal(t, "", scheme)
+}
+
+func TestSelectMirrorHost_MirrorNoPingURL(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeMirrorHostsToml(t, tmpDir, `
+[host]
+  [host."http://mirror1:5000"]
+`)
+	scheme, host, _ := selectMirrorHost(tmpDir, testRegistryHost)
+	require.Equal(t, "mirror1:5000", host)
+	require.Equal(t, "http", scheme)
+}
+
+func TestSelectMirrorHost_MirrorPingSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	writeMirrorHostsToml(t, tmpDir, `
+[host]
+  [host."http://mirror1:5000"]
+    ping_url = "`+srv.URL+`"
+`)
+	scheme, host, _ := selectMirrorHost(tmpDir, testRegistryHost)
+	require.Equal(t, "mirror1:5000", host)
+	require.Equal(t, "http", scheme)
+}
+
+func TestSelectMirrorHost_MirrorPingFails_FallbackToOrigin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	writeMirrorHostsToml(t, tmpDir, `
+[host]
+  [host."http://mirror1:5000"]
+    ping_url = "`+srv.URL+`"
+`)
+	scheme, host, _ := selectMirrorHost(tmpDir, testRegistryHost)
+	require.Equal(t, testRegistryHost, host)
+	require.Equal(t, "", scheme)
+}
+
+func TestSelectMirrorHost_FirstMirrorFails_SecondMirrorNoPing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	writeMirrorHostsToml(t, tmpDir, `
+[host]
+  [host."http://mirror1:5000"]
+    ping_url = "`+srv.URL+`"
+  [host."https://mirror2.example.com"]
+`)
+	scheme, host, _ := selectMirrorHost(tmpDir, testRegistryHost)
+	require.Equal(t, "mirror2.example.com", host)
+	require.Equal(t, "https", scheme)
+}

--- a/config/daemonconfig/mirrors.go
+++ b/config/daemonconfig/mirrors.go
@@ -20,6 +20,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+type MirrorConfig struct {
+	Host                string
+	Headers             map[string]string
+	HealthCheckInterval int
+	FailureLimit        uint8
+	PingURL             string
+}
+
 // Copied from containerd, for compatibility with containerd's toml configuration file.
 type HostFileConfig struct {
 	Capabilities []string               `toml:"capabilities"`

--- a/misc/snapshotter/config.toml
+++ b/misc/snapshotter/config.toml
@@ -73,9 +73,10 @@ collect_interval = "1m"
 convert_vpc_registry = false
 
 [remote.mirrors_config]
-# Snapshotter will overwrite daemon's mirrors configuration
-# if the values loaded from this driectory are not null before starting a daemon.
-# Set to "" or an empty directory to disable it.
+# Snapshotter will rewrite nydusd's backend host to the first reachable mirror
+# loaded from this directory before each mount. Mirror selection is done by the
+# snapshotter (ping_url health check) and falls back to the origin registry host
+# when no mirror is available. Set to "" or an empty directory to disable it.
 #dir = "/etc/nydus/certs.d"
 
 [remote.auth]


### PR DESCRIPTION
## Overview

Hosts.toml configuration management in nydus-snapshotter was no more working since mirror feature removal in nydusd. 

## Related Issues
Implements #732 

## Change Details

Reading containerd hosts.toml was no more working as nydus-snapshotter is generating a mirror configuration which has been removed in nydusd. 

This PR reimplements the logic of hosts.toml by taking the first reacheable host described in the hosts.toml

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [X] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [X] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.