### PR TITLE
Add nydusd_image_info metric mapping daemons to served images

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/auth"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/containerd/nydus-snapshotter/pkg/metrics/collector"
 	"github.com/containerd/nydus-snapshotter/pkg/rafs"
 	"github.com/containerd/nydus-snapshotter/pkg/supervisor"
 	"github.com/containerd/nydus-snapshotter/pkg/utils/erofs"
@@ -150,6 +151,7 @@ func (d *Daemon) AddRafsInstance(r *rafs.Rafs) {
 	d.RafsCache.Add(r)
 	d.IncRef()
 	r.DaemonID = d.ID()
+	collector.NewDaemonImageCollector(d.ID(), r.ImageID).Collect()
 }
 
 func (d *Daemon) UpdateRafsInstance(r *rafs.Rafs) {
@@ -157,6 +159,9 @@ func (d *Daemon) UpdateRafsInstance(r *rafs.Rafs) {
 }
 
 func (d *Daemon) RemoveRafsInstance(snapshotID string) {
+	if r := d.RafsCache.Get(snapshotID); r != nil {
+		collector.NewDaemonImageCollector(d.ID(), r.ImageID).Delete()
+	}
 	d.RafsCache.Remove(snapshotID)
 	d.DecRef()
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -255,6 +255,12 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 
 	defer m.cleanUpDaemonResources(d)
 
+	// Clean up any remaining RAFS instances that were not individually
+	// unmounted (e.g., during forced shutdown or error recovery paths).
+	for _, r := range d.RafsCache.List() {
+		d.RemoveRafsInstance(r.SnapshotID)
+	}
+
 	if err := d.UmountRafsInstances(); err != nil {
 		log.L.Errorf("Failed to detach all fs instances from daemon %s, %s", d.ID(), err)
 	}

--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -45,6 +45,10 @@ func NewDaemonInfoCollector(version *types.BuildTimeInfo, value float64) *Daemon
 	return &DaemonInfoCollector{version, value}
 }
 
+func NewDaemonImageCollector(daemonID, imageRef string) *DaemonImageCollector {
+	return &DaemonImageCollector{DaemonID: daemonID, ImageRef: imageRef}
+}
+
 func NewSnapshotterMetricsCollector(ctx context.Context, cacheDir string, pid int) (*SnapshotterMetricsCollector, error) {
 	currentStat, err := tool.GetProcessStat(pid)
 	if err != nil {

--- a/pkg/metrics/collector/daemon.go
+++ b/pkg/metrics/collector/daemon.go
@@ -26,6 +26,11 @@ type DaemonResourceCollector struct {
 	Value    float64
 }
 
+type DaemonImageCollector struct {
+	DaemonID string
+	ImageRef string
+}
+
 func (d *DaemonEventCollector) Collect() {
 	data.NydusdEventCount.WithLabelValues(string(d.event)).Inc()
 }
@@ -40,4 +45,12 @@ func (d *DaemonInfoCollector) Collect() {
 
 func (d *DaemonResourceCollector) Collect() {
 	data.NydusdRSS.WithLabelValues(d.DaemonID).Set(d.Value)
+}
+
+func (d *DaemonImageCollector) Collect() {
+	data.NydusdImageInfo.WithLabelValues(d.DaemonID, d.ImageRef).Set(1)
+}
+
+func (d *DaemonImageCollector) Delete() {
+	data.NydusdImageInfo.DeleteLabelValues(d.DaemonID, d.ImageRef)
 }

--- a/pkg/metrics/data/daemon.go
+++ b/pkg/metrics/data/daemon.go
@@ -34,4 +34,11 @@ var (
 		[]string{daemonIDLabel},
 		ttl.DefaultTTL,
 	)
+	NydusdImageInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "nydusd_image_info",
+			Help: "Mapping of nydus daemon to served image references.",
+		},
+		[]string{daemonIDLabel, imageRefLabel},
+	)
 )

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -24,6 +24,7 @@ func init() {
 		data.NydusdEventCount,
 		data.NydusdCount,
 		data.NydusdRSS,
+		data.NydusdImageInfo,
 		data.SnapshotEventElapsedHists,
 		data.CacheUsage,
 		data.CPUUsage,


### PR DESCRIPTION
## Overview

Currently, there's no way to map a daemon id to an image ref using the prometheus metrics which makes debugging a bit cumbersome.
Add a new Prometheus gauge metric `nydusd_image_info` that maps nydus daemon IDs
to the image references they serve. For dedicated daemons this is a 1:1 mapping;
for shared daemons it is 1:N.

## Related Issues

None.

## Change Details

- New `nydusd_image_info` gauge with labels `{daemon_id, image_ref}`, set to 1
  for each active daemon-to-image association.
- Metric is collected in `AddRafsInstance` and deleted in `RemoveRafsInstance`.
- `DestroyDaemon` now calls `RemoveRafsInstance` for any remaining RAFS instances
  before `UmountRafsInstances`, covering error/forced-shutdown paths where
  individual `Umount` calls were skipped.

## Test Results

Tested locally, metrics are added as expected and cleaned up when the image is removed:

```
$ curl -s http://localhost:9110/v1/metrics | grep image_info
# HELP nydusd_image_info Mapping of nydus daemon to served image references.
# TYPE nydusd_image_info gauge
nydusd_image_info{daemon_id="d7gal69jjoq0eer34190",image_ref="localhost:5000/my-image:nydus"} 1
```

## Change Type

- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.