### PR TITLE
fix(daemon): drop bogus leading slash from blobcache metrics id

### DIFF
--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -312,7 +312,9 @@ func (c *nydusdClient) GetInflightMetrics() (*types.InflightMetrics, error) {
 func (c *nydusdClient) GetCacheMetrics(sid string) (*types.CacheMetrics, error) {
 	query := query{}
 	if sid != "" {
-		query.Add("id", "/"+sid)
+		// nydusd's blobcache metrics are keyed by the raw fscache ID (a digest),
+		// unlike /api/v1/metrics which uses a "/<mountpoint>" path.
+		query.Add("id", sid)
 	}
 
 	url := c.url(endpointCacheMetrics, query)


### PR DESCRIPTION
## Summary

`GetCacheMetrics` was querying `/api/v1/metrics/blobcache?id=/<fscacheID>`, but nydusd's blobcache counters are keyed by the bare fscache ID (a sha256 digest). Every request came back `404 BlobcacheMetrics(Metrics(Stats(NoCounter)))`, which bubbles up as `failed to get cache metric` and blocks container create on fscache snapshots.

The `/` prefix is correct for `/api/v1/metrics` (keyed by mountpoint path like `/rafs`) but wrong for `/api/v1/metrics/blobcache`. The latent bug was introduced by 88d6769 ("[fs] Fix mismatch in GetCacheMetrics call"), which switched the sid from `snapshotID` to `fscacheID` but kept the mountpoint-style leading `/`.

## Reproduction

Against a running `nydusd singleton --fscache` with an erofs fscache mount:

```
# keyed correctly
curl --unix-socket $API "http://l/api/v1/metrics/blobcache?id=5ba77d4f..."
-> HTTP 200 { "underlying_files": ["...blob.data"], ... }

# current code (leading slash)
curl --unix-socket $API "http://l/api/v1/metrics/blobcache?id=/5ba77d4f..."
-> HTTP 404 { "code": "UNDEFINED", "message": "BlobcacheMetrics(Metrics(Stats(NoCounter)))" }
```

## Test plan

- [x] Direct API probe against nydusd v2.4.1 confirms the key format (see above).
- [x] With the fix applied, a `hostUsers: false` pod using an fscache-backed nydus image reaches `Running`, and `/api/v1/metrics/blobcache?id=<fscacheID>` returns real counters to the snapshotter.
- [ ] CI.