### PR TITLE
Propage CA configuration from containerd toml file to fuse and fscache configuration

### DIFF
--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -95,8 +95,9 @@ type BackendConfig struct {
 	Region string `json:"region,omitempty"`
 
 	// Shared by registry, oss, and s3
-	Scheme     string `json:"scheme,omitempty"`
-	SkipVerify bool   `json:"skip_verify,omitempty"`
+	Scheme      string   `json:"scheme,omitempty"`
+	SkipVerify  bool     `json:"skip_verify,omitempty"`
+	CACertFiles []string `json:"ca_cert_files,omitempty"`
 
 	// Below configs are common configs shared by all backends
 	Proxy struct {

--- a/config/daemonconfig/fscache.go
+++ b/config/daemonconfig/fscache.go
@@ -70,12 +70,15 @@ func LoadFscacheConfig(p string) (*FscacheDaemonConfig, error) {
 }
 
 func (c *FscacheDaemonConfig) UpdateMirrors(mirrorsConfigDir, registryHost string) error {
-	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	mirrors, caCerts, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	if err != nil {
 		return err
 	}
 	if len(mirrors) > 0 {
 		c.Config.BackendConfig.Mirrors = mirrors
+	}
+	if len(caCerts) > 0 {
+		c.Config.BackendConfig.CACertFiles = caCerts
 	}
 	return nil
 }

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -85,12 +85,15 @@ func (c *FuseDaemonConfig) FillAuth(kc *auth.PassKeyChain) {
 }
 
 func (c *FuseDaemonConfig) UpdateMirrors(mirrorsConfigDir, registryHost string) error {
-	mirrors, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	mirrors, caCerts, err := LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	if err != nil {
 		return err
 	}
 	if len(mirrors) > 0 {
 		c.Device.Backend.Config.Mirrors = mirrors
+	}
+	if len(caCerts) > 0 {
+		c.Device.Backend.Config.CACertFiles = caCerts
 	}
 	return nil
 }

--- a/config/daemonconfig/mirrors.go
+++ b/config/daemonconfig/mirrors.go
@@ -40,6 +40,7 @@ type hostConfig struct {
 	Host   string
 	Header http.Header
 
+	CACerts             []string
 	HealthCheckInterval int
 	FailureLimit        uint8
 	PingURL             string
@@ -138,8 +139,17 @@ func getSortedHosts(root *toml.Tree) ([]string, error) {
 	return list, nil
 }
 
+// makeAbsPath resolves a relative path p against base directory base.
+// Mirrors containerd's unexported helper of the same name.
+func makeAbsPath(p, base string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(base, p)
+}
+
 // parseHostConfig returns the parsed host configuration, make sure the server is not null.
-func parseHostConfig(server string, config HostFileConfig) (hostConfig, error) {
+func parseHostConfig(server string, config HostFileConfig, baseDir string) (hostConfig, error) {
 	var (
 		result = hostConfig{}
 		err    error
@@ -173,6 +183,23 @@ func parseHostConfig(server string, config HostFileConfig) (hostConfig, error) {
 		result.Header = header
 	}
 
+	if config.CACert != nil {
+		switch cert := config.CACert.(type) {
+		case string:
+			result.CACerts = []string{makeAbsPath(cert, baseDir)}
+		case []interface{}:
+			certs, err := makeStringSlice(cert, func(s string) string {
+				return makeAbsPath(s, baseDir)
+			})
+			if err != nil {
+				return hostConfig{}, fmt.Errorf("invalid type for ca: %w", err)
+			}
+			result.CACerts = certs
+		default:
+			return hostConfig{}, fmt.Errorf("invalid type %v for ca", config.CACert)
+		}
+	}
+
 	result.HealthCheckInterval = config.HealthCheckInterval
 	result.FailureLimit = config.FailureLimit
 	result.PingURL = config.PingURL
@@ -180,7 +207,7 @@ func parseHostConfig(server string, config HostFileConfig) (hostConfig, error) {
 	return result, nil
 }
 
-func parseHostsFile(b []byte) ([]hostConfig, error) {
+func parseHostsFile(b []byte, baseDir string) ([]hostConfig, error) {
 	tree, err := toml.LoadBytes(b)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse TOML: %w", err)
@@ -207,7 +234,7 @@ func parseHostsFile(b []byte) ([]hostConfig, error) {
 	for _, host := range orderedHosts {
 		if host != "" {
 			config := c.HostConfigs[host]
-			parsed, err := parseHostConfig(host, config)
+			parsed, err := parseHostConfig(host, config, baseDir)
 			if err != nil {
 				return nil, err
 			}
@@ -227,7 +254,7 @@ func loadHostDir(hostsDir string) ([]hostConfig, error) {
 		return []hostConfig{}, nil
 	}
 
-	hosts, err := parseHostsFile(b)
+	hosts, err := parseHostsFile(b, hostsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -235,25 +262,34 @@ func loadHostDir(hostsDir string) ([]hostConfig, error) {
 	return hosts, nil
 }
 
-func LoadMirrorsConfig(mirrorsConfigDir, registryHost string) ([]MirrorConfig, error) {
-	var mirrors []MirrorConfig
-
+func LoadMirrorsConfig(mirrorsConfigDir, registryHost string) ([]MirrorConfig, []string, error) {
 	if mirrorsConfigDir == "" {
-		return mirrors, nil
+		return nil, nil, nil
 	}
 	hostDir, err := hostDirFromRoot(mirrorsConfigDir, registryHost)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if hostDir == "" {
-		return mirrors, nil
+		return nil, nil, nil
 	}
 
-	hostConfig, err := loadHostDir(hostDir)
+	hosts, err := loadHostDir(hostDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	mirrors = append(mirrors, parseMirrorsConfig(hostConfig)...)
 
-	return mirrors, nil
+	// Collect CA certs from all host entries and deduplicate.
+	seen := make(map[string]struct{})
+	var caCerts []string
+	for _, h := range hosts {
+		for _, ca := range h.CACerts {
+			if _, ok := seen[ca]; !ok {
+				seen[ca] = struct{}{}
+				caCerts = append(caCerts, ca)
+			}
+		}
+	}
+
+	return parseMirrorsConfig(hosts), caCerts, nil
 }

--- a/config/daemonconfig/mirrors.go
+++ b/config/daemonconfig/mirrors.go
@@ -139,17 +139,8 @@ func getSortedHosts(root *toml.Tree) ([]string, error) {
 	return list, nil
 }
 
-// makeAbsPath resolves a relative path p against base directory base.
-// Mirrors containerd's unexported helper of the same name.
-func makeAbsPath(p, base string) string {
-	if filepath.IsAbs(p) {
-		return p
-	}
-	return filepath.Join(base, p)
-}
-
 // parseHostConfig returns the parsed host configuration, make sure the server is not null.
-func parseHostConfig(server string, config HostFileConfig, baseDir string) (hostConfig, error) {
+func parseHostConfig(server string, config HostFileConfig) (hostConfig, error) {
 	var (
 		result = hostConfig{}
 		err    error
@@ -186,11 +177,9 @@ func parseHostConfig(server string, config HostFileConfig, baseDir string) (host
 	if config.CACert != nil {
 		switch cert := config.CACert.(type) {
 		case string:
-			result.CACerts = []string{makeAbsPath(cert, baseDir)}
+			result.CACerts = []string{cert}
 		case []interface{}:
-			certs, err := makeStringSlice(cert, func(s string) string {
-				return makeAbsPath(s, baseDir)
-			})
+			certs, err := makeStringSlice(cert, nil)
 			if err != nil {
 				return hostConfig{}, fmt.Errorf("invalid type for ca: %w", err)
 			}
@@ -207,7 +196,7 @@ func parseHostConfig(server string, config HostFileConfig, baseDir string) (host
 	return result, nil
 }
 
-func parseHostsFile(b []byte, baseDir string) ([]hostConfig, error) {
+func parseHostsFile(b []byte) ([]hostConfig, error) {
 	tree, err := toml.LoadBytes(b)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse TOML: %w", err)
@@ -234,7 +223,7 @@ func parseHostsFile(b []byte, baseDir string) ([]hostConfig, error) {
 	for _, host := range orderedHosts {
 		if host != "" {
 			config := c.HostConfigs[host]
-			parsed, err := parseHostConfig(host, config, baseDir)
+			parsed, err := parseHostConfig(host, config)
 			if err != nil {
 				return nil, err
 			}
@@ -254,7 +243,7 @@ func loadHostDir(hostsDir string) ([]hostConfig, error) {
 		return []hostConfig{}, nil
 	}
 
-	hosts, err := parseHostsFile(b, hostsDir)
+	hosts, err := parseHostsFile(b)
 	if err != nil {
 		return nil, err
 	}

--- a/config/daemonconfig/mirrors_test.go
+++ b/config/daemonconfig/mirrors_test.go
@@ -38,25 +38,6 @@ func TestLoadMirrorConfigCACerts(t *testing.T) {
 		require.Equal(t, []string{caPath}, caCerts)
 	})
 
-	t.Run("single CA cert as relative path resolved against hosts dir", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		hostDir := filepath.Join(tmpDir, "certs.d", registryHost)
-		require.NoError(t, os.MkdirAll(hostDir, os.ModePerm))
-
-		caFile := "my-ca.pem"
-		require.NoError(t, os.WriteFile(filepath.Join(hostDir, caFile), []byte(""), 0600))
-
-		hosts := fmt.Sprintf(`
-[host."https://mirror.example.com"]
-  ca = %q
-`, caFile)
-		require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hosts), 0600))
-
-		_, caCerts, err := LoadMirrorsConfig(filepath.Join(tmpDir, "certs.d"), registryHost)
-		require.NoError(t, err)
-		require.Equal(t, []string{filepath.Join(hostDir, caFile)}, caCerts)
-	})
-
 	t.Run("multiple CA certs as array", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		hostDir := filepath.Join(tmpDir, "certs.d", registryHost)

--- a/config/daemonconfig/mirrors_test.go
+++ b/config/daemonconfig/mirrors_test.go
@@ -7,6 +7,7 @@
 package daemonconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,104 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoadMirrorConfigCACerts(t *testing.T) {
+	registryHost := "registry.example.com"
+
+	t.Run("single CA cert as absolute path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hostDir := filepath.Join(tmpDir, "certs.d", registryHost)
+		require.NoError(t, os.MkdirAll(hostDir, os.ModePerm))
+
+		caPath := filepath.Join(tmpDir, "my-ca.pem")
+		require.NoError(t, os.WriteFile(caPath, []byte(""), 0600))
+
+		hosts := fmt.Sprintf(`
+[host."https://mirror.example.com"]
+  ca = %q
+`, caPath)
+		require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hosts), 0600))
+
+		_, caCerts, err := LoadMirrorsConfig(filepath.Join(tmpDir, "certs.d"), registryHost)
+		require.NoError(t, err)
+		require.Equal(t, []string{caPath}, caCerts)
+	})
+
+	t.Run("single CA cert as relative path resolved against hosts dir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hostDir := filepath.Join(tmpDir, "certs.d", registryHost)
+		require.NoError(t, os.MkdirAll(hostDir, os.ModePerm))
+
+		caFile := "my-ca.pem"
+		require.NoError(t, os.WriteFile(filepath.Join(hostDir, caFile), []byte(""), 0600))
+
+		hosts := fmt.Sprintf(`
+[host."https://mirror.example.com"]
+  ca = %q
+`, caFile)
+		require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hosts), 0600))
+
+		_, caCerts, err := LoadMirrorsConfig(filepath.Join(tmpDir, "certs.d"), registryHost)
+		require.NoError(t, err)
+		require.Equal(t, []string{filepath.Join(hostDir, caFile)}, caCerts)
+	})
+
+	t.Run("multiple CA certs as array", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hostDir := filepath.Join(tmpDir, "certs.d", registryHost)
+		require.NoError(t, os.MkdirAll(hostDir, os.ModePerm))
+
+		ca1 := filepath.Join(tmpDir, "ca1.pem")
+		ca2 := filepath.Join(tmpDir, "ca2.pem")
+
+		hosts := fmt.Sprintf(`
+[host."https://mirror.example.com"]
+  ca = [%q, %q]
+`, ca1, ca2)
+		require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hosts), 0600))
+
+		_, caCerts, err := LoadMirrorsConfig(filepath.Join(tmpDir, "certs.d"), registryHost)
+		require.NoError(t, err)
+		require.Equal(t, []string{ca1, ca2}, caCerts)
+	})
+
+	t.Run("CA certs deduplicated across multiple hosts", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hostDir := filepath.Join(tmpDir, "certs.d", registryHost)
+		require.NoError(t, os.MkdirAll(hostDir, os.ModePerm))
+
+		ca1 := filepath.Join(tmpDir, "ca1.pem")
+		ca2 := filepath.Join(tmpDir, "ca2.pem")
+
+		hosts := fmt.Sprintf(`
+[host."https://mirror1.example.com"]
+  ca = %q
+
+[host."https://mirror2.example.com"]
+  ca = [%q, %q]
+`, ca1, ca1, ca2)
+		require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hosts), 0600))
+
+		_, caCerts, err := LoadMirrorsConfig(filepath.Join(tmpDir, "certs.d"), registryHost)
+		require.NoError(t, err)
+		require.Equal(t, []string{ca1, ca2}, caCerts)
+	})
+
+	t.Run("no CA cert field returns nil caCerts", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hostDir := filepath.Join(tmpDir, "certs.d", registryHost)
+		require.NoError(t, os.MkdirAll(hostDir, os.ModePerm))
+
+		hosts := `
+[host."https://mirror.example.com"]
+`
+		require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hosts), 0600))
+
+		_, caCerts, err := LoadMirrorsConfig(filepath.Join(tmpDir, "certs.d"), registryHost)
+		require.NoError(t, err)
+		require.Nil(t, caCerts)
+	})
+}
 
 func TestLoadMirrorConfig(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -25,18 +124,18 @@ func TestLoadMirrorConfig(t *testing.T) {
 	registryHostConfigDir := filepath.Join(mirrorsConfigDir, registryHost)
 	defaultHostConfigDir := filepath.Join(mirrorsConfigDir, "_default")
 
-	mirrors, err := LoadMirrorsConfig("", registryHost)
+	mirrors, _, err := LoadMirrorsConfig("", registryHost)
 	require.NoError(t, err)
 	require.Nil(t, mirrors)
 
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	mirrors, _, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	require.NoError(t, err)
 	require.Nil(t, mirrors)
 
 	err = os.MkdirAll(defaultHostConfigDir, os.ModePerm)
 	assert.NoError(t, err)
 
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	mirrors, _, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	require.NoError(t, err)
 	require.Nil(t, mirrors)
 
@@ -48,7 +147,7 @@ func TestLoadMirrorConfig(t *testing.T) {
 	`)
 	err = os.WriteFile(filepath.Join(defaultHostConfigDir, "hosts.toml"), buf1, 0600)
 	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	mirrors, _, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	require.NoError(t, err)
 	require.Equal(t, len(mirrors), 1)
 	require.Equal(t, mirrors[0].Host, "http://default-p2p-mirror1:65001")
@@ -65,7 +164,7 @@ func TestLoadMirrorConfig(t *testing.T) {
 	`)
 	err = os.WriteFile(filepath.Join(registryHostConfigDir, "hosts.toml"), buf2, 0600)
 	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	mirrors, _, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	require.NoError(t, err)
 	require.Equal(t, len(mirrors), 1)
 	require.Equal(t, mirrors[0].Host, "http://p2p-mirror1:65001")
@@ -78,7 +177,7 @@ func TestLoadMirrorConfig(t *testing.T) {
 	`)
 	err = os.WriteFile(filepath.Join(registryHostConfigDir, "hosts.toml"), buf3, 0600)
 	assert.NoError(t, err)
-	mirrors, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
+	mirrors, _, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	require.NoError(t, err)
 	require.Equal(t, len(mirrors), 1)
 	require.Equal(t, mirrors[0].Host, "http://p2p-mirror2:65001")

--- a/config/daemonconfig/mirrors_test.go
+++ b/config/daemonconfig/mirrors_test.go
@@ -118,7 +118,7 @@ func TestLoadMirrorConfig(t *testing.T) {
 
 	mirrors, _, err = LoadMirrorsConfig(mirrorsConfigDir, registryHost)
 	require.NoError(t, err)
-	require.Nil(t, mirrors)
+	require.Equal(t, len(mirrors), 0)
 
 	buf1 := []byte(`server = "https://default-docker.hub.com"
 	[host]


### PR DESCRIPTION
## Overview

In containerd, the hosts.toml file contains [ca](https://github.com/containerd/containerd/blob/main/docs/hosts.md#ca-field) attribute to trust some additionals CAs 

This PR reads the configuration from 
 
## Related Issues
* It is the nydus-snapshotter part of https://github.com/dragonflyoss/nydus/issues/1924 
* It is related to https://github.com/containerd/nydus-snapshotter/issues/732 as it modify the obsolete mirror code feature that will be replaced

## Change Details

Remarks on the ca field : 
* ca attribute in hosts.toml  can be a string scalar or a string array 
* consider ca attributes to be absolute (and don't handling case of being relative to containerd current directory) 

The code will change a bit when the daemon mirror code will be removed 

## Test Results

See https://github.com/dragonflyoss/nydus/pull/1925 for the test made. 

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [X] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.