### PR TITLE
ci: bump actions/checkout from v4 to v6 (#724)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -104,7 +104,7 @@ jobs:
         GOARCH: ["amd64", "arm64"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -121,7 +121,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup Golang

--- a/.github/workflows/optimizer.yml
+++ b/.github/workflows/optimizer.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             build-arch: static
             build-linker: static
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -113,7 +113,7 @@ jobs:
             build-arch: ppc64le
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Refs #724.

## What changed

Bumped \`actions/checkout\` from \`@v4\` to \`@v6\` across all 13 occurrences in the five workflow files:

| Workflow | Jobs touched |
|---|---|
| ci.yml | 6 |
| e2e.yml | 2 |
| k8s-e2e.yml | 1 |
| optimizer.yml | 1 |
| release.yml | 3 |

## Why this matters

actions/checkout@v4 runs on Node.js 20, which GitHub flagged as deprecated in the warning quoted in #724:

> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

actions/checkout@v6 runs on Node.js 24 and is the current stable major. Bumping it now lets the CI surface real failures (if any) before the forced cutover instead of hitting them at the deadline.

## Out of scope

The issue also lists \`azure/setup-helm@v4\`, but that action is not currently used by any workflow in main. It's coming in via the open Helm chart PR (#719). When that PR lands, the same v4→v5 bump can be applied there or as a focused follow-up — keeping it out of this PR avoids cross-branch entanglement.

This PR also leaves the v4-pinned \`actions/cache\`, \`actions/upload-artifact\`, and \`actions/download-artifact\` alone. Those are still on Node.js 20 and will need their own bump when stable v5 majors land, but they're a different upstream-driven cadence than checkout's release schedule.