### PR TITLE
[daemonconfig] Write config file atomically

### DIFF
--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -127,11 +127,6 @@ type DeviceConfig struct {
 // For nydusd as FUSE daemon. Serialize Daemon info and persist to a json file
 // We don't have to persist configuration file for fscache since its configuration
 // is passed through HTTP API.
-//
-// The write is atomic: contents are written to a tmp file in the same directory
-// and renamed over the target. A concurrent reader, or a reader after the
-// snapshotter is killed mid-write, will see either the previous contents or
-// the new contents, never a truncated/empty file.
 func DumpConfigFile(c interface{}, path string) error {
 	if config.IsBackendSourceEnabled() {
 		c = serializeWithSecretFilter(c)
@@ -141,9 +136,17 @@ func DumpConfigFile(c interface{}, path string) error {
 		return errors.Wrapf(err, "marshal config")
 	}
 
+	return atomicWriteFile(path, b)
+}
+
+// atomicWriteFile writes data to a tmp file in the same directory as path and
+// renames it over path. A concurrent reader, or a reader after the process is
+// killed mid-write, sees either the previous contents or the new contents,
+// never a truncated/empty file.
+func atomicWriteFile(path string, data []byte) (err error) {
 	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
 	if err != nil {
-		return errors.Wrapf(err, "create tmp config in %s", filepath.Dir(path))
+		return errors.Wrapf(err, "create tmp file in %s", filepath.Dir(path))
 	}
 	tmpPath := tmp.Name()
 	defer func() {
@@ -152,15 +155,15 @@ func DumpConfigFile(c interface{}, path string) error {
 		}
 	}()
 
-	if _, err = tmp.Write(b); err != nil {
+	if _, err = tmp.Write(data); err != nil {
 		tmp.Close()
-		return errors.Wrapf(err, "write tmp config %s", tmpPath)
+		return errors.Wrapf(err, "write tmp file %s", tmpPath)
 	}
 	if err = tmp.Close(); err != nil {
-		return errors.Wrapf(err, "close tmp config %s", tmpPath)
+		return errors.Wrapf(err, "close tmp file %s", tmpPath)
 	}
 	if err = os.Rename(tmpPath, path); err != nil {
-		return errors.Wrapf(err, "rename tmp config to %s", path)
+		return errors.Wrapf(err, "rename tmp file to %s", path)
 	}
 	return nil
 }

--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -126,6 +127,11 @@ type DeviceConfig struct {
 // For nydusd as FUSE daemon. Serialize Daemon info and persist to a json file
 // We don't have to persist configuration file for fscache since its configuration
 // is passed through HTTP API.
+//
+// The write is atomic: contents are written to a tmp file in the same directory
+// and renamed over the target. A concurrent reader, or a reader after the
+// snapshotter is killed mid-write, will see either the previous contents or
+// the new contents, never a truncated/empty file.
 func DumpConfigFile(c interface{}, path string) error {
 	if config.IsBackendSourceEnabled() {
 		c = serializeWithSecretFilter(c)
@@ -135,7 +141,28 @@ func DumpConfigFile(c interface{}, path string) error {
 		return errors.Wrapf(err, "marshal config")
 	}
 
-	return os.WriteFile(path, b, 0600)
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return errors.Wrapf(err, "create tmp config in %s", filepath.Dir(path))
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if err != nil {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = tmp.Write(b); err != nil {
+		tmp.Close()
+		return errors.Wrapf(err, "write tmp config %s", tmpPath)
+	}
+	if err = tmp.Close(); err != nil {
+		return errors.Wrapf(err, "close tmp config %s", tmpPath)
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		return errors.Wrapf(err, "rename tmp config to %s", path)
+	}
+	return nil
 }
 
 func DumpConfigString(c interface{}) (string, error) {


### PR DESCRIPTION
## Overview
`DumpConfigFile` writes the daemon JSON config via `os.WriteFile`, which truncates the target before writing the new contents. If the snapshotter is killed mid-write, or if a concurrent writer races on the same path, the file can be left empty or partial, breaking subsequent loads by the snapshotter or by nydusd.

This PR switches the write to a tmp-file + `rename(2)` pattern so the swap is atomic: readers always observe either the previous or the new contents.

## Related Issues
N/A

## Change Details
- Write the JSON to a tmp file created via `os.CreateTemp` in the same directory as the target.
- `os.Rename` over the target. Same-filesystem rename is atomic on Linux.
- On error, the tmp file is removed by a deferred cleanup.
- `os.CreateTemp` creates the tmp file with mode `0600`, matching the previous permissions.

## Test Results
- `make build` passes.
- `go test ./config/daemonconfig/... ./pkg/daemon/...` passes.
- `go vet` passes.

## Change Type
- [x] Bug Fix

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.