### PR TITLE
ci: declare workflow-level `contents: read` on ci and e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   security:
     name: Security scan

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,9 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
 
+permissions:
+  contents: read
+
 jobs:
   run-e2e-for-cgroups-v1:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Both workflows run build / e2e tests; no GitHub API writes from the workflows.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.