### PR TITLE
fix: build release binaries statically to avoid glibc relocation errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           if [ "${{ matrix.build-arch }}" == "static" ]; then
             make static-package
           else
-            make package GOOS=${{ matrix.build-os }} GOARCH=${{ matrix.build-arch }}
+            CGO_ENABLED=0 make package GOOS=${{ matrix.build-os }} GOARCH=${{ matrix.build-arch }}
           fi
       - name: upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Overview

Builds the per-arch release binaries with `CGO_ENABLED=0` so the published 0.15.x images, which run on a musl/alpine base, no longer fail with glibc `__vfprintf_chk` relocation errors.

## Related Issues

Fixes #748

## Change Details

The release workflow built the per-arch `make package` targets with cgo enabled, producing glibc-dynamically-linked binaries. Run on the musl/alpine image base, the dynamic loader fails on glibc-specific relocations such as `__vfprintf_chk`. Setting `CGO_ENABLED=0` for the `make package` step produces statically-linked, libc-independent binaries (the same approach the existing `static-package` matrix arm already uses), so the images run on alpine. @imeoer diagnosed this root cause and invited the fix.

## Test Results

This is a release-workflow change exercised by the release pipeline. The fix mirrors the existing `static-package` arm's static-linking approach, so the produced binaries no longer depend on glibc at runtime.

## Change Type

- [x] Bug Fix

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors (single-line workflow edit)
- [x] I have added appropriate comments to my code (n/a, one-line build-flag change)
- [x] I have updated the documentation (n/a, no user-facing docs affected)
- [x] I have written appropriate unit tests (n/a, a CI build-flag change is exercised by the release pipeline, not unit tests)
