### PR TITLE
feat: support stream_prefetch in fs_prefetch config

### DIFF
--- a/config/daemonconfig/daemonconfig_test.go
+++ b/config/daemonconfig/daemonconfig_test.go
@@ -50,7 +50,8 @@ func TestLoadConfig(t *testing.T) {
   "fs_prefetch": {
     "enable": true,
     "threads_count": 10,
-    "merging_size": 131072
+    "merging_size": 131072,
+    "stream_prefetch": true
   }
 }`)
 	var cfg FuseDaemonConfig
@@ -59,6 +60,7 @@ func TestLoadConfig(t *testing.T) {
 	require.Equal(t, cfg.Enable, true)
 	require.Equal(t, cfg.MergingSize, 131072)
 	require.Equal(t, cfg.ThreadsCount, 10)
+	require.Equal(t, cfg.StreamPrefetch, true)
 	require.Equal(t, cfg.Device.Backend.Config.BlobURLScheme, "http")
 	require.Equal(t, cfg.Device.Backend.Config.SkipVerify, true)
 	require.Equal(t, cfg.Device.Backend.Config.Proxy.CheckInterval, 5)

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -35,11 +35,12 @@ type FuseDaemonConfig struct {
 
 // Control how to perform prefetch from file system layer
 type FSPrefetch struct {
-	Enable        bool `json:"enable"`
-	PrefetchAll   bool `json:"prefetch_all"`
-	ThreadsCount  int  `json:"threads_count,omitempty"`
-	MergingSize   int  `json:"merging_size,omitempty"`
-	BandwidthRate int  `json:"bandwidth_rate,omitempty"`
+	Enable         bool `json:"enable"`
+	PrefetchAll    bool `json:"prefetch_all"`
+	ThreadsCount   int  `json:"threads_count,omitempty"`
+	MergingSize    int  `json:"merging_size,omitempty"`
+	BandwidthRate  int  `json:"bandwidth_rate,omitempty"`
+	StreamPrefetch bool `json:"stream_prefetch,omitempty"`
 }
 
 // Load fuse daemon configuration from template file


### PR DESCRIPTION
## What this PR does

Adds the `stream_prefetch` field to the FUSE daemon config's `FSPrefetch`
(`fs_prefetch`) struct.

## Why

nydusd's `FsPrefetchControl` config accepts a `stream_prefetch` field
(introduced in nydus v2.4.3). The snapshotter unmarshals the user-supplied
daemon config into `FSPrefetch` and re-serializes it before handing it to
nydusd. Since `FSPrefetch` had no field for `stream_prefetch`, the key was
silently dropped during the unmarshal/marshal round-trip, so users who set
`stream_prefetch` in their config saw it have no effect.

## Changes

- Add `StreamPrefetch bool` (json: `stream_prefetch`, `omitempty`) to `FSPrefetch`.
- Cover the field in `TestLoadConfig`.

`omitempty` keeps the output unchanged for configs that don't set the field,
so this is backward compatible with older nydusd.

## How to verify

Set `"stream_prefetch": true` under `fs_prefetch` in the nydusd config and
confirm it now propagates to the config nydusd actually receives.