### PR TITLE
ci: bump softprops/action-gh-release to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           path: builds
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: "Nydus Snapshotter ${{ github.ref_name }} Release"
           generate_release_notes: true


### PR DESCRIPTION
## Overview
Bumps `softprops/action-gh-release` from v1 to v2 in the release workflow. v1 runs on Node.js 20; v2 runs on Node.js 24.

## Related Issues
Fixes #724

## Change Details
`softprops/action-gh-release@v1` was the last remaining Node.js 20-era GitHub Action in `.github/workflows/release.yml`. The rest of #724 is already addressed: every `actions/checkout` is on `@v6` and `azure/setup-helm` has been removed from the workflow tree. Bumping this single action to `@v2` clears the final Node.js 20 deprecation warning. The `name`, `generate_release_notes`, and `files` inputs already in use are all supported unchanged in v2, so no other changes are needed.

## Test Results
No functional change to the release output. Verified by grep that `softprops/action-gh-release` now resolves only to `@v2` and that no other `@v1` JavaScript action remains in `.github/workflows/`.

## Change Type
- [x] Other (CI maintenance: GitHub Actions version bump)

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (not applicable: workflow version bump).
- [x] I have updated the documentation (not applicable).
- [x] I have written appropriate unit tests (not applicable: CI workflow change).
