### PR TITLE
fix: remove snapshotter blob cache after fscache unbind

### DIFF
--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -637,7 +637,6 @@ func (fs *Filesystem) RemoveCache(blobDigest string) error {
 			if err := c.UnbindBlob("", blobID); err != nil {
 				return err
 			}
-			return nil
 		}
 	}
 


### PR DESCRIPTION
## Overview
When fscache is enabled, RemoveCache returns immediately after asking nydusd to unbind the blob. Continue to remove the snapshotter-managed blob cache files as well.

## Related Issues
Fixes #760 

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [x] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.