### PR TITLE
fix(snapshot): clean up fscache snapshots asynchronously

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -368,7 +368,10 @@ func (d *Daemon) sharedErofsUmount(ra *rafs.Rafs) error {
 	fscacheID := ra.Annotations[rafs.AnnoFsCacheID]
 
 	if err := c.UnbindBlob(domainID, fscacheID); err != nil {
-		return errors.Wrapf(err, "request to unbind fscache blob, domain %s, fscache %s", domainID, fscacheID)
+		if !isBlobCacheEntryNotFound(err) {
+			return errors.Wrapf(err, "request to unbind fscache blob, domain %s, fscache %s", domainID, fscacheID)
+		}
+		log.L.Warnf("ignore missing blob cache entry while unbinding domain %s, fscache %s", domainID, fscacheID)
 	}
 
 	mountpoint := ra.GetMountpoint()
@@ -383,6 +386,10 @@ func (d *Daemon) sharedErofsUmount(ra *rafs.Rafs) error {
 	}
 
 	return nil
+}
+
+func isBlobCacheEntryNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "blob_cache: cache entry not found")
 }
 
 func (d *Daemon) UmountRafsInstance(r *rafs.Rafs) error {

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -716,6 +716,9 @@ func (fs *Filesystem) umountRafsInstance(rafs *racache.Rafs) error {
 
 		daemon, daemonErr := fs.getDaemonByRafs(rafs)
 		if daemonErr == nil {
+			if err := daemon.UmountRafsInstance(rafs); err != nil {
+				return errors.Wrapf(err, "umount instance %s", rafs.SnapshotID)
+			}
 			daemon.RemoveRafsInstance(rafs.SnapshotID)
 		} else {
 			log.L.Debugf("snapshot %s has no associated nydusd: %v", rafs.SnapshotID, daemonErr)
@@ -725,9 +728,6 @@ func (fs *Filesystem) umountRafsInstance(rafs *racache.Rafs) error {
 			log.L.WithError(err).Warnf("remove rafs %s from store", rafs.SnapshotID)
 		}
 		if daemonErr == nil {
-			if err := daemon.UmountRafsInstance(rafs); err != nil {
-				log.L.WithError(err).Warnf("umount instance %s", rafs.SnapshotID)
-			}
 			if daemon.IsSharedDaemon() {
 				fs.cleanUpSharedRafsResources(daemon.ID(), rafs)
 			}

--- a/snapshot/cleanup_queue.go
+++ b/snapshot/cleanup_queue.go
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package snapshot
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/containerd/log"
+)
+
+type snapshotCleanupTask struct {
+	dir        string
+	key        string
+	snapshotID string
+	done       chan struct{}
+}
+
+type snapshotCleanupQueue struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	tasks   []snapshotCleanupTask
+	head    int
+	pending map[string]chan struct{}
+	closed  bool
+	cleanup func(context.Context, string) error
+}
+
+func newSnapshotCleanupQueue(cleanup func(context.Context, string) error) *snapshotCleanupQueue {
+	q := &snapshotCleanupQueue{
+		pending: make(map[string]chan struct{}),
+		cleanup: cleanup,
+	}
+	q.cond = sync.NewCond(&q.mu)
+
+	go q.run()
+	return q
+}
+
+func (q *snapshotCleanupQueue) enqueue(dir, key string) {
+	q.enqueueTask(dir, key)
+}
+
+func (q *snapshotCleanupQueue) enqueueAndWait(ctx context.Context, dir, key string) error {
+	done := q.enqueueTask(dir, key)
+	if done == nil {
+		return nil
+	}
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (q *snapshotCleanupQueue) enqueueTask(dir, key string) <-chan struct{} {
+	if dir == "" {
+		return nil
+	}
+
+	task := snapshotCleanupTask{
+		dir:        dir,
+		key:        key,
+		snapshotID: filepath.Base(dir),
+		done:       make(chan struct{}),
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.closed {
+		log.L.Warnf("snapshot cleanup queue is closed snapshot_id=%s dir=%s key=%s",
+			task.snapshotID, task.dir, task.key)
+		return nil
+	}
+
+	if done, ok := q.pending[task.snapshotID]; ok {
+		log.L.Debugf("snapshot cleanup task already pending snapshot_id=%s dir=%s key=%s",
+			task.snapshotID, task.dir, task.key)
+		return done
+	}
+
+	q.pending[task.snapshotID] = task.done
+	q.tasks = append(q.tasks, task)
+	log.L.Infof("queued async snapshot cleanup snapshot_id=%s dir=%s key=%s queue_depth=%d",
+		task.snapshotID, task.dir, task.key, len(q.tasks)-q.head)
+	q.cond.Signal()
+	return task.done
+}
+
+func (q *snapshotCleanupQueue) close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if !q.closed {
+		q.closed = true
+		for i := q.head; i < len(q.tasks); i++ {
+			task := q.tasks[i]
+			delete(q.pending, task.snapshotID)
+			close(task.done)
+		}
+		q.tasks = nil
+		q.head = 0
+		q.cond.Broadcast()
+	}
+}
+
+func (q *snapshotCleanupQueue) run() {
+	for {
+		task, ok := q.next()
+		if !ok {
+			return
+		}
+		if q.isClosed() {
+			q.finish(task)
+			return
+		}
+		q.runTask(task)
+	}
+}
+
+func (q *snapshotCleanupQueue) next() (snapshotCleanupTask, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for q.head >= len(q.tasks) && !q.closed {
+		q.cond.Wait()
+	}
+	if q.head >= len(q.tasks) && q.closed {
+		return snapshotCleanupTask{}, false
+	}
+
+	task := q.tasks[q.head]
+	q.tasks[q.head] = snapshotCleanupTask{}
+	q.head++
+	if q.head == len(q.tasks) {
+		q.tasks = nil
+		q.head = 0
+	}
+	return task, true
+}
+
+func (q *snapshotCleanupQueue) isClosed() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.closed
+}
+
+func (q *snapshotCleanupQueue) runTask(task snapshotCleanupTask) {
+	defer q.finish(task)
+
+	start := time.Now()
+	log.L.Infof("async snapshot cleanup begin snapshot_id=%s dir=%s key=%s",
+		task.snapshotID, task.dir, task.key)
+
+	if err := q.cleanup(context.Background(), task.dir); err != nil {
+		log.L.WithError(err).Warnf("async snapshot cleanup failed snapshot_id=%s dir=%s key=%s duration=%s",
+			task.snapshotID, task.dir, task.key, time.Since(start))
+		return
+	}
+
+	log.L.Infof("async snapshot cleanup done snapshot_id=%s dir=%s key=%s duration=%s",
+		task.snapshotID, task.dir, task.key, time.Since(start))
+}
+
+func (q *snapshotCleanupQueue) finish(task snapshotCleanupTask) {
+	q.mu.Lock()
+	delete(q.pending, task.snapshotID)
+	q.mu.Unlock()
+	close(task.done)
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -63,6 +63,7 @@ type snapshotter struct {
 	syncRemove              bool
 	cleanupOnClose          bool
 	enableOverlayfsVolatile bool
+	cleanupQueue            *snapshotCleanupQueue
 }
 
 func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapshots.Snapshotter, error) {
@@ -297,12 +298,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 
 	syncRemove := cfg.SnapshotsConfig.SyncRemove
-	if config.GetFsDriver() == config.FsDriverFscache {
-		log.L.Infof("enable syncRemove for fscache mode")
-		syncRemove = true
-	}
-
-	return &snapshotter{
+	sn := &snapshotter{
 		root:                    cfg.Root,
 		nydusdPath:              cfg.DaemonConfig.NydusdPath,
 		ms:                      ms,
@@ -314,7 +310,13 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 		enableKataVolume:        cfg.SnapshotsConfig.EnableKataVolume,
 		enableOverlayfsVolatile: cfg.SnapshotsConfig.EnableOverlayfsVolatile,
 		cleanupOnClose:          cfg.CleanupOnClose,
-	}, nil
+	}
+	if config.GetFsDriver() == config.FsDriverFscache && !syncRemove {
+		log.L.Infof("enable async snapshot cleanup for fscache mode")
+		sn.cleanupQueue = newSnapshotCleanupQueue(sn.cleanupSnapshotDirectory)
+	}
+
+	return sn, nil
 }
 
 func (o *snapshotter) Cleanup(ctx context.Context) error {
@@ -331,6 +333,12 @@ func (o *snapshotter) Cleanup(ctx context.Context) error {
 	log.L.Infof("[Cleanup] orphan directories %v", cleanup)
 
 	for _, dir := range cleanup {
+		if o.cleanupQueue != nil {
+			if err := o.cleanupQueue.enqueueAndWait(ctx, dir, "cleanup"); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := o.cleanupSnapshotDirectory(ctx, dir); err != nil {
 			log.L.WithError(err).Warnf("failed to remove directory %s", dir)
 		}
@@ -682,7 +690,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		return errors.Wrapf(err, "failed to remove key %s", key)
 	}
 
-	if o.syncRemove {
+	if o.cleanupQueue == nil && o.syncRemove {
 		var removals []string
 		removals, err = o.getCleanupDirectories(ctx)
 		if err != nil {
@@ -711,7 +719,14 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		}
 	}()
 
-	return t.Commit()
+	if err = t.Commit(); err != nil {
+		return err
+	}
+
+	if o.cleanupQueue != nil {
+		o.cleanupQueue.enqueue(o.snapshotDir(id), key)
+	}
+	return nil
 }
 
 func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...string) error {
@@ -730,6 +745,10 @@ func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...str
 
 func (o *snapshotter) Close() error {
 	log.L.Info("[Close] shutdown snapshotter")
+
+	if o.cleanupQueue != nil {
+		o.cleanupQueue.close()
+	}
 
 	if o.cleanupOnClose {
 		err := o.fs.Teardown(context.Background())
@@ -1351,6 +1370,7 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 	snapshotID := filepath.Base(dir)
 	if err := o.fs.Umount(ctx, snapshotID); err != nil && !os.IsNotExist(err) {
 		log.G(ctx).WithError(err).WithField("dir", dir).Error("failed to unmount")
+		return errors.Wrapf(err, "unmount snapshot directory %q", dir)
 	}
 
 	if o.fs.TarfsEnabled() {


### PR DESCRIPTION
## Overview
Run fscache snapshot directory cleanup after metadata removal has been committed. This keeps slow unmount, tarfs detach, and RemoveAll work out of Remove's critical path.

## Related Issues
Fixes #761 

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [x] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.