### PR TITLE
[Feat] Support user-namespace UID/GID remap-ids for fusedev

### DIFF
--- a/config/daemonconfig/daemonconfig.go
+++ b/config/daemonconfig/daemonconfig.go
@@ -43,6 +43,9 @@ type DaemonConfig interface {
 	StorageBackend() (StorageBackendType, *BackendConfig)
 	DumpString() (string, error)
 	DumpFile(path string) error
+	// SetIDMapping sets the UID/GID mapping tuple (internal, external, range)
+	// for user-namespace remap-ids support. A nil value clears any mapping.
+	SetIDMapping(m *[3]uint32)
 }
 
 // Daemon configurations factory

--- a/config/daemonconfig/daemonconfig_test.go
+++ b/config/daemonconfig/daemonconfig_test.go
@@ -66,33 +66,60 @@ func TestLoadConfig(t *testing.T) {
 	require.Equal(t, cfg.Device.Backend.Config.Proxy.CheckInterval, 5)
 }
 
-func TestAmplifyIo(t *testing.T) {
-	// Test non-zero value
-	input1 := []byte(`{"amplify_io": 1048576}`)
-	var cfg1 FuseDaemonConfig
-	err1 := json.Unmarshal(input1, &cfg1)
-	require.Nil(t, err1)
-	require.Equal(t, *cfg1.AmplifyIo, 1048576)
-	output1, _ := json.Marshal(cfg1)
-	require.Contains(t, string(output1), `"amplify_io":1048576`)
+func TestFuseDaemonConfigOptionalFields(t *testing.T) {
+	t.Run("amplify_io non-zero", func(t *testing.T) {
+		input := []byte(`{"amplify_io": 1048576}`)
+		var cfg FuseDaemonConfig
+		err := json.Unmarshal(input, &cfg)
+		require.Nil(t, err)
+		require.Equal(t, *cfg.AmplifyIo, 1048576)
+		output, _ := json.Marshal(cfg)
+		require.Contains(t, string(output), `"amplify_io":1048576`)
+	})
 
-	// Test zero value
-	input2 := []byte(`{"amplify_io": 0}`)
-	var cfg2 FuseDaemonConfig
-	err2 := json.Unmarshal(input2, &cfg2)
-	require.Nil(t, err2)
-	require.Equal(t, *cfg2.AmplifyIo, 0)
-	output2, _ := json.Marshal(cfg2)
-	require.Contains(t, string(output2), `"amplify_io":0`)
+	t.Run("amplify_io zero", func(t *testing.T) {
+		input := []byte(`{"amplify_io": 0}`)
+		var cfg FuseDaemonConfig
+		err := json.Unmarshal(input, &cfg)
+		require.Nil(t, err)
+		require.Equal(t, *cfg.AmplifyIo, 0)
+		output, _ := json.Marshal(cfg)
+		require.Contains(t, string(output), `"amplify_io":0`)
+	})
 
-	// Test nil value
-	input3 := []byte(`{}`)
-	var cfg3 FuseDaemonConfig
-	err3 := json.Unmarshal(input3, &cfg3)
-	require.Nil(t, err3)
-	require.Nil(t, cfg3.AmplifyIo)
-	output3, _ := json.Marshal(cfg3)
-	require.NotContains(t, string(output3), `amplify_io`)
+	t.Run("amplify_io nil", func(t *testing.T) {
+		input := []byte(`{}`)
+		var cfg FuseDaemonConfig
+		err := json.Unmarshal(input, &cfg)
+		require.Nil(t, err)
+		require.Nil(t, cfg.AmplifyIo)
+		output, _ := json.Marshal(cfg)
+		require.NotContains(t, string(output), `amplify_io`)
+	})
+
+	t.Run("id_mapping round-trip", func(t *testing.T) {
+		// Must serialize as a 3-element JSON array matching nydusd's
+		// `RafsConfigV2.id_mapping` (u32, u32, u32) tuple.
+		cfg := FuseDaemonConfig{Mode: "direct"}
+		cfg.SetIDMapping(&[3]uint32{0, 100000, 65536})
+
+		b, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		require.Contains(t, string(b), `"id_mapping":[0,100000,65536]`)
+
+		var restored FuseDaemonConfig
+		err = json.Unmarshal(b, &restored)
+		require.NoError(t, err)
+		require.NotNil(t, restored.IDMapping)
+		require.Equal(t, [3]uint32{0, 100000, 65536}, *restored.IDMapping)
+	})
+
+	t.Run("id_mapping unset omitted", func(t *testing.T) {
+		cfg := FuseDaemonConfig{Mode: "direct"}
+		b, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		require.NotContains(t, string(b), "id_mapping")
+	})
 }
 
 func TestSerializeWithSecretFilter(t *testing.T) {

--- a/config/daemonconfig/fscache.go
+++ b/config/daemonconfig/fscache.go
@@ -112,6 +112,13 @@ func (c *FscacheDaemonConfig) FillAuth(kc *auth.PassKeyChain) {
 	}
 }
 
+// SetIDMapping is a no-op: idmap is currently not initialized/applied for the fscache driver in this layer.
+func (c *FscacheDaemonConfig) SetIDMapping(m *[3]uint32) {
+	if m != nil {
+		log.L.Warnf("nydus idmap: id_mapping is not supported by the fscache driver, ignoring")
+	}
+}
+
 func (c *FscacheDaemonConfig) DumpString() (string, error) {
 	return DumpConfigString(c)
 }

--- a/config/daemonconfig/fuse.go
+++ b/config/daemonconfig/fuse.go
@@ -31,6 +31,10 @@ type FuseDaemonConfig struct {
 	FSPrefetch      `json:"fs_prefetch,omitempty"`
 	// (experimental) The nydus daemon could cache more data to increase hit ratio when enabled the warmup feature.
 	Warmup uint64 `json:"warmup,omitempty"`
+	// UID/GID mapping tuple (internal, external, range) for user-namespace
+	// remap-ids support. Serialized as a 3-element JSON array to match nydusd's
+	// `RafsConfigV2.id_mapping` tuple. Omitted when no mapping is configured.
+	IDMapping *[3]uint32 `json:"id_mapping,omitempty"`
 }
 
 // Control how to perform prefetch from file system layer
@@ -87,6 +91,10 @@ func (c *FuseDaemonConfig) FillAuth(kc *auth.PassKeyChain) {
 
 func (c *FuseDaemonConfig) StorageBackend() (string, *BackendConfig) {
 	return c.Device.Backend.BackendType, &c.Device.Backend.Config
+}
+
+func (c *FuseDaemonConfig) SetIDMapping(m *[3]uint32) {
+	c.IDMapping = m
 }
 
 func (c *FuseDaemonConfig) DumpString() (string, error) {

--- a/misc/example/containerd-config.toml
+++ b/misc/example/containerd-config.toml
@@ -23,4 +23,5 @@ oom_score = 0
   [proxy_plugins.nydus]
       type = "snapshot"
       address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+      capabilities = ["remap-ids"]
 

--- a/misc/example/containerd-test-config.toml
+++ b/misc/example/containerd-test-config.toml
@@ -26,3 +26,4 @@ oom_score = 0
   [proxy_plugins.nydus]
       type = "snapshot"
       address = "/var/lib/containerd-test/io.containerd.snapshotter.v1.nydus/containerd-nydus-grpc.sock"
+      capabilities = ["remap-ids"]

--- a/misc/optimizer/containerd-config.toml
+++ b/misc/optimizer/containerd-config.toml
@@ -18,6 +18,7 @@ version = 2
   [proxy_plugins.nydus]
     type = "snapshot"
     address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+    capabilities = ["remap-ids"]
 
 [plugins."io.containerd.nri.v1.nri"]
   config_file = "/etc/nri/nri.conf"

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -12,6 +12,7 @@ package filesystem
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -248,14 +249,19 @@ func (fs *Filesystem) TryStopSharedDaemon() {
 
 // WaitUntilReady wait until daemon ready by snapshotID, it will wait until nydus domain socket established
 // and the status of nydusd daemon must be ready
-func (fs *Filesystem) WaitUntilReady(snapshotID string) error {
-	rafs := racache.RafsGlobalCache.Get(snapshotID)
+func (fs *Filesystem) WaitUntilReady(snapshotID string, labels map[string]string) error {
+	rafsKey, err := label.RafsInstanceIDFromLabels(snapshotID, labels)
+	if err != nil {
+		return errors.Wrapf(err, "parse id mapping for snapshot %s", snapshotID)
+	}
+
+	rafs := racache.RafsGlobalCache.Get(rafsKey)
 	if rafs == nil {
 		// If NoneDaemon mode, there's no need to wait for daemon ready
 		if config.GetDaemonMode() == config.DaemonModeNone {
 			return nil
 		}
-		return errors.Wrapf(errdefs.ErrNotFound, "no instance %s", snapshotID)
+		return errors.Wrapf(errdefs.ErrNotFound, "no instance %s", rafsKey)
 	}
 
 	if rafs.GetFsDriver() == config.FsDriverFscache || rafs.GetFsDriver() == config.FsDriverFusedev {
@@ -321,19 +327,43 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 	mu.Lock()
 	defer mu.Unlock()
 
-	rafs := racache.RafsGlobalCache.Get(snapshotID)
-	if rafs != nil {
-		// Instance already exists, how could this happen? Can containerd handle this case?
-		return nil
+	// Parse id-mapping labels early so each pod with a distinct UID range
+	// gets its own RAFS instance (per-pod rafsKey includes the mapping suffix).
+	// A shared daemon has a single id_mapping config, so different pods
+	// cannot reuse the same FUSE mount.
+	idMapping, err := label.ParseIDMapping(labels)
+	if err != nil {
+		return errors.Wrapf(err, "parse id mapping for snapshot %s", snapshotID)
 	}
+
+	// Per-pod rafs cache key: two pods sharing the same image but with
+	// different user-namespace mappings get separate rafs instances.
+	rafsKey := label.RafsInstanceID(snapshotID, idMapping)
 
 	fsDriver := config.GetFsDriver()
 	if label.IsTarfsDataLayer(labels) {
 		fsDriver = config.FsDriverBlockdev
 	}
+
+	if idMapping != nil {
+		if fsDriver != config.FsDriverFusedev {
+			return errors.Errorf("id mapping (remap-ids) is only supported by the fusedev driver, got %q", fsDriver)
+		}
+	}
 	isSharedFusedev := fsDriver == config.FsDriverFusedev && config.GetDaemonMode() == config.DaemonModeShared
 	useSharedDaemon := fsDriver == config.FsDriverFscache || isSharedFusedev
 
+	rafs := racache.RafsGlobalCache.Get(rafsKey)
+	if rafs != nil && idMapping == nil {
+		// Instance already exists and no remap-ids needed — safe to reuse.
+		return nil
+	}
+	if rafs != nil && idMapping != nil {
+		// Per-pod compound rafsKey already includes the UID mapping in
+		// its suffix, so a cache hit means this exact pod already has
+		// a mount — duplicate Mount() call, safe to reuse.
+		return nil
+	}
 	var imageID string
 	imageID, ok := labels[snpkg.TargetRefLabel]
 	if !ok {
@@ -346,17 +376,19 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 		}
 	}
 
-	rafs, err = racache.NewRafs(snapshotID, imageID, fsDriver)
+	rafs, err = racache.NewRafs(rafsKey, imageID, fsDriver)
 	if err != nil {
 		return errors.Wrapf(err, "create rafs instance %s", snapshotID)
+	}
+	if idMapping != nil {
+		rafs.SourceSnapshotID = snapshotID
 	}
 
 	defer func() {
 		if err != nil {
-			if umountErr := fs.Umount(ctx, snapshotID); umountErr != nil {
+			if umountErr := fs.umountRafsInstances([]*racache.Rafs{rafs}); umountErr != nil {
 				log.L.WithError(umountErr).Warnf("failed to umount snapshot %s during cleanup", snapshotID)
 			}
-			racache.RafsGlobalCache.Remove(snapshotID)
 		}
 	}()
 
@@ -393,6 +425,12 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 			if err != nil {
 				return err
 			}
+			if idMapping != nil {
+				mp = fmt.Sprintf("%s-%d", mp, idMapping.External)
+				if err := os.MkdirAll(mp, 0755); err != nil {
+					return errors.Wrapf(err, "create idmap mountpoint dir %s", mp)
+				}
+			}
 			d, err = fs.createDaemon(fsManager, config.DaemonModeDedicated, mp, 0)
 			// if daemon already exists for snapshotID, just return
 			if err != nil && !errdefs.IsAlreadyExists(err) {
@@ -408,16 +446,21 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 			daemonconfig.CacheDir:  cacheDir,
 		}
 		cfg := deepcopy.Copy(*fsManager.DaemonConfig).(daemonconfig.DaemonConfig)
-		err = daemonconfig.SupplementDaemonConfig(cfg, imageID, snapshotID, false, labels, params)
+		err = daemonconfig.SupplementDaemonConfig(cfg, imageID, rafsKey, false, labels, params)
 		if err != nil {
 			return errors.Wrap(err, "supplement configuration")
+		}
+
+		// Inject the UID/GID mapping so nydusd applies VFS-layer remapping.
+		if idMapping != nil && fsDriver == config.FsDriverFusedev {
+			cfg.SetIDMapping(&[3]uint32{idMapping.Internal, idMapping.External, idMapping.Range})
 		}
 
 		// TODO: How to manage rafs configurations on-disk? separated json config file or DB record?
 		// In order to recover erofs mount, the configuration file has to be persisted.
 		var configSubDir string
 		if useSharedDaemon {
-			configSubDir = snapshotID
+			configSubDir = rafsKey
 		} else {
 			// Associate daemon config object when creating a new daemon object to avoid
 			// reading disk file again and again.
@@ -547,61 +590,144 @@ func (fs *Filesystem) copyFile(src, dst string) error {
 }
 
 func (fs *Filesystem) Umount(_ context.Context, snapshotID string) error {
-	rafs := racache.RafsGlobalCache.Get(snapshotID)
-	if rafs == nil {
+	rafsList := fs.collectRafsInstances(snapshotID)
+	if len(rafsList) == 0 {
 		log.L.Debugf("no RAFS filesystem instance associated with snapshot %s", snapshotID)
 		return nil
 	}
 
-	fsDriver := rafs.GetFsDriver()
-	if fsDriver == config.FsDriverNodev {
+	return fs.umountRafsInstances(rafsList)
+}
+
+func (fs *Filesystem) UmountByLabels(_ context.Context, snapshotID string, labels map[string]string) error {
+	rafsKey, err := label.RafsInstanceIDFromLabels(snapshotID, labels)
+	if err != nil {
+		return errors.Wrapf(err, "parse id mapping for snapshot %s", snapshotID)
+	}
+
+	rafs := racache.RafsGlobalCache.Get(rafsKey)
+	if rafs == nil {
 		return nil
 	}
-	fsManager, err := fs.getManager(fsDriver)
-	if err != nil {
-		return errors.Wrapf(err, "get manager for filesystem instance %s", rafs.DaemonID)
+
+	return fs.umountRafsInstances([]*racache.Rafs{rafs})
+}
+
+// collectRafsInstances gathers all RAFS instances associated with a snapshot:
+// the shared instance keyed by snapshotID itself, plus any per-pod idmap
+// derivatives whose SourceSnapshotID matches snapshotID. In the idmap scenario,
+// a single base snapshot may spawn multiple RAFS instances (one per user
+// namespace mapping), all of which must be collected for unmount.
+func (fs *Filesystem) collectRafsInstances(snapshotID string) []*racache.Rafs {
+	var rafsList []*racache.Rafs
+	// Get the shared (non-idmap) RAFS instance.
+	if r := racache.RafsGlobalCache.Get(snapshotID); r != nil {
+		rafsList = append(rafsList, r)
+	}
+	// Find per-pod idmap derivatives whose SourceSnapshotID matches.
+	for _, r := range racache.RafsGlobalCache.List() {
+		if r.SnapshotID != snapshotID && r.GetSourceSnapshotID() == snapshotID {
+			rafsList = append(rafsList, r)
+		}
 	}
 
-	switch fsDriver {
+	return rafsList
+}
+
+func (fs *Filesystem) umountRafsInstances(rafsList []*racache.Rafs) error {
+	var firstErr error
+
+	for _, rafs := range rafsList {
+		if err := fs.umountRafsInstance(rafs); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			log.L.WithError(err).Warnf("failed to umount RAFS instance %s", rafs.SnapshotID)
+		}
+	}
+
+	return firstErr
+}
+
+func (fs *Filesystem) umountRafsInstance(rafs *racache.Rafs) error {
+	switch rafs.GetFsDriver() {
 	case config.FsDriverFscache, config.FsDriverFusedev:
-		daemon, err := fs.getDaemonByRafs(rafs)
+		fsManager, err := fs.getManager(rafs.GetFsDriver())
 		if err != nil {
-			log.L.Debugf("snapshot %s has no associated nydusd", snapshotID)
-			return errors.Wrapf(err, "get daemon with ID %s for snapshot %s", rafs.DaemonID, snapshotID)
+			return errors.Wrapf(err, "get manager for filesystem instance %s", rafs.DaemonID)
 		}
 
-		daemon.RemoveRafsInstance(snapshotID)
-		if err := fsManager.RemoveRafsInstance(snapshotID); err != nil {
-			return errors.Wrapf(err, "remove snapshot %s", snapshotID)
+		daemon, daemonErr := fs.getDaemonByRafs(rafs)
+		if daemonErr == nil {
+			daemon.RemoveRafsInstance(rafs.SnapshotID)
+		} else {
+			log.L.Debugf("snapshot %s has no associated nydusd: %v", rafs.SnapshotID, daemonErr)
 		}
-		if err := daemon.UmountRafsInstance(rafs); err != nil {
-			return errors.Wrapf(err, "umount instance %s", snapshotID)
+
+		if err := fsManager.RemoveRafsInstance(rafs.SnapshotID); err != nil {
+			log.L.WithError(err).Warnf("remove rafs %s from store", rafs.SnapshotID)
 		}
-		// Once daemon's reference reaches 0, destroy the whole daemon
-		if daemon.GetRef() == 0 {
-			if err := fsManager.DestroyDaemon(daemon); err != nil {
-				return errors.Wrapf(err, "destroy daemon %s", daemon.ID())
+		if daemonErr == nil {
+			if err := daemon.UmountRafsInstance(rafs); err != nil {
+				log.L.WithError(err).Warnf("umount instance %s", rafs.SnapshotID)
+			}
+			if daemon.IsSharedDaemon() {
+				fs.cleanUpSharedRafsResources(daemon.ID(), rafs)
+			}
+			if daemon.GetRef() == 0 {
+				if err := fsManager.DestroyDaemon(daemon); err != nil {
+					return errors.Wrapf(err, "destroy daemon %s", daemon.ID())
+				}
 			}
 		}
+
+		racache.RafsGlobalCache.Remove(rafs.SnapshotID)
 	case config.FsDriverBlockdev:
-		if err := fs.tarfsMgr.UmountTarErofs(snapshotID); err != nil {
-			return errors.Wrapf(err, "umount tar erofs on snapshot %s", snapshotID)
+		fsManager, err := fs.getManager(rafs.GetFsDriver())
+		if err != nil {
+			return errors.Wrapf(err, "get manager for filesystem instance %s", rafs.DaemonID)
 		}
-		if err := fsManager.RemoveRafsInstance(snapshotID); err != nil {
-			return errors.Wrapf(err, "remove snapshot %s", snapshotID)
+		if err := fs.tarfsMgr.UmountTarErofs(rafs.SnapshotID); err != nil {
+			return errors.Wrapf(err, "umount tar erofs on snapshot %s", rafs.SnapshotID)
 		}
-	case config.FsDriverNodev, config.FsDriverProxy:
-		// For proxy mode, we still need to clean up the DB entry to prevent
-		// "already exists" errors on subsequent Mount() calls.
-		if err := fsManager.RemoveRafsInstance(snapshotID); err != nil {
-			// Log but don't fail - the entry might not exist
-			log.L.Debugf("remove instance %s from DB: %v", snapshotID, err)
+		if err := fsManager.RemoveRafsInstance(rafs.SnapshotID); err != nil {
+			return errors.Wrapf(err, "remove snapshot %s", rafs.SnapshotID)
 		}
+		racache.RafsGlobalCache.Remove(rafs.SnapshotID)
+	case config.FsDriverProxy:
+		fsManager, err := fs.getManager(rafs.GetFsDriver())
+		if err != nil {
+			return errors.Wrapf(err, "get manager for filesystem instance %s", rafs.DaemonID)
+		}
+		if err := fsManager.RemoveRafsInstance(rafs.SnapshotID); err != nil {
+			log.L.Debugf("remove instance %s from DB: %v", rafs.SnapshotID, err)
+		}
+		racache.RafsGlobalCache.Remove(rafs.SnapshotID)
+	case config.FsDriverNodev:
+		racache.RafsGlobalCache.Remove(rafs.SnapshotID)
 	default:
-		return errors.Errorf("unknown filesystem driver %s for snapshot %s", fsDriver, snapshotID)
+		return errors.Errorf("unknown filesystem driver %s for snapshot %s", rafs.GetFsDriver(), rafs.SnapshotID)
 	}
 
 	return nil
+}
+
+func (fs *Filesystem) cleanUpSharedRafsResources(daemonID string, rafs *racache.Rafs) {
+	resources := []string{
+		filepath.Join(config.GetConfigRoot(), daemonID, rafs.SnapshotID),
+	}
+	if mountpoint := rafs.GetMountpoint(); mountpoint != "" {
+		resources = append(resources, mountpoint)
+	}
+
+	for _, resource := range resources {
+		if resource == "" {
+			continue
+		}
+		if err := os.RemoveAll(resource); err != nil {
+			log.L.WithError(err).Warnf("remove shared rafs resource %s", resource)
+		}
+	}
 }
 
 // How much space the layer/blob cache filesystem is occupying

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -7,7 +7,13 @@
 package label
 
 import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
 	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/nydus-snapshotter/pkg/utils/parser"
 )
 
 // For package compatibility, we still keep the old exported name here.
@@ -63,7 +69,99 @@ const (
 
 	// An alternative nydus index manifest exists in the original OCI index manifest for this snapshot
 	NydusIndexAlternative = "containerd.io/snapshot/nydus-index-alternative"
+
+	SnapshotUIDMapping = snapshots.LabelSnapshotUIDMapping
+
+	SnapshotGIDMapping = snapshots.LabelSnapshotGIDMapping
 )
+
+// IDMapping represents a contiguous UID/GID mapping tuple (Internal, External, Range),
+// matching nydusd's `RafsConfigV2.id_mapping` format.
+type IDMapping struct {
+	Internal uint32 // User/Group ID inside the container (namespace)
+	External uint32 // Mapped User/Group ID on the host
+	Range    uint32 // Number of contiguous IDs in the mapping
+}
+
+// parseSingleMapping parses one containerd mapping string `internalID:hostID:size`.
+// The format maps an in-container (namespace) User/Group ID to a host (external) ID.
+func parseSingleMapping(kind, value string) (*IDMapping, error) {
+	parts := strings.Split(strings.TrimSpace(value), ":")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("nydus idmap: invalid %s mapping %q, expected internalID:hostID:size", kind, value)
+	}
+
+	internalID, err := parser.ParseUint32(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("nydus idmap: invalid %s internalID in %q: %w", kind, value, err)
+	}
+
+	externalID, err := parser.ParseUint32(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("nydus idmap: invalid %s hostID in %q: %w", kind, value, err)
+	}
+
+	size, err := parser.ParseUint32(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("nydus idmap: invalid %s size in %q: %w", kind, value, err)
+	}
+
+	if size == 0 {
+		return nil, fmt.Errorf("nydus idmap: %s mapping %q has zero range", kind, value)
+	}
+
+	// Perform arithmetic overflow checks.
+	if internalID > math.MaxUint32-size || externalID > math.MaxUint32-size {
+		return nil, fmt.Errorf("nydus idmap: %s mapping %q overflows uint32", kind, value)
+	}
+
+	return &IDMapping{Internal: internalID, External: externalID, Range: size}, nil
+}
+
+// ParseIDMapping extracts raw UID/GID mappings from snapshot labels.
+// It enforces that UID and GID mappings are identical and returns a single
+// unified IDMapping. Returns nil with no error if idmap labels are absent.
+func ParseIDMapping(labels map[string]string) (*IDMapping, error) {
+	uidStr := labels[SnapshotUIDMapping]
+	gidStr := labels[SnapshotGIDMapping]
+
+	if uidStr == "" && gidStr == "" {
+		//nolint:nilnil // intentionally nil, nil: success with no mapping present
+		return nil, nil
+	}
+
+	if uidStr == "" || gidStr == "" {
+		return nil, fmt.Errorf("nydus idmap: both uid and gid mappings must be provided")
+	}
+
+	if uidStr != gidStr {
+		return nil, fmt.Errorf("nydus idmap: uid mapping %q and gid mapping %q do not match", uidStr, gidStr)
+	}
+
+	idMapping, err := parseSingleMapping("uid", uidStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return idMapping, nil
+}
+
+func RafsInstanceID(snapshotID string, idMapping *IDMapping) string {
+	if idMapping == nil {
+		return snapshotID
+	}
+
+	return fmt.Sprintf("%s-userns-%d", snapshotID, idMapping.External)
+}
+
+func RafsInstanceIDFromLabels(snapshotID string, labels map[string]string) (string, error) {
+	idMapping, err := ParseIDMapping(labels)
+	if err != nil {
+		return "", err
+	}
+
+	return RafsInstanceID(snapshotID, idMapping), nil
+}
 
 func IsNydusDataLayer(labels map[string]string) bool {
 	_, ok := labels[NydusDataLayer]

--- a/pkg/label/label_test.go
+++ b/pkg/label/label_test.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package label
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIDMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		wantMapping *IDMapping
+		wantErr     bool
+		errContains string
+	}{
+		// ---- absent / empty ----
+		{
+			name:    "no labels",
+			labels:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty labels",
+			labels:  map[string]string{},
+			wantErr: false,
+		},
+
+		// ---- valid ----
+		{
+			name: "valid idmap",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0:100000:65536",
+				SnapshotGIDMapping: "0:100000:65536",
+			},
+			wantMapping: &IDMapping{Internal: 0, External: 100000, Range: 65536},
+		},
+		{
+			name: "single id mapping (uid 1)",
+			labels: map[string]string{
+				SnapshotUIDMapping: "1:1:1",
+				SnapshotGIDMapping: "1:1:1",
+			},
+			wantMapping: &IDMapping{Internal: 1, External: 1, Range: 1},
+		},
+		{
+			name: "trimmed values",
+			labels: map[string]string{
+				SnapshotUIDMapping: " 0:100000:65536 ",
+				SnapshotGIDMapping: " 0:100000:65536 ",
+			},
+			wantMapping: &IDMapping{Internal: 0, External: 100000, Range: 65536},
+		},
+		{
+			name: "MaxUint32 boundary - fits exactly",
+			labels: map[string]string{
+				SnapshotUIDMapping: "4294967294:0:1",
+				SnapshotGIDMapping: "4294967294:0:1",
+			},
+			wantMapping: &IDMapping{Internal: 4294967294, External: 0, Range: 1},
+		},
+
+		// ---- uid / gid mismatch ----
+		{
+			name: "uid and gid mismatch",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0:100000:65536",
+				SnapshotGIDMapping: "0:200000:65536",
+			},
+			wantErr:     true,
+			errContains: "do not match",
+		},
+
+		// ---- missing one mapping ----
+		{
+			name: "only uid mapping, missing gid",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0:100000:65536",
+			},
+			wantErr:     true,
+			errContains: "both uid and gid mappings must be provided",
+		},
+		{
+			name: "only gid mapping, missing uid",
+			labels: map[string]string{
+				SnapshotGIDMapping: "0:100000:65536",
+			},
+			wantErr:     true,
+			errContains: "both uid and gid mappings must be provided",
+		},
+
+		// ---- invalid format ----
+		{
+			name: "invalid format - missing colon",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0:100000",
+				SnapshotGIDMapping: "0:100000",
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+		{
+			name: "invalid format - extra colons",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0:100000:65536:extra",
+				SnapshotGIDMapping: "0:100000:65536:extra",
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+		{
+			name: "invalid format - non-numeric",
+			labels: map[string]string{
+				SnapshotUIDMapping: "abc:def:ghi",
+				SnapshotGIDMapping: "abc:def:ghi",
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+		{
+			name: "invalid format - negative number",
+			labels: map[string]string{
+				SnapshotUIDMapping: "-1:100000:65536",
+				SnapshotGIDMapping: "-1:100000:65536",
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+		{
+			name: "invalid format - empty middle field",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0::65536",
+				SnapshotGIDMapping: "0::65536",
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+
+		// ---- zero range ----
+		{
+			name: "zero range",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0:100000:0",
+				SnapshotGIDMapping: "0:100000:0",
+			},
+			wantErr:     true,
+			errContains: "zero range",
+		},
+
+		// ---- overflow ----
+		{
+			name: "overflow internal plus range",
+			labels: map[string]string{
+				SnapshotUIDMapping: "3000000000:0:3000000000",
+				SnapshotGIDMapping: "3000000000:0:3000000000",
+			},
+			wantErr:     true,
+			errContains: "overflows",
+		},
+		{
+			name: "overflow external plus range",
+			labels: map[string]string{
+				SnapshotUIDMapping: "0:3000000000:3000000000",
+				SnapshotGIDMapping: "0:3000000000:3000000000",
+			},
+			wantErr:     true,
+			errContains: "overflows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idMapping, err := ParseIDMapping(tt.labels)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.wantMapping != nil {
+				require.NotNil(t, idMapping)
+				assert.Equal(t, *tt.wantMapping, *idMapping)
+			} else {
+				assert.Nil(t, idMapping)
+			}
+		})
+	}
+}
+
+func TestRafsInstanceID(t *testing.T) {
+	assert.Equal(t, "snapshot-1", RafsInstanceID("snapshot-1", nil))
+	assert.Equal(t, "snapshot-1-userns-100000", RafsInstanceID("snapshot-1", &IDMapping{
+		Internal: 0,
+		External: 100000,
+		Range:    65536,
+	}))
+}
+
+func TestRafsInstanceIDFromLabels(t *testing.T) {
+	id, err := RafsInstanceIDFromLabels("snapshot-1", map[string]string{
+		SnapshotUIDMapping: "0:100000:65536",
+		SnapshotGIDMapping: "0:100000:65536",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "snapshot-1-userns-100000", id)
+
+	id, err = RafsInstanceIDFromLabels("snapshot-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "snapshot-1", id)
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -294,7 +294,7 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 
 func (m *Manager) cleanUpDaemonResources(d *daemon.Daemon) {
 	// TODO: use recycle bin to stage directories/files to be deleted.
-	resource := []string{d.States.ConfigDir, d.States.LogDir}
+	resource := []string{d.States.ConfigDir, d.States.LogDir, d.HostMountpoint()}
 	if !d.IsSharedDaemon() {
 		socketDir := path.Dir(d.GetAPISock())
 		resource = append(resource, socketDir)

--- a/pkg/rafs/rafs.go
+++ b/pkg/rafs/rafs.go
@@ -110,13 +110,14 @@ func (rs *Cache) SetIntances(instances map[string]*Rafs) {
 
 // The whole struct will be persisted
 type Rafs struct {
-	Seq             uint64
-	ImageID         string // Usually is the image reference
-	DaemonID        string
-	FsDriver        string
-	SnapshotID      string // Given by containerd
-	SnapshotDir     string
-	UnderlyingFiles []string // Underlying cache blob files
+	Seq              uint64
+	ImageID          string // Usually is the image reference
+	DaemonID         string
+	FsDriver         string
+	SnapshotID       string // Given by containerd
+	SnapshotDir      string
+	SourceSnapshotID string
+	UnderlyingFiles  []string // Underlying cache blob files
 	// 1. A host kernel EROFS/TARFS mountpoint
 	// 2. Absolute path to each rafs instance root directory.
 	Mountpoint  string
@@ -149,6 +150,14 @@ func (r *Rafs) AddAnnotation(k, v string) {
 
 func (r *Rafs) GetSnapshotDir() string {
 	return r.SnapshotDir
+}
+
+func (r *Rafs) GetSourceSnapshotID() string {
+	if r.SourceSnapshotID != "" {
+		return r.SourceSnapshotID
+	}
+
+	return r.SnapshotID
 }
 
 func (r *Rafs) GetFsDriver() string {
@@ -187,8 +196,9 @@ func (r *Rafs) RelaMountpoint() string {
 }
 
 func (r *Rafs) BootstrapFile() (string, error) {
+	sourceSnapshotDir := path.Join(config.GetSnapshotsRootDir(), r.GetSourceSnapshotID())
 	// meta files are stored at <snapshot_id>/fs/image/image.boot
-	bootstrap := filepath.Join(r.SnapshotDir, "fs", "image", "image.boot")
+	bootstrap := filepath.Join(sourceSnapshotDir, "fs", "image", "image.boot")
 	_, err := os.Stat(bootstrap)
 	if err == nil {
 		return bootstrap, nil
@@ -196,7 +206,7 @@ func (r *Rafs) BootstrapFile() (string, error) {
 
 	if os.IsNotExist(err) {
 		// check legacy location for backward compatibility
-		bootstrap = filepath.Join(r.SnapshotDir, "fs", "image.boot")
+		bootstrap = filepath.Join(sourceSnapshotDir, "fs", "image.boot")
 		_, err = os.Stat(bootstrap)
 		if err == nil {
 			return bootstrap, nil

--- a/pkg/utils/parser/parser.go
+++ b/pkg/utils/parser/parser.go
@@ -9,6 +9,7 @@ package parser
 import (
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -74,4 +75,12 @@ func MemoryConfigToBytes(data string, totalMemoryBytes int) (int64, error) {
 
 	multiplier := unitMultipliers[unit]
 	return int64(value * float64(multiplier)), nil
+}
+
+func ParseUint32(s string) (uint32, error) {
+	v, err := strconv.ParseUint(strings.TrimSpace(s), 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
 }

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -48,7 +48,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 			}
 
 			// Let Prepare operation show the rootfs content.
-			if err := sn.fs.WaitUntilReady(id); err != nil {
+			if err := sn.fs.WaitUntilReady(id, labels); err != nil {
 				return false, nil, err
 			}
 
@@ -142,6 +142,17 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 		if handler == nil {
 			if id, info, err := sn.findMetaLayer(ctx, key); err == nil {
 				logger.Infof("Prepare active Nydus snapshot %s", key)
+				// Propagate user-namespace remap-ids labels from the Active
+				// snapshot to the meta layer so fs.Mount() and mountRemote()
+				// can apply the correct id_mapping.
+				for _, k := range []string{
+					label.SnapshotUIDMapping,
+					label.SnapshotGIDMapping,
+				} {
+					if v, ok := labels[k]; ok {
+						info.Labels[k] = v
+					}
+				}
 				handler = remoteHandler(id, info.Labels)
 			}
 		}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -419,7 +419,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 	switch info.Kind {
 	case snapshots.KindView:
 		if label.IsNydusMetaLayer(info.Labels) {
-			err = o.fs.WaitUntilReady(id)
+			err = o.fs.WaitUntilReady(id, info.Labels)
 			if err != nil {
 				// Skip waiting if clients is unpacking nydus artifacts to `mounts`
 				// For example, nydus-snapshotter's client like Buildkit is calling snapshotter in below workflow:
@@ -444,7 +444,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 			pKey := info.Parent
 			if pID, pInfo, _, err := snapshot.GetSnapshotInfo(ctx, o.ms, pKey); err == nil {
 				if label.IsNydusMetaLayer(pInfo.Labels) {
-					if err = o.fs.WaitUntilReady(pID); err != nil {
+					if err = o.fs.WaitUntilReady(pID, info.Labels); err != nil {
 						return nil, errors.Wrapf(err, "mounts: snapshot %s is not ready, err: %v", pID, err)
 					}
 					needRemoteMounts = true
@@ -543,13 +543,13 @@ func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 
 	if label.IsNydusMetaLayer(pInfo.Labels) {
 		// Nydusd might not be running. We should run nydusd to reflect the rootfs.
-		if err = o.fs.WaitUntilReady(pID); err != nil {
+		if err = o.fs.WaitUntilReady(pID, pInfo.Labels); err != nil {
 			if errors.Is(err, errdefs.ErrNotFound) {
 				if err := o.fs.Mount(ctx, pID, pInfo.Labels, nil); err != nil {
 					return nil, errors.Wrapf(err, "mount rafs, instance id %s", pID)
 				}
 
-				if err := o.fs.WaitUntilReady(pID); err != nil {
+				if err := o.fs.WaitUntilReady(pID, pInfo.Labels); err != nil {
 					return nil, errors.Wrapf(err, "wait for instance id %s", pID)
 				}
 			} else {
@@ -656,6 +656,15 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		return errors.Wrapf(err, "get snapshot %s", key)
 	}
 
+	var removeRafsSnapshotID string
+	if info.Kind == snapshots.KindActive || info.Kind == snapshots.KindView {
+		if idMapping, parseErr := label.ParseIDMapping(info.Labels); parseErr == nil && idMapping != nil {
+			if metaID, _, metaErr := o.findMetaLayer(ctx, key); metaErr == nil {
+				removeRafsSnapshotID = metaID
+			}
+		}
+	}
+
 	switch {
 	case label.IsNydusMetaLayer(info.Labels):
 		log.L.Infof("[Remove] nydus meta snapshot with key %s snapshot id %s", key, id)
@@ -693,6 +702,14 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 			}
 		}()
 	}
+
+	defer func() {
+		if err == nil && removeRafsSnapshotID != "" {
+			if umountErr := o.fs.UmountByLabels(ctx, removeRafsSnapshotID, info.Labels); umountErr != nil {
+				log.G(ctx).WithError(umountErr).WithField("snapshot_id", removeRafsSnapshotID).Warn("failed to remove per-pod lower RAFS instance")
+			}
+		}
+	}()
 
 	return t.Commit()
 }
@@ -858,8 +875,20 @@ func (o *snapshotter) createSnapshotWithRecovery(ctx context.Context, kind snaps
 		return nil, storage.Snapshot{}, errors.Wrap(err, "create snapshot")
 	}
 
-	// Try to keep the whole stack having the same UID and GID
-	if len(s.ParentIDs) > 0 {
+	// When remap-ids labels are present, containerd skips its own recursive
+	// chown — we chown just the upper dir to the mapped host ID (single
+	// directory, does not defeat lazy pulling). Without idmap, inherit the
+	// parent's UID/GID as before.
+	idMapping, err := label.ParseIDMapping(base.Labels)
+	if err != nil {
+		return nil, storage.Snapshot{}, errors.Wrap(err, "parse id mapping")
+	}
+	if idMapping != nil {
+		externalID := int(idMapping.External)
+		if err := os.Lchown(filepath.Join(td, "fs"), externalID, externalID); err != nil {
+			return nil, storage.Snapshot{}, errors.Wrap(err, "perform idmapped chown")
+		}
+	} else if len(s.ParentIDs) > 0 {
 		st, err := os.Stat(o.upperPath(s.ParentIDs[0]))
 		if err != nil {
 			return nil, storage.Snapshot{}, errors.Wrap(err, "stat parent")
@@ -1022,15 +1051,18 @@ func (o *snapshotter) mergeTarfs(ctx context.Context, s storage.Snapshot, pID st
 	return nil
 }
 
-func bindMount(source, roFlag string) []mount.Mount {
+func bindMount(source, roFlag string, extraOptions ...string) []mount.Mount {
+	options := []string{
+		roFlag,
+		"rbind",
+	}
+	options = append(options, extraOptions...)
+
 	return []mount.Mount{
 		{
-			Type:   "bind",
-			Source: source,
-			Options: []string{
-				roFlag,
-				"rbind",
-			},
+			Type:    "bind",
+			Source:  source,
+			Options: options,
 		},
 	}
 }
@@ -1118,7 +1150,11 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 		}
 	}
 
-	lowerPathNydus, err := o.lowerPath(id)
+	rafsKey, err := label.RafsInstanceIDFromLabels(id, labels)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse id mapping for remote mount")
+	}
+	lowerPathNydus, err := o.lowerPath(rafsKey)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to locate overlay lowerdir")
 	}
@@ -1144,6 +1180,19 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 	overlayOptions = append(overlayOptions, lowerDirOption)
 	log.G(ctx).Infof("remote mount options %v", overlayOptions)
 
+	// Chown overlay upperdir/workdir to the mapped host UID (from
+	// remap-ids labels) so the container can write to its rootfs.
+	if s.Kind == snapshots.KindActive {
+		if idMapping, _ := label.ParseIDMapping(labels); idMapping != nil {
+			externalID := int(idMapping.External)
+			for _, d := range []string{o.upperPath(s.ID), o.workPath(s.ID)} {
+				if err := os.Lchown(d, externalID, externalID); err != nil {
+					log.G(ctx).WithError(err).Warnf("chown %s to %d for idmap: %v", d, externalID, err)
+				}
+			}
+		}
+	}
+
 	if o.enableKataVolume {
 		return o.mountWithKataVolume(ctx, id, overlayOptions, key)
 	}
@@ -1154,14 +1203,30 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 	return overlayMount(overlayOptions), nil
 }
 
+// mountNative builds mount options for non-nydus (plain OCI) images.
 func (o *snapshotter) mountNative(ctx context.Context, labels map[string]string, s storage.Snapshot) ([]mount.Mount, error) {
+	idMapping, err := label.ParseIDMapping(labels)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse id mapping for native mount")
+	}
+
+	var idMapOptions []string
+	if idMapping != nil {
+		// uidmap=/gidmap= are consumed by containerd's mount package
+		// (open_tree + mount_setattr + move_mount), NOT by the kernel.
+		idMapOptions = []string{
+			fmt.Sprintf("uidmap=%d:%d:%d", idMapping.Internal, idMapping.External, idMapping.Range),
+			fmt.Sprintf("gidmap=%d:%d:%d", idMapping.Internal, idMapping.External, idMapping.Range),
+		}
+	}
+
 	if len(s.ParentIDs) == 0 {
 		// if we only have one layer/no parents then just return a bind mount as overlay will not work
 		roFlag := "rw"
 		if s.Kind == snapshots.KindView {
 			roFlag = "ro"
 		}
-		return bindMount(o.upperPath(s.ID), roFlag), nil
+		return bindMount(o.upperPath(s.ID), roFlag, idMapOptions...), nil
 	}
 
 	var options []string
@@ -1177,8 +1242,9 @@ func (o *snapshotter) mountNative(ctx context.Context, labels map[string]string,
 		parentPath := o.upperPath(s.ParentIDs[0])
 		// if we only have one parent then just return a bind mount
 		log.G(ctx).Debugf("bind mount on %s", parentPath)
-		return bindMount(parentPath, "ro"), nil
+		return bindMount(parentPath, "ro", idMapOptions...), nil
 	}
+	options = append(options, idMapOptions...)
 
 	parentPaths := make([]string, len(s.ParentIDs))
 	for i := range s.ParentIDs {
@@ -1215,6 +1281,13 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 		return nil, err
 	}
 
+	// Per-pod RAFS instances (e.g. "48-userns-<uid>") live outside
+	// containerd's IDMap — keep them alive while still referenced.
+	liveRafsSnapshotDirs := make(map[string]struct{})
+	for _, instance := range rafs.RafsGlobalCache.List() {
+		liveRafsSnapshotDirs[filepath.Base(instance.GetSnapshotDir())] = struct{}{}
+	}
+
 	// For example:
 	// 23:default/24/sha256:8c2ed532dce363da2d08489f385c432f7c0ee4509ab4e20eb2778803916adc93
 	// 24:sha256:c858413d9e5162c287028d630128ea4323d5029bf8a093af783480b38cf8d44e
@@ -1234,6 +1307,9 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 	cleanup := make([]string, 0, 16)
 	for _, d := range dirs {
 		if _, ok := ids[d]; ok {
+			continue
+		}
+		if _, ok := liveRafsSnapshotDirs[d]; ok {
 			continue
 		}
 		// When it quits, there will be nothing inside

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/nydus-snapshotter/pkg/filesystem"
 	"github.com/containerd/nydus-snapshotter/pkg/label"
+	"github.com/containerd/nydus-snapshotter/pkg/rafs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -201,6 +203,79 @@ func TestMountNative(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "no parents, active snapshot with idmap - rw bind mount with uidmap/gidmap",
+			snapshot: storage.Snapshot{
+				ID:        "snap10",
+				Kind:      snapshots.KindActive,
+				ParentIDs: []string{},
+			},
+			labels: map[string]string{
+				snapshots.LabelSnapshotUIDMapping: "0:100000:65536",
+				snapshots.LabelSnapshotGIDMapping: "0:100000:65536",
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: s.upperPath("snap10"),
+					Options: []string{
+						"rw",
+						"rbind",
+						"uidmap=0:100000:65536",
+						"gidmap=0:100000:65536",
+					},
+				},
+			},
+		},
+		{
+			name: "one parent, view snapshot with idmap - ro bind mount with uidmap/gidmap",
+			snapshot: storage.Snapshot{
+				ID:        "snap11",
+				Kind:      snapshots.KindView,
+				ParentIDs: []string{"parent1"},
+			},
+			labels: map[string]string{
+				snapshots.LabelSnapshotUIDMapping: "0:200000:65536",
+				snapshots.LabelSnapshotGIDMapping: "0:200000:65536",
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: s.upperPath("parent1"),
+					Options: []string{
+						"ro",
+						"rbind",
+						"uidmap=0:200000:65536",
+						"gidmap=0:200000:65536",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple parents, active snapshot with idmap - overlay with uidmap/gidmap",
+			snapshot: storage.Snapshot{
+				ID:        "snap12",
+				Kind:      snapshots.KindActive,
+				ParentIDs: []string{"parent1", "parent2"},
+			},
+			labels: map[string]string{
+				snapshots.LabelSnapshotUIDMapping: "0:100000:65536",
+				snapshots.LabelSnapshotGIDMapping: "0:100000:65536",
+			},
+			expectedMounts: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						fmt.Sprintf("workdir=%s", s.workPath("snap12")),
+						fmt.Sprintf("upperdir=%s", s.upperPath("snap12")),
+						fmt.Sprintf("lowerdir=%s:%s", s.upperPath("parent1"), s.upperPath("parent2")),
+						"uidmap=0:100000:65536",
+						"gidmap=0:100000:65536",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -269,4 +344,41 @@ func TestMountNativeConfigVolatile(t *testing.T) {
 		require.Len(t, mounts, 1)
 		assert.NotContains(t, mounts[0].Options, "volatile")
 	})
+}
+
+func TestMountRemoteUsesPerPodLowerdirForIDMap(t *testing.T) {
+	originalInstances := rafs.RafsGlobalCache.List()
+	rafs.RafsGlobalCache.SetIntances(make(map[string]*rafs.Rafs))
+	t.Cleanup(func() {
+		rafs.RafsGlobalCache.SetIntances(originalInstances)
+	})
+
+	snapshotterRoot := t.TempDir()
+	s := &snapshotter{
+		root: snapshotterRoot,
+		fs:   &filesystem.Filesystem{},
+	}
+
+	labels := map[string]string{
+		label.SnapshotUIDMapping: "0:100000:65536",
+		label.SnapshotGIDMapping: "0:100000:65536",
+	}
+	rafsKey, err := label.RafsInstanceIDFromLabels("meta", labels)
+	require.NoError(t, err)
+
+	mountpoint := filepath.Join(snapshotterRoot, "mnt", rafsKey)
+	rafs.RafsGlobalCache.Add(&rafs.Rafs{
+		SnapshotID:  rafsKey,
+		SnapshotDir: filepath.Join(snapshotterRoot, "snapshots", "meta"),
+		Mountpoint:  mountpoint,
+	})
+
+	mounts, err := s.mountRemote(context.Background(), labels, storage.Snapshot{
+		ID:   "active",
+		Kind: snapshots.KindActive,
+	}, "meta", "active-key")
+	require.NoError(t, err)
+	require.Len(t, mounts, 1)
+	assert.Contains(t, mounts[0].Options, fmt.Sprintf("lowerdir=%s", mountpoint))
+	assert.NotContains(t, mounts[0].Options, fmt.Sprintf("lowerdir=%s", filepath.Join(snapshotterRoot, "snapshots", "meta", "fs")))
 }


### PR DESCRIPTION
## Overview
When a Kubernetes Pod has hostUsers: false, containerd creates a user namespace with a unique UID/GID range, sets containerd.io/snapshot/uidmapping and containerd.io/snapshot/gidmapping labels on the
  Active snapshot, and — if the snapshotter declares capabilities = ["remap-ids"] — skips its own recursive chown, expecting the snapshotter to handle ownership remapping.

  This PR makes the nydus snapshotter honor those labels, giving each pod its own nydusd FUSE mount with a distinct id_mapping tuple so:
  - container stat / shows 0:0
  - host stat on the FUSE mount shows the mapped external UID
  - overlay upperdir/workdir are chown'd to the external UID, allowing write
  - two pods sharing the same image get isolated lower-layer mounts and cleanup independently

## Related Issues
Close https://github.com/containerd/nydus-snapshotter/issues/750

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.