### PR TITLE
fix(daemon): only DecRef on Umount when the rafs instance was cached

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -159,11 +159,16 @@ func (d *Daemon) UpdateRafsInstance(r *rafs.Rafs) {
 }
 
 func (d *Daemon) RemoveRafsInstance(snapshotID string) {
+	// Only drop the reference when the instance was actually cached.
+	// AddRafsInstance only IncRef()s when it adds, so a duplicate Umount
+	// (retry / recovery) for an already-removed snapshot must not DecRef()
+	// again, otherwise a shared daemon's refcount goes too low and the
+	// nydusd can be torn down while other snapshots still use it.
 	if r := d.RafsCache.Get(snapshotID); r != nil {
 		collector.NewDaemonImageCollector(d.ID(), r.ImageID).Delete()
+		d.RafsCache.Remove(snapshotID)
+		d.DecRef()
 	}
-	d.RafsCache.Remove(snapshotID)
-	d.DecRef()
 }
 
 // Get and cache daemon current working state by querying nydusd:

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
 	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/containerd/nydus-snapshotter/pkg/rafs"
 )
 
 func TestMain(m *testing.M) {
@@ -149,4 +150,30 @@ func TestUpdateAuthConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRemoveRafsInstanceRefcount checks that a duplicate Umount for an
+// already-removed snapshot does not decrement the daemon refcount a second
+// time. AddRafsInstance only IncRef()s when it adds, so RemoveRafsInstance
+// must only DecRef() when the instance was really cached.
+func TestRemoveRafsInstanceRefcount(t *testing.T) {
+	d := &Daemon{
+		States:    ConfigState{ID: "daemon-1"},
+		RafsCache: rafs.NewRafsCache(),
+	}
+
+	r := &rafs.Rafs{SnapshotID: "snap-1", ImageID: "example.com/foo:latest"}
+	d.AddRafsInstance(r)
+	assert.Equal(t, int32(1), d.GetRef())
+	assert.Equal(t, 1, d.RafsCache.Len())
+
+	// First Umount: instance is cached, so it drops the reference.
+	d.RemoveRafsInstance(r.SnapshotID)
+	assert.Equal(t, int32(0), d.GetRef())
+	assert.Equal(t, 0, d.RafsCache.Len())
+
+	// Duplicate Umount for the same snapshot must be a no-op on the refcount.
+	d.RemoveRafsInstance(r.SnapshotID)
+	assert.Equal(t, int32(0), d.GetRef())
+	assert.Equal(t, 0, d.RafsCache.Len())
 }


### PR DESCRIPTION
## Overview

I noticed #763 while reading the open bugs. `RemoveRafsInstance` unconditionally calls `DecRef()`, even when the snapshot was not in the RafsCache. Since `AddRafsInstance` only bumps the refcount when it actually adds an instance, a duplicate Umount (a retry or recovery for an already-removed snapshot) decrements a second time, and in shared-daemon mode that can push the count too low and tear down a nydusd that other snapshots still need.

This moves the `Remove` and `DecRef()` calls into the existing `if r != nil` guard so we only drop the reference when there was one to drop. I also added a daemon test that removes the same snapshot twice and checks the refcount stays at 0 instead of going to -1.

## Related Issues

Fix #763

## Test Results

`go test ./pkg/daemon/...` and `go vet ./pkg/daemon/...` pass on linux/amd64, and the new test fails without the fix.

## Change Type

- [x] Bug Fix