### PR TITLE
fix: race in copyBlobMetaFiles with concurrent hardlinks

### DIFF
--- a/pkg/filesystem/bootstrap_test.go
+++ b/pkg/filesystem/bootstrap_test.go
@@ -40,7 +40,7 @@ func TestWaitForReadyBootstrapWaitsForStableBlobMeta(t *testing.T) {
 	bootstrap := filepath.Join(dir, "image.boot")
 	blobMeta := filepath.Join(dir, "a.blob.meta")
 
-	require.NoError(t, writeFakeV5Bootstrap(bootstrap, 8192))
+	require.NoError(t, writeFakeV5Bootstrap(bootstrap))
 
 	go func() {
 		time.Sleep(5 * time.Millisecond)
@@ -73,7 +73,7 @@ func TestWaitForReadyBootstrapRejectsStableMisalignedV6(t *testing.T) {
 func TestWaitForReadyBootstrapAcceptsStableV5(t *testing.T) {
 	dir := t.TempDir()
 	bootstrap := filepath.Join(dir, "image.boot")
-	require.NoError(t, writeFakeV5Bootstrap(bootstrap, 8192))
+	require.NoError(t, writeFakeV5Bootstrap(bootstrap))
 
 	err := waitForReadyBootstrapWithRetry(bootstrap, 3, 5*time.Millisecond)
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestValidateBootstrapAndBlobMetaReturnsCombinedState(t *testing.T) {
 	dir := t.TempDir()
 	bootstrap := filepath.Join(dir, "image.boot")
 
-	require.NoError(t, writeFakeV5Bootstrap(bootstrap, 8192))
+	require.NoError(t, writeFakeV5Bootstrap(bootstrap))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "layer.blob.meta"), []byte{1, 2, 3, 4}, 0644))
 
 	state, err := validateBootstrapAndBlobMeta(bootstrap)
@@ -217,8 +217,8 @@ func TestBootstrapStateEqual(t *testing.T) {
 	require.False(t, a.Equal(d))
 }
 
-func writeFakeV5Bootstrap(path string, size int) error {
-	buf := make([]byte, size)
+func writeFakeV5Bootstrap(path string) error {
+	buf := make([]byte, 8192)
 	binary.LittleEndian.PutUint32(buf[0:4], layout.RafsV5SuperMagic)
 	binary.LittleEndian.PutUint32(buf[4:8], layout.RafsV5SuperVersion)
 	return os.WriteFile(path, buf, 0644)
@@ -232,4 +232,33 @@ func writeFakeV6Bootstrap(path string, size int, blockBits byte) error {
 	)
 	buf[v6BlockBitsOffset] = blockBits
 	return os.WriteFile(path, buf, 0644)
+}
+
+func TestCopyBlobMetaFilesDoesNotTruncateSourceViaExistingHardlink(t *testing.T) {
+	srcDir := t.TempDir()
+	cacheDir := t.TempDir()
+	bootstrap := filepath.Join(srcDir, "image.boot")
+	srcMeta := filepath.Join(srcDir, "layer.blob.meta")
+	dstMeta := filepath.Join(cacheDir, "layer.blob.meta")
+
+	require.NoError(t, writeFakeV5Bootstrap(bootstrap))
+	require.NoError(t, os.WriteFile(srcMeta, []byte("blob-meta"), 0644))
+	require.NoError(t, os.Link(srcMeta, dstMeta))
+
+	fs := &Filesystem{}
+	require.NoError(t, fs.copyBlobMetaFiles(bootstrap, cacheDir))
+
+	srcContent, err := os.ReadFile(srcMeta)
+	require.NoError(t, err)
+	require.Equal(t, []byte("blob-meta"), srcContent)
+
+	dstContent, err := os.ReadFile(dstMeta)
+	require.NoError(t, err)
+	require.Equal(t, []byte("blob-meta"), dstContent)
+
+	srcInfo, err := os.Stat(srcMeta)
+	require.NoError(t, err)
+	dstInfo, err := os.Stat(dstMeta)
+	require.NoError(t, err)
+	require.False(t, os.SameFile(srcInfo, dstInfo))
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -515,15 +515,10 @@ func (fs *Filesystem) copyBlobMetaFiles(bootstrap, cacheDir string) error {
 		fileName := filepath.Base(srcPath)
 		dstPath := filepath.Join(cacheDir, fileName)
 
-		if err := os.Link(srcPath, dstPath); err != nil {
-			log.L.Warnf("Failed to create hardlink for %s: %v, falling back to copy", fileName, err)
-			if err := fs.copyFile(srcPath, dstPath); err != nil {
-				return errors.Wrapf(err, "copy blob meta file %s", fileName)
-			}
-			log.L.Debugf("Copied blob meta file: %s -> %s", srcPath, dstPath)
-		} else {
-			log.L.Debugf("Created hardlink for blob meta: %s -> %s", srcPath, dstPath)
+		if err := fs.copyFile(srcPath, dstPath); err != nil {
+			return errors.Wrapf(err, "copy blob meta file %s", fileName)
 		}
+		log.L.Debugf("Copied blob meta file: %s -> %s", srcPath, dstPath)
 	}
 
 	return nil
@@ -536,14 +531,32 @@ func (fs *Filesystem) copyFile(src, dst string) error {
 	}
 	defer source.Close()
 
-	destination, err := os.Create(dst)
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	destination, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+".tmp-*")
 	if err != nil {
 		return err
 	}
-	defer destination.Close()
+	tmpPath := destination.Name()
+	defer func() {
+		if destination != nil {
+			destination.Close()
+		}
+		_ = os.Remove(tmpPath)
+	}()
 
 	_, err = io.Copy(destination, source)
-	return err
+	if err != nil {
+		return err
+	}
+	if err := destination.Close(); err != nil {
+		return err
+	}
+	destination = nil
+
+	return os.Rename(tmpPath, dst)
 }
 
 func (fs *Filesystem) Umount(_ context.Context, snapshotID string) error {


### PR DESCRIPTION
## Overview
When two pods start simultaneously and share the same image, copyBlobMetaFiles can truncate blob.meta source files via hardlink conflicts. This PR replaces hardlink-then-fallback-copy with a direct atomic write (temp file + rename).

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.