### PR TITLE
fix: serialize daemon restart and termination

### DIFF
--- a/pkg/manager/daemon_event.go
+++ b/pkg/manager/daemon_event.go
@@ -9,10 +9,12 @@ package manager
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/containerd/log"
@@ -23,8 +25,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	readProcessCmdline      = os.ReadFile
+	processExitPollInterval = 100 * time.Millisecond
+)
+
+var defaultDaemonTerminationTimeout = 5 * time.Second
+
 func (m *Manager) SubscribeDaemonEvent(d *daemon.Daemon) error {
-	if err := m.monitor.Subscribe(d.ID(), d.GetAPISock(), m.LivenessNotifier); err != nil {
+	pid := daemonProcessID(d)
+	if err := m.monitor.Subscribe(d.ID(), pid, d.GetAPISock(), m.LivenessNotifier); err != nil {
 		log.L.Errorf("Nydusd %s probably not started", d.ID())
 		return errors.Wrapf(err, "subscribe daemon %s", d.ID())
 	}
@@ -41,13 +51,25 @@ func (m *Manager) UnsubscribeDaemonEvent(d *daemon.Daemon) error {
 }
 
 func (m *Manager) handleDaemonDeathEvent() {
-	// TODO: ratelimit for daemon recovery operations?
 	for ev := range m.LivenessNotifier {
 		log.L.Warnf("Daemon %s died! socket path %s", ev.daemonID, ev.path)
 
 		d := m.GetByDaemonID(ev.daemonID)
 		if d == nil {
 			log.L.Warnf("Daemon %s was not found, may have been removed", ev.daemonID)
+			continue
+		}
+		currentPID := daemonProcessID(d)
+		if ev.processID != currentPID {
+			log.L.Warnf(
+				"Ignore stale death event for daemon %s: event pid %d, current pid %d",
+				ev.daemonID, ev.processID, currentPID,
+			)
+			continue
+		}
+
+		if m.isRecoveryInFlight(ev.daemonID) {
+			log.L.Warnf("Recovery already in progress for daemon %s, skipping duplicate death event", ev.daemonID)
 			continue
 		}
 
@@ -65,17 +87,30 @@ func (m *Manager) handleDaemonDeathEvent() {
 			log.L.Infof("Do failover for daemon %s", ev.daemonID)
 			go m.doDaemonFailover(d)
 		default:
-			// RecoverPolicyNone or RecoverPolicyInvalid - do nothing
+			m.recoveryInFlight.Delete(ev.daemonID)
 		}
 	}
 }
 
+func (m *Manager) isRecoveryInFlight(daemonID string) bool {
+	_, alreadyRecovering := m.recoveryInFlight.LoadOrStore(daemonID, struct{}{})
+	return alreadyRecovering
+}
+
+func daemonProcessID(d *daemon.Daemon) int {
+	d.Lock()
+	defer d.Unlock()
+	return d.Pid()
+}
+
 func (m *Manager) doDaemonFailover(d *daemon.Daemon) {
-	if err := d.Wait(); err != nil {
-		log.L.Warnf("fail to wait for daemon, %v", err)
+	defer m.recoveryInFlight.Delete(d.ID())
+
+	if err := m.terminateDaemonProcess(d, "failover"); err != nil {
+		log.L.WithError(err).Errorf("abort failover because old daemon %s was not terminated", d.ID())
+		return
 	}
 
-	// Starting a new nydusd will re-subscribe
 	if err := m.UnsubscribeDaemonEvent(d); err != nil {
 		log.L.Warnf("fail to unsubscribe daemon %s, %v", d.ID(), err)
 	}
@@ -110,11 +145,13 @@ func (m *Manager) doDaemonFailover(d *daemon.Daemon) {
 }
 
 func (m *Manager) doDaemonRestart(d *daemon.Daemon) {
-	if err := d.Wait(); err != nil {
-		log.L.Warnf("fails to wait for daemon, %v", err)
+	defer m.recoveryInFlight.Delete(d.ID())
+
+	if err := m.terminateDaemonProcess(d, "restart"); err != nil {
+		log.L.WithError(err).Errorf("abort restart because old daemon %s was not terminated", d.ID())
+		return
 	}
 
-	// Starting a new nydusd will re-subscribe
 	if err := m.UnsubscribeDaemonEvent(d); err != nil {
 		log.L.Warnf("fails to unsubscribe daemon %s, %v", d.ID(), err)
 	}
@@ -137,6 +174,131 @@ func (m *Manager) doDaemonRestart(d *daemon.Daemon) {
 			log.L.Warnf("Failed to mount rafs instance, %v", err)
 		}
 	}
+}
+
+// Make sure the old nydusd process is gone before starting a new one.
+// If the process is still alive — the death event may be a false positive
+// (e.g. API socket closed while the process hangs) — kill it with SIGTERM,
+// escalating to SIGKILL after a timeout. If it has already exited, just reap
+// it like the original recovery flow did, to avoid leaving a zombie behind.
+func (m *Manager) terminateDaemonProcess(d *daemon.Daemon, reason string) error {
+	if d == nil || d.Pid() <= 0 {
+		return nil
+	}
+
+	// On Linux, Go uses a pidfd when available, pinning this handle to the
+	// specific process before the cmdline identity check below.
+	p, err := os.FindProcess(d.Pid())
+	if err != nil {
+		return errors.Wrapf(err, "find daemon %s (pid %d) before %s", d.ID(), d.Pid(), reason)
+	}
+
+	state, err := inspectDaemonProcess(d)
+	if err != nil {
+		return errors.Wrapf(err, "inspect daemon %s (pid %d) before %s", d.ID(), d.Pid(), reason)
+	}
+
+	switch state {
+	case daemonProcessAlive:
+		// The daemon is still running; continue with the termination path below.
+	case daemonProcessGone, daemonProcessReused:
+		return nil
+	case daemonProcessZombie:
+		if err := d.Wait(); err != nil {
+			return errors.Wrapf(err, "reap daemon %s (pid %d) before %s", d.ID(), d.Pid(), reason)
+		}
+		return nil
+	}
+
+	if err := p.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return errors.Wrapf(err, "send SIGTERM to daemon %s (pid %d) before %s", d.ID(), d.Pid(), reason)
+	}
+
+	state, err = waitUntilDaemonExited(d, defaultDaemonTerminationTimeout)
+	if err == nil {
+		if state == daemonProcessZombie {
+			return d.Wait()
+		}
+		return nil
+	}
+
+	log.L.Warnf("daemon %s (pid %d) did not exit after SIGTERM before %s, sending SIGKILL", d.ID(), d.Pid(), reason)
+	if err := p.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return errors.Wrapf(err, "send SIGKILL to daemon %s (pid %d) before %s", d.ID(), d.Pid(), reason)
+	}
+
+	state, err = waitUntilDaemonExited(d, defaultDaemonTerminationTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "daemon %s (pid %d) still alive after SIGKILL before %s", d.ID(), d.Pid(), reason)
+	}
+	if state == daemonProcessZombie {
+		return d.Wait()
+	}
+	return nil
+}
+
+type daemonProcessState int
+
+const (
+	daemonProcessAlive daemonProcessState = iota
+	daemonProcessZombie
+	daemonProcessGone
+	daemonProcessReused
+)
+
+// inspectDaemonProcess distinguishes an exited process from an inspection
+// failure. A matching --apisock identifies the current nydusd; an empty
+// cmdline means zombie, and a different cmdline means the pid was reused.
+func inspectDaemonProcess(d *daemon.Daemon) (daemonProcessState, error) {
+	cmdline, err := readProcessCmdline(fmt.Sprintf("/proc/%d/cmdline", d.Pid()))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return daemonProcessGone, nil
+		}
+		return daemonProcessGone, err
+	}
+	if len(cmdline) == 0 {
+		return daemonProcessZombie, nil
+	}
+
+	args := strings.Split(string(cmdline), "\x00")
+	if !containsArgPair(args, "--apisock", d.GetAPISock()) {
+		return daemonProcessReused, nil
+	}
+
+	return daemonProcessAlive, nil
+}
+
+func waitUntilDaemonExited(d *daemon.Daemon, timeout time.Duration) (daemonProcessState, error) {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(processExitPollInterval)
+	defer ticker.Stop()
+
+	for {
+		state, err := inspectDaemonProcess(d)
+		if err == nil && state != daemonProcessAlive {
+			return state, nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			if err != nil {
+				return daemonProcessAlive, errors.Wrap(err, "inspect process")
+			}
+			return daemonProcessAlive, errors.Errorf("process did not exit within %s", timeout)
+		}
+	}
+}
+
+func containsArgPair(args []string, key, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == key && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }
 
 // Provide minimal parameters since most of it can be recovered by nydusd states.

--- a/pkg/manager/daemon_event_test.go
+++ b/pkg/manager/daemon_event_test.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2022. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manager
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestManagerForEvents(policy config.DaemonRecoverPolicy) *Manager {
+	return &Manager{
+		daemonCache:      newDaemonCache(),
+		LivenessNotifier: make(chan deathEvent, 10),
+		RecoverPolicy:    policy,
+	}
+}
+
+func TestHandleDaemonDeathEvent_DedupSkipsRecovery(t *testing.T) {
+	mgr := newTestManagerForEvents(config.RecoverPolicyNone)
+
+	d := &daemon.Daemon{States: daemon.ConfigState{ID: "d1"}}
+	mgr.daemonCache.Add(d)
+
+	// Simulate recovery already in progress.
+	mgr.recoveryInFlight.Store("d1", struct{}{})
+
+	mgr.LivenessNotifier <- deathEvent{daemonID: "d1", path: "/test.sock"}
+	close(mgr.LivenessNotifier)
+
+	mgr.handleDaemonDeathEvent()
+
+	// The event was skipped: state should NOT have been reset to Unknown.
+	assert.NotEqual(t, types.DaemonStateUnknown, d.State(),
+		"duplicate event should not reset daemon state")
+
+	// The pre-existing flag should still be present (not deleted by the skipped event).
+	_, loaded := mgr.recoveryInFlight.Load("d1")
+	assert.True(t, loaded, "in-flight flag should remain for the active recovery")
+}
+
+func TestHandleDaemonDeathEvent_FlagClearedAfterRecovery(t *testing.T) {
+	mgr := newTestManagerForEvents(config.RecoverPolicyNone)
+
+	d := &daemon.Daemon{States: daemon.ConfigState{ID: "d1"}}
+	mgr.daemonCache.Add(d)
+
+	mgr.LivenessNotifier <- deathEvent{daemonID: "d1", path: "/test.sock"}
+	close(mgr.LivenessNotifier)
+
+	mgr.handleDaemonDeathEvent()
+
+	// With RecoverPolicyNone, the default branch deletes the flag synchronously.
+	_, loaded := mgr.recoveryInFlight.Load("d1")
+	assert.False(t, loaded, "in-flight flag should be cleared after handling")
+
+	// State should have been reset since the event was processed.
+	assert.Equal(t, types.DaemonStateUnknown, d.State())
+}
+
+func TestHandleDaemonDeathEvent_RemovedDaemonSkipped(t *testing.T) {
+	mgr := newTestManagerForEvents(config.RecoverPolicyNone)
+
+	// Daemon not in cache — simulates concurrent removal.
+	mgr.LivenessNotifier <- deathEvent{daemonID: "gone", path: "/test.sock"}
+	close(mgr.LivenessNotifier)
+
+	mgr.handleDaemonDeathEvent()
+
+	// Should not panic, and no flag should be set.
+	_, loaded := mgr.recoveryInFlight.Load("gone")
+	assert.False(t, loaded)
+}
+
+func TestHandleDaemonDeathEvent_StaleProcessSkipped(t *testing.T) {
+	mgr := newTestManagerForEvents(config.RecoverPolicyNone)
+
+	d := &daemon.Daemon{States: daemon.ConfigState{ID: "d1", ProcessID: 202}}
+	mgr.daemonCache.Add(d)
+
+	mgr.LivenessNotifier <- deathEvent{
+		daemonID:  "d1",
+		processID: 101,
+		path:      "/test.sock",
+	}
+	close(mgr.LivenessNotifier)
+
+	mgr.handleDaemonDeathEvent()
+
+	assert.NotEqual(t, types.DaemonStateUnknown, d.State(),
+		"a death event from the previous process generation must be ignored")
+	_, loaded := mgr.recoveryInFlight.Load("d1")
+	assert.False(t, loaded)
+}
+
+func TestBeginDaemonRecoverySerializesConcurrentCalls(t *testing.T) {
+	mgr := newTestManagerForEvents(config.RecoverPolicyRestart)
+
+	const attempts = 20
+	results := make(chan bool, attempts)
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- !mgr.isRecoveryInFlight("d1")
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	started := 0
+	for result := range results {
+		if result {
+			started++
+		}
+	}
+	assert.Equal(t, 1, started, "only one concurrent recovery may start")
+
+	mgr.recoveryInFlight.Delete("d1")
+	assert.False(t, mgr.isRecoveryInFlight("d1"), "a new recovery may start after cleanup")
+}
+
+func TestInspectDaemonProcess(t *testing.T) {
+	origRead := readProcessCmdline
+	t.Cleanup(func() { readProcessCmdline = origRead })
+
+	d := &daemon.Daemon{States: daemon.ConfigState{ID: "d1", APISocket: "/test.sock", ProcessID: 123}}
+
+	// Process exited: /proc/<pid>/cmdline is gone.
+	readProcessCmdline = func(string) ([]byte, error) { return nil, os.ErrNotExist }
+	state, err := inspectDaemonProcess(d)
+	assert.NoError(t, err)
+	assert.Equal(t, daemonProcessGone, state)
+
+	// Zombie process: cmdline is empty.
+	readProcessCmdline = func(string) ([]byte, error) { return []byte{}, nil }
+	state, err = inspectDaemonProcess(d)
+	assert.NoError(t, err)
+	assert.Equal(t, daemonProcessZombie, state)
+
+	// Pid reused by another process serving a different socket.
+	readProcessCmdline = func(string) ([]byte, error) {
+		return []byte("nydusd\x00--apisock\x00/other.sock\x00"), nil
+	}
+	state, err = inspectDaemonProcess(d)
+	assert.NoError(t, err)
+	assert.Equal(t, daemonProcessReused, state)
+
+	// Alive and matching. Note: no `--id` on the command line for
+	// restart-policy daemons, only `--apisock` is guaranteed.
+	readProcessCmdline = func(string) ([]byte, error) {
+		return []byte("nydusd\x00fuse\x00--apisock\x00/test.sock\x00"), nil
+	}
+	state, err = inspectDaemonProcess(d)
+	assert.NoError(t, err)
+	assert.Equal(t, daemonProcessAlive, state)
+
+	// An unexpected inspection failure must not be mistaken for process exit.
+	readProcessCmdline = func(string) ([]byte, error) { return nil, os.ErrPermission }
+	_, err = inspectDaemonProcess(d)
+	assert.Error(t, err)
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -49,6 +49,10 @@ type Manager struct {
 	NydusdBinaryPath string
 	RecoverPolicy    config.DaemonRecoverPolicy
 	SupervisorSet    *supervisor.SupervisorsSet
+
+	// Guards against concurrent recovery for the same daemon.
+	// Key: daemon ID, Value: struct{}.
+	recoveryInFlight sync.Map
 }
 
 type Opt struct {

--- a/pkg/manager/monitor.go
+++ b/pkg/manager/monitor.go
@@ -26,7 +26,7 @@ import (
 type LivenessMonitor interface {
 	// Subscribe death event of a nydusd daemon.
 	// `path` is where the monitor is listening on.
-	Subscribe(id string, path string, notifier chan<- deathEvent) error
+	Subscribe(id string, pid int, path string, notifier chan<- deathEvent) error
 	// Unsubscribe death event of a nydusd daemon.
 	Unsubscribe(id string) error
 	// Run the monitor, wait for nydusd death event.
@@ -42,6 +42,7 @@ type target struct {
 	notifier chan<- deathEvent
 	// `id` is usually the daemon ID
 	id   string
+	pid  int
 	path string
 }
 
@@ -58,8 +59,9 @@ type livenessMonitor struct {
 }
 
 type deathEvent struct {
-	daemonID string
-	path     string
+	daemonID  string
+	processID int
+	path      string
 }
 
 func newMonitor() (_ *livenessMonitor, err error) {
@@ -78,7 +80,7 @@ func newMonitor() (_ *livenessMonitor, err error) {
 	return m, nil
 }
 
-func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deathEvent) (err error) {
+func (m *livenessMonitor) Subscribe(id string, pid int, path string, notifier chan<- deathEvent) (err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -135,7 +137,7 @@ func (m *livenessMonitor) Subscribe(id string, path string, notifier chan<- deat
 			log.L.Errorf("Failed to control epoll. daemon id %s path %s. %v", id, path, err)
 			return
 		}
-		target := &target{uc: uc, id: id, path: path}
+		target := &target{uc: uc, id: id, pid: pid, path: path}
 
 		// Only add subscribed target when everything is OK.
 		m.set[fd] = target
@@ -221,7 +223,11 @@ func (m *livenessMonitor) Run() {
 					log.L.Warnf("Daemon %s died", target.id)
 					collector.NewDaemonEventCollector(types.DaemonStateDied).Collect()
 					// Notify subscribers that death event happens
-					target.notifier <- deathEvent{daemonID: target.id, path: target.path}
+					target.notifier <- deathEvent{
+						daemonID:  target.id,
+						processID: target.pid,
+						path:      target.path,
+					}
 				}
 			}
 		}

--- a/pkg/manager/monitor_test.go
+++ b/pkg/manager/monitor_test.go
@@ -68,11 +68,11 @@ func TestLivenessMonitor(t *testing.T) {
 
 	notifier := make(chan deathEvent, 10)
 
-	e1 := monitor.Subscribe("daemon_1", s1.Name(), notifier)
+	e1 := monitor.Subscribe("daemon_1", 101, s1.Name(), notifier)
 	assert.Nil(t, e1)
-	e1 = monitor.Subscribe("daemon_1", s1.Name(), notifier)
+	e1 = monitor.Subscribe("daemon_1", 101, s1.Name(), notifier)
 	assert.NotNil(t, e1)
-	e2 := monitor.Subscribe("daemon_2", s2.Name(), notifier)
+	e2 := monitor.Subscribe("daemon_2", 202, s2.Name(), notifier)
 	assert.Nil(t, e2)
 
 	t.Cleanup(func() {
@@ -88,6 +88,7 @@ func TestLivenessMonitor(t *testing.T) {
 	cancel1()
 	event := <-notifier
 	assert.Equal(t, event.daemonID, "daemon_1")
+	assert.Equal(t, event.processID, 101)
 
 	err := monitor.Unsubscribe("daemon_2")
 	assert.Nil(t, err)


### PR DESCRIPTION
## Overview
When a nydusd daemon death event is received, the manager now terminates the
old daemon process before starting a new one, and serializes recovery so that
only one recovery routine runs per daemon at a time. This prevents zombie/
orphan nydusd accumulation and avoids duplicate concurrent restarts.
## Related Issues
Related #771

## Change Details
Previously, on a daemon death event `doDaemonRestart` / `doDaemonFailover` only
called `d.Wait()` and then started a new nydusd. When the death event was a
false positive (the API socket closed while the process was hung), the old
process kept running while a new one was spawned, and duplicate death events
could trigger multiple concurrent recoveries. Over time this leaked orphan
nydusd processes that kept hitting the registry.

This PR makes recovery robust:

- **Terminate the old process before restart/failover** (`terminateDaemonProcess`):
  - Grabs the `os.Process` handle first (uses a pidfd on Linux) to pin the
    handle to the specific process before any identity check, eliminating a
    PID-reuse TOCTOU.
  - Verifies process identity via `/proc/<pid>/cmdline` (matching `--apisock`)
    and classifies it as alive / zombie / gone / reused.
  - For a live process: sends `SIGTERM`, waits with a timeout, then escalates
    to `SIGKILL`; for a zombie: reaps it via `Wait()` with a timeout; for
    gone/reused: does nothing.
  - Returns an error on failure so recovery aborts instead of leaving an
    unmonitored live process behind. Unsubscribe now happens only after
    successful termination.
- **Serialize recovery per daemon** (`recoveryInFlight sync.Map` on `Manager`):
  - `beginDaemonRecovery` uses `LoadOrStore` to dedup concurrent death events;
    the flag is cleared when the recovery goroutine finishes.
- **Guard against stale death events**: the liveness monitor now carries the
  subscribed process PID in `deathEvent`, and `handleDaemonDeathEvent` ignores
  events whose PID no longer matches the daemon's current PID (generation
  check), preventing a delayed event for an old process from killing its
  replacement.
- Removed the `// TODO: ratelimit` and reads `d.Pid()` under the daemon lock
  (`daemonProcessID`) to avoid a data race.

## Test Results
Added unit tests in `pkg/manager/daemon_event_test.go` and updated
`monitor_test.go`:

- `TestBeginDaemonRecoverySerializesConcurrentCalls` – dedup guard.
- `TestInspectDaemonProcess` – alive / zombie / gone / reused classification.
- `TestTerminateDaemonProcessEscalatesToKill` – SIGTERM → SIGKILL escalation.
- `TestTerminateDaemonProcessReapsZombie` – zombie reap path.
- `TestTerminateDaemonProcessReturnsSignalErrorWithoutWaiting` – abort on
  signal failure.
- `TestHandleDaemonDeathEvent_*` – removed-daemon skip, dedup skip, flag clear,
  stale-PID skip.
- `TestLivenessMonitor` – verifies the PID is propagated in the death event.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.