### PR TITLE
fix: reap old nydusd after hot upgrade

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -599,12 +599,18 @@ func (d *Daemon) Terminate() error {
 	return nil
 }
 
-func (d *Daemon) Wait() error {
-	// if we found pid here, we need to kill and wait process to exit, Pid=0 means somehow we lost
-	// the daemon pid, so that we can't kill the process, just roughly umount the mountpoint
+// WaitForExit waits for the daemon process to exit and reaps it.
+// It does not perform any mount cleanup, so it is safe to use during hot upgrade.
+func (d *Daemon) WaitForExit() error {
 	d.Lock()
 	defer d.Unlock()
 
+	return d.waitProcessLocked()
+}
+
+func (d *Daemon) waitProcessLocked() error {
+	// If we found pid here, wait for the daemon process to exit. Pid=0 means somehow we lost
+	// the daemon pid, so that we can't wait for it, just roughly umount the mountpoint.
 	if d.Pid() > 0 {
 		p, err := os.FindProcess(d.Pid())
 		if err != nil {
@@ -613,7 +619,22 @@ func (d *Daemon) Wait() error {
 
 		// if nydus-snapshotter restarts, it will break the relationship between nydusd and
 		// nydus-snapshotter, p.Wait() will return err, so here should exclude this case
-		if _, err = p.Wait(); err != nil && !errors.Is(err, syscall.ECHILD) {
+		if _, err = p.Wait(); err != nil && !errors.Is(err, syscall.ECHILD) && !errors.Is(err, os.ErrProcessDone) {
+			return errors.Wrapf(err, "wait process %d", d.Pid())
+		}
+	}
+
+	return nil
+}
+
+func (d *Daemon) Wait() error {
+	// If we found pid here, wait for the daemon process to exit. Pid=0 means somehow we lost
+	// the daemon pid, so that we can't wait for it, just roughly umount the mountpoint.
+	d.Lock()
+	defer d.Unlock()
+
+	if d.Pid() > 0 {
+		if err := d.waitProcessLocked(); err != nil {
 			log.L.Errorf("failed to process wait, %v", err)
 		} else if d.HostMountpoint() != "" && config.GetFsDriver() == config.FsDriverFusedev {
 			// No need to umount if the nydusd never performs mount. In other word, it does not

--- a/pkg/daemon/daemon_wait_test.go
+++ b/pkg/daemon/daemon_wait_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package daemon
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForExitReapsChildProcess(t *testing.T) {
+	cmd := exec.Command("sleep", "1000")
+	require.NoError(t, cmd.Start())
+
+	d := &Daemon{
+		States: ConfigState{
+			ProcessID: cmd.Process.Pid,
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		done <- cmd.Process.Kill()
+	}()
+
+	require.NoError(t, d.WaitForExit())
+	require.NoError(t, <-done)
+
+	_, err := cmd.Process.Wait()
+	require.Error(t, err)
+}

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -212,12 +212,25 @@ func (fs *Filesystem) TryRetainSharedDaemon(d *daemon.Daemon) {
 			log.L.Debug("retain fscache shared daemon")
 			fs.fscacheSharedDaemon = d
 			d.IncRef()
+			return
+		}
+		// Hot-upgrade keeps the same daemon ID but replaces the running process.
+		// Make sure the filesystem tracks the new daemon object so shutdown and
+		// recovery operate on the live pid/socket pair instead of the stale one.
+		if fs.fscacheSharedDaemon.ID() == d.ID() {
+			log.L.Debugf("replace fscache shared daemon %s with upgraded daemon", d.ID())
+			fs.fscacheSharedDaemon = d
 		}
 	case config.FsDriverFusedev:
 		if fs.fusedevSharedDaemon == nil && d.HostMountpoint() == fs.rootMountpoint {
 			log.L.Debug("retain fusedev shared daemon")
 			fs.fusedevSharedDaemon = d
 			d.IncRef()
+			return
+		}
+		if fs.fusedevSharedDaemon != nil && fs.fusedevSharedDaemon.ID() == d.ID() {
+			log.L.Debugf("replace fusedev shared daemon %s with upgraded daemon", d.ID())
+			fs.fusedevSharedDaemon = d
 		}
 	}
 }

--- a/pkg/filesystem/fs_test.go
+++ b/pkg/filesystem/fs_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryRetainSharedDaemonReplacesUpgradedDaemon(t *testing.T) {
+	fs := &Filesystem{}
+
+	oldDaemon := &daemon.Daemon{
+		States: daemon.ConfigState{
+			ID:       "shared-daemon",
+			FsDriver: config.FsDriverFscache,
+		},
+	}
+	fs.TryRetainSharedDaemon(oldDaemon)
+	require.Same(t, oldDaemon, fs.fscacheSharedDaemon)
+	require.Equal(t, int32(1), oldDaemon.GetRef())
+
+	newDaemon := &daemon.Daemon{
+		States: daemon.ConfigState{
+			ID:       "shared-daemon",
+			FsDriver: config.FsDriverFscache,
+		},
+	}
+	newDaemon.IncRef()
+	fs.TryRetainSharedDaemon(newDaemon)
+
+	require.Same(t, newDaemon, fs.fscacheSharedDaemon)
+	require.Equal(t, int32(1), oldDaemon.GetRef())
+	require.Equal(t, int32(1), newDaemon.GetRef())
+}

--- a/pkg/manager/daemon_event.go
+++ b/pkg/manager/daemon_event.go
@@ -190,9 +190,12 @@ func (m *Manager) DoDaemonUpgrade(d *daemon.Daemon, nydusdPath string, manager *
 		return nil, errors.Wrap(err, "unsubscribe daemon event")
 	}
 
-	// Let the older daemon exit without umount
+	// Let the older daemon exit and be reaped without umount.
 	if err := d.Exit(); err != nil {
 		return nil, errors.Wrap(err, "old daemon exits")
+	}
+	if err := d.WaitForExit(); err != nil {
+		log.L.Warnf("wait old daemon %s exit failed: %v", d.ID(), err)
 	}
 
 	if err := newDaemon.Start(); err != nil {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -435,9 +435,12 @@ func (sc *Controller) upgradeNydusDaemon(d *daemon.Daemon, c upgradeRequest, man
 		return errors.Wrap(err, "unsubscribe daemon event")
 	}
 
-	// Let the older daemon exit without umount
+	// Let the older daemon exit and be reaped without umount.
 	if err := d.Exit(); err != nil {
 		return errors.Wrap(err, "old daemon exits")
+	}
+	if err := d.WaitForExit(); err != nil {
+		log.L.Warnf("wait old daemon %s exit failed: %v", d.ID(), err)
 	}
 
 	fs.TryRetainSharedDaemon(&newDaemon)


### PR DESCRIPTION
## Overview
Hot upgrade asks the old nydusd to exit, but snapshotter never waits on that child process. So the old daemon can be left as a defunct process after a successful upgrade.

Add a process-only wait and call it after the old daemon exits. Also keep the shared daemon pointer on the upgraded daemon object.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)