### PR TITLE
fix(snapshot): only protect idmapped RAFS instances from orphan cleanup

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -1281,11 +1281,20 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 		return nil, err
 	}
 
-	// Per-pod RAFS instances (e.g. "48-userns-<uid>") live outside
-	// containerd's IDMap — keep them alive while still referenced.
+	// Per-pod idmapped RAFS instances (e.g. "48-userns-<uid>") live outside
+	// containerd's IDMap, so they must be protected from orphan cleanup while
+	// still referenced. They are the only instances with a SourceSnapshotID
+	// (set when remap-ids labels are present). Ordinary instances share their
+	// ID with containerd's IDMap: while live they are already retained by the
+	// `ids` check below, and once their snapshot metadata is removed they must
+	// stay eligible for cleanup so the mount is torn down and the cached blobs
+	// released. Protecting them here would keep the mount referenced
+	// indefinitely and leak disk.
 	liveRafsSnapshotDirs := make(map[string]struct{})
 	for _, instance := range rafs.RafsGlobalCache.List() {
-		liveRafsSnapshotDirs[filepath.Base(instance.GetSnapshotDir())] = struct{}{}
+		if instance.SourceSnapshotID != "" {
+			liveRafsSnapshotDirs[filepath.Base(instance.GetSnapshotDir())] = struct{}{}
+		}
 	}
 
 	// For example:

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -9,6 +9,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -344,6 +345,62 @@ func TestMountNativeConfigVolatile(t *testing.T) {
 		require.Len(t, mounts, 1)
 		assert.NotContains(t, mounts[0].Options, "volatile")
 	})
+}
+
+func TestGetCleanupDirectoriesProtectsOnlyIDMappedInstances(t *testing.T) {
+	originalInstances := rafs.RafsGlobalCache.List()
+	rafs.RafsGlobalCache.SetIntances(make(map[string]*rafs.Rafs))
+	t.Cleanup(func() {
+		rafs.RafsGlobalCache.SetIntances(originalInstances)
+	})
+
+	snapshotterRoot := t.TempDir()
+	ms, err := storage.NewMetaStore(filepath.Join(snapshotterRoot, "metadata.db"))
+	require.NoError(t, err)
+	s := &snapshotter{
+		root: snapshotterRoot,
+		ms:   ms,
+	}
+
+	// A committed snapshot that containerd still tracks: it appears in the
+	// IDMap and represents a genuinely-live ordinary instance.
+	txCtx, trans, err := ms.TransactionContext(context.Background(), true)
+	require.NoError(t, err)
+	_, err = storage.CreateSnapshot(txCtx, snapshots.KindActive, "live-key", "")
+	require.NoError(t, err)
+	liveID, err := storage.CommitActive(txCtx, "live-key", "live", snapshots.Usage{})
+	require.NoError(t, err)
+	require.NoError(t, trans.Commit())
+
+	// An orphaned ordinary instance and an orphaned idmapped instance: both
+	// exist on disk and are still referenced in the RAFS cache, but neither is
+	// tracked by containerd anymore (as after image GC removed their metadata).
+	// The idmapped per-pod instance carries a SourceSnapshotID (set only when
+	// remap-ids labels are present); ordinary instances leave it empty.
+	const ordinaryID = "48"
+	const idMappedSource = "50"
+	idMappedID := label.RafsInstanceID(idMappedSource, &label.IDMapping{External: 100000, Range: 65536})
+	instances := []*rafs.Rafs{
+		{SnapshotID: liveID, SnapshotDir: s.snapshotDir(liveID)},
+		{SnapshotID: ordinaryID, SnapshotDir: s.snapshotDir(ordinaryID)},
+		{SnapshotID: idMappedID, SnapshotDir: s.snapshotDir(idMappedID), SourceSnapshotID: idMappedSource},
+	}
+	for _, instance := range instances {
+		require.NoError(t, os.MkdirAll(instance.SnapshotDir, 0o755))
+		rafs.RafsGlobalCache.Add(instance)
+	}
+
+	cleanup, err := s.cleanupDirectories(context.Background())
+	require.NoError(t, err)
+
+	// The ordinary orphan must be eligible for cleanup, otherwise its mount is
+	// never torn down and its cached blobs are never released.
+	assert.Contains(t, cleanup, s.snapshotDir(ordinaryID))
+	// A live ordinary instance stays protected via the IDMap, and the idmapped
+	// per-pod instance (which containerd's IDMap never tracks) stays protected
+	// while still referenced.
+	assert.NotContains(t, cleanup, s.snapshotDir(liveID))
+	assert.NotContains(t, cleanup, s.snapshotDir(idMappedID))
 }
 
 func TestMountRemoteUsesPerPodLowerdirForIDMap(t *testing.T) {


### PR DESCRIPTION
`getCleanupDirectories` protects live RAFS instance directories from orphan cleanup by building `liveRafsSnapshotDirs` from every entry in `RafsGlobalCache`. This was introduced in #767 to keep per-pod idmapped instances (`<snapshotID>-userns-<uid>`), which are absent from containerd's snapshot `IDMap`, from being reaped while live.

It also protects ordinary (non-idmapped) instances, whose directory name is exactly the containerd snapshot ID. Those are already retained by the existing `IDMap` (`ids`) check while live. Once their metadata is removed by image GC they should become cleanup-eligible, but the instance remains in `RafsGlobalCache` until it is unmounted — and cleanup is what performs the unmount. The instance therefore protects itself indefinitely: it is never unmounted, never leaves the cache, and its mount keeps the cached blobs referenced, so disk is never reclaimed.

This fix restricts the protection set to genuinely idmapped instances (the `-userns-` suffix). Ordinary instances remain governed solely by the `IDMap` check — retained while live, eligible for cleanup once GC'd. Idmapped instances are unmounted on `Remove` via the existing `UmountByLabels`, after which they leave the cache and become eligible on the next pass.

A regression test (`TestGetCleanupDirectoriesProtectsOnlyIDMappedInstances`) covers all three cases: a live ordinary instance stays protected via the `IDMap`, an orphaned ordinary instance becomes cleanup-eligible, and a live idmapped instance stays protected.
