### PR TITLE
fix(snapshot): make blob cache GC fail-safe for instances with unknown usage

### DIFF
--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -308,7 +308,13 @@ func (fs *Filesystem) WaitUntilReady(snapshotID string, labels map[string]string
 
 		cacheMetrics, err := d.GetCacheMetrics(sid)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get cache metric")
+			// The daemon is already verified RUNNING above; failing the mount
+			// over a metrics hiccup fails pod creation for no reason (#762).
+			// The underlying-files list only feeds blob cache GC accounting,
+			// and GC treats instances with unknown usage as fully in use, so
+			// continuing without it is safe.
+			log.L.WithError(err).Warnf("failed to get cache metrics for rafs instance %s", rafs.SnapshotID)
+			return nil
 		}
 		log.L.Debugf("Found %d underlying files for rafs instance %s", len(cacheMetrics.UnderlyingFiles), rafs.SnapshotID)
 

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -287,42 +287,16 @@ func (fs *Filesystem) WaitUntilReady(snapshotID string, labels map[string]string
 			return err
 		}
 
-		// For shared daemons, we need to use the correct cache ID to query metrics.
-		// For fscache, the cache is registered with fscacheID (a digest), not the raw snapshot ID.
-		// For fusedev, the cache is registered with the snapshot ID.
-		sid := ""
-		if d.IsSharedDaemon() {
-			if rafs.GetFsDriver() == config.FsDriverFscache {
-				// For fscache, use the fscache ID from annotations if available
-				if fscacheID, ok := rafs.Annotations[racache.AnnoFsCacheID]; ok && fscacheID != "" {
-					sid = fscacheID
-				} else {
-					// Fallback: compute fscacheID if not in annotations yet
-					sid = erofs.FscacheID(rafs.SnapshotID)
-				}
-			} else {
-				// For fusedev, use the snapshot ID directly
-				sid = rafs.SnapshotID
-			}
-		}
-
-		cacheMetrics, err := d.GetCacheMetrics(sid)
-		if err != nil {
+		if err := fs.RefreshUnderlyingFiles(rafs); err != nil {
 			// The daemon is already verified RUNNING above; failing the mount
 			// over a metrics hiccup fails pod creation for no reason (#762).
 			// The underlying-files list only feeds blob cache GC accounting,
-			// and GC treats instances with unknown usage as fully in use, so
-			// continuing without it is safe.
+			// and the GC reconciles instances with unknown usage before every
+			// round, treating them as fully in use until then, so continuing
+			// without it is safe.
 			log.L.WithError(err).Warnf("failed to get cache metrics for rafs instance %s", rafs.SnapshotID)
 			return nil
 		}
-		log.L.Debugf("Found %d underlying files for rafs instance %s", len(cacheMetrics.UnderlyingFiles), rafs.SnapshotID)
-
-		// Lock the daemon's RafsCache when modifying rafs fields to prevent
-		// race conditions with concurrent reads (e.g., during cache cleanup)
-		d.RafsCache.Lock()
-		rafs.UnderlyingFiles = cacheMetrics.UnderlyingFiles
-		d.RafsCache.Unlock()
 
 		fsManager, err := fs.getManager(rafs.GetFsDriver())
 		if err != nil {
@@ -334,6 +308,57 @@ func (fs *Filesystem) WaitUntilReady(snapshotID string, labels map[string]string
 		}
 		log.L.Debugf("Nydus remote snapshot %s is ready", snapshotID)
 	}
+
+	return nil
+}
+
+// RefreshUnderlyingFiles queries the nydusd daemon serving a RAFS instance for
+// its cache metrics and updates instance.UnderlyingFiles with the result.
+//
+// Unlike calling d.GetCacheMetrics directly, it fails fast when the daemon's
+// API socket does not exist instead of polling for it to appear, so periodic
+// callers (e.g. blob cache GC reconciliation) are never stalled behind a dead
+// or still-starting daemon.
+func (fs *Filesystem) RefreshUnderlyingFiles(instance *racache.Rafs) error {
+	d, err := fs.getDaemonByRafs(instance)
+	if err != nil {
+		return errors.Wrapf(err, "get daemon for rafs instance %s", instance.SnapshotID)
+	}
+
+	if st, err := os.Stat(d.GetAPISock()); err != nil || st.Mode()&os.ModeSocket == 0 {
+		return errors.Wrapf(errdefs.ErrNotFound, "api socket %s of daemon %s", d.GetAPISock(), d.ID())
+	}
+
+	// For shared daemons, we need to use the correct cache ID to query metrics.
+	// For fscache, the cache is registered with fscacheID (a digest), not the raw snapshot ID.
+	// For fusedev, the cache is registered with the snapshot ID.
+	sid := ""
+	if d.IsSharedDaemon() {
+		if instance.GetFsDriver() == config.FsDriverFscache {
+			// For fscache, use the fscache ID from annotations if available
+			if fscacheID, ok := instance.Annotations[racache.AnnoFsCacheID]; ok && fscacheID != "" {
+				sid = fscacheID
+			} else {
+				// Fallback: compute fscacheID if not in annotations yet
+				sid = erofs.FscacheID(instance.SnapshotID)
+			}
+		} else {
+			// For fusedev, use the snapshot ID directly
+			sid = instance.SnapshotID
+		}
+	}
+
+	cacheMetrics, err := d.GetCacheMetrics(sid)
+	if err != nil {
+		return errors.Wrapf(err, "get cache metrics for rafs instance %s", instance.SnapshotID)
+	}
+	log.L.Debugf("Found %d underlying files for rafs instance %s", len(cacheMetrics.UnderlyingFiles), instance.SnapshotID)
+
+	// Lock the daemon's RafsCache when modifying rafs fields to prevent
+	// race conditions with concurrent reads (e.g., during cache cleanup)
+	d.RafsCache.Lock()
+	instance.UnderlyingFiles = cacheMetrics.UnderlyingFiles
+	d.RafsCache.Unlock()
 
 	return nil
 }

--- a/pkg/filesystem/fs_test.go
+++ b/pkg/filesystem/fs_test.go
@@ -8,10 +8,16 @@ package filesystem
 
 import (
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
-	"github.com/stretchr/testify/require"
+	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/containerd/nydus-snapshotter/pkg/manager"
+	racache "github.com/containerd/nydus-snapshotter/pkg/rafs"
+	"github.com/containerd/nydus-snapshotter/pkg/store"
 )
 
 func TestTryRetainSharedDaemonReplacesUpgradedDaemon(t *testing.T) {
@@ -39,4 +45,45 @@ func TestTryRetainSharedDaemonReplacesUpgradedDaemon(t *testing.T) {
 	require.Same(t, newDaemon, fs.fscacheSharedDaemon)
 	require.Equal(t, int32(1), oldDaemon.GetRef())
 	require.Equal(t, int32(1), newDaemon.GetRef())
+}
+
+// RefreshUnderlyingFiles is called from the blob cache GC path for every
+// instance with unknown usage, so a daemon whose API socket is gone must make
+// it fail immediately rather than sit in the 10-second socket poll that
+// d.GetClient performs.
+func TestRefreshUnderlyingFilesFailsFastWithoutDaemonSocket(t *testing.T) {
+	rootDir := t.TempDir()
+	db, err := store.NewDatabase(rootDir)
+	require.NoError(t, err)
+
+	m, err := manager.NewManager(manager.Opt{
+		Database:      db,
+		RootDir:       rootDir,
+		FsDriver:      config.FsDriverFusedev,
+		RecoverPolicy: config.RecoverPolicyRestart,
+	})
+	require.NoError(t, err)
+
+	d, err := daemon.NewDaemon(
+		daemon.WithSocketDir(rootDir),
+		daemon.WithConfigDir(rootDir),
+		daemon.WithLogDir(rootDir),
+		daemon.WithFsDriver(config.FsDriverFusedev),
+		daemon.WithDaemonMode(config.DaemonModeDedicated),
+	)
+	require.NoError(t, err)
+	require.NoError(t, m.AddDaemon(d))
+
+	fs := &Filesystem{enabledManagers: map[string]*manager.Manager{config.FsDriverFusedev: m}}
+	instance := &racache.Rafs{
+		SnapshotID: "snap-1",
+		DaemonID:   d.ID(),
+		FsDriver:   config.FsDriverFusedev,
+	}
+
+	start := time.Now()
+	err = fs.RefreshUnderlyingFiles(instance)
+	require.True(t, errdefs.IsNotFound(err))
+	require.Less(t, time.Since(start), 5*time.Second)
+	require.Empty(t, instance.UnderlyingFiles)
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -1396,7 +1396,43 @@ func collectUsedCacheBlobIDs(instances []*rafs.Rafs) (map[string]bool, bool) {
 	return usedBlobIDs, complete
 }
 
+// reconcileUnknownCacheUsage re-queries cache metrics for RAFS instances whose
+// UnderlyingFiles has not been populated yet — their post-mount Mounts() call
+// has not happened, or its metrics fetch failed — so that a single such
+// instance does not keep blob cache GC paused. It involves daemon socket I/O
+// and therefore must run outside any metastore transaction. Failures are
+// tolerated: the instance keeps its unknown usage and getUnusedCacheBlobs
+// skips the round.
+func (o *snapshotter) reconcileUnknownCacheUsage() {
+	if err := o.fs.WalkManagers(func(fsManager *mgr.Manager) error {
+		for _, d := range fsManager.ListDaemons() {
+			for snapshotID, instance := range d.RafsCache.List() {
+				fsDriver := instance.GetFsDriver()
+				if fsDriver != config.FsDriverFscache && fsDriver != config.FsDriverFusedev {
+					continue
+				}
+				if len(instance.UnderlyingFiles) != 0 {
+					continue
+				}
+				// List() hands out deep copies; refresh the registered instance.
+				live := d.RafsCache.Get(snapshotID)
+				if live == nil {
+					continue
+				}
+				if err := o.fs.RefreshUnderlyingFiles(live); err != nil {
+					log.L.WithError(err).Debugf("[getUnusedCacheBlobs] cannot refresh underlying files of rafs instance %s", snapshotID)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		log.L.WithError(err).Warn("[getUnusedCacheBlobs] reconcile instances with unknown cache usage")
+	}
+}
+
 func (o *snapshotter) getUnusedCacheBlobs(ctx context.Context) ([]string, error) {
+	o.reconcileUnknownCacheUsage()
+
 	// Get a write transaction to ensure no other write transaction can be entered
 	// while the cleanup is scanning.
 	_, t, err := o.ms.TransactionContext(ctx, true)
@@ -1426,10 +1462,11 @@ func (o *snapshotter) getUnusedCacheBlobs(ctx context.Context) ([]string, error)
 	usedBlobIDs, complete := collectUsedCacheBlobIDs(instances)
 	if !complete {
 		// Unknown usage must count as "in use": deleting blobs based on
-		// incomplete knowledge unlinks cache files under a live daemon. The
-		// gap self-heals once WaitUntilReady populates the instance on the
-		// next Mounts() call, so skip this round instead of guessing.
-		log.L.Info("[getUnusedCacheBlobs] usage of some RAFS instances is not known yet, skipping cache GC this round")
+		// incomplete knowledge unlinks cache files under a live daemon.
+		// Reconciliation above already retried the metrics query, so reaching
+		// this point means a daemon is unreachable right now; skip the round
+		// instead of guessing and let a later round retry.
+		log.L.Info("[getUnusedCacheBlobs] usage of some RAFS instances is still unknown after reconciliation, skipping cache GC this round")
 		return nil, nil
 	}
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -1366,6 +1366,36 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 	return nil
 }
 
+// collectUsedCacheBlobIDs gathers the cache blob IDs referenced by the given
+// RAFS instances. It returns complete == false when any fscache/fusedev
+// instance has no underlying-files information yet — e.g. it was just mounted
+// and containerd has not called Mounts()/WaitUntilReady for it, or its cache
+// metrics fetch failed — meaning the returned set MUST NOT be used to decide
+// deletions: an instance with unknown usage may use any blob in the cache.
+func collectUsedCacheBlobIDs(instances []*rafs.Rafs) (map[string]bool, bool) {
+	usedBlobIDs := make(map[string]bool)
+	complete := true
+	for _, instance := range instances {
+		fsDriver := instance.GetFsDriver()
+		if fsDriver != config.FsDriverFscache && fsDriver != config.FsDriverFusedev {
+			// Only blobcache-backed drivers materialize files in the cache
+			// directory; other drivers never populate UnderlyingFiles.
+			continue
+		}
+		if len(instance.UnderlyingFiles) == 0 {
+			complete = false
+			continue
+		}
+		for _, filePath := range instance.UnderlyingFiles {
+			filename := filepath.Base(filePath)
+			if blobID := cache.ExtractBlobIDFromFilename(filename); blobID != "" {
+				usedBlobIDs[blobID] = true
+			}
+		}
+	}
+	return usedBlobIDs, complete
+}
+
 func (o *snapshotter) getUnusedCacheBlobs(ctx context.Context) ([]string, error) {
 	// Get a write transaction to ensure no other write transaction can be entered
 	// while the cleanup is scanning.
@@ -1381,25 +1411,26 @@ func (o *snapshotter) getUnusedCacheBlobs(ctx context.Context) ([]string, error)
 	}()
 
 	// Collect all used blob IDs from all daemons
-	usedBlobIDs := make(map[string]bool)
+	var instances []*rafs.Rafs
 	if err := o.fs.WalkManagers(func(mgr *mgr.Manager) error {
 		for _, d := range mgr.ListDaemons() {
-			// Get all rafs instances for this daemon
-			for _, rafs := range d.RafsCache.List() {
-				// Extract blob IDs from underlying files and mark as used
-				for _, filePath := range rafs.UnderlyingFiles {
-					// Extract blob ID from the file path
-					filename := filepath.Base(filePath)
-					blobID := cache.ExtractBlobIDFromFilename(filename)
-					if blobID != "" {
-						usedBlobIDs[blobID] = true
-					}
-				}
+			for _, instance := range d.RafsCache.List() {
+				instances = append(instances, instance)
 			}
 		}
 		return nil
 	}); err != nil {
 		return nil, errors.Wrap(err, "walk managers to collect used blobs")
+	}
+
+	usedBlobIDs, complete := collectUsedCacheBlobIDs(instances)
+	if !complete {
+		// Unknown usage must count as "in use": deleting blobs based on
+		// incomplete knowledge unlinks cache files under a live daemon. The
+		// gap self-heals once WaitUntilReady populates the instance on the
+		// next Mounts() call, so skip this round instead of guessing.
+		log.L.Info("[getUnusedCacheBlobs] usage of some RAFS instances is not known yet, skipping cache GC this round")
+		return nil, nil
 	}
 
 	log.L.Debugf("[getUnusedCacheBlobs] found %d used blob IDs", len(usedBlobIDs))

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -347,6 +347,31 @@ func TestMountNativeConfigVolatile(t *testing.T) {
 	})
 }
 
+func TestCollectUsedCacheBlobIDs(t *testing.T) {
+	blobA := "1f66d51e5b3a51e0a4e942f89e2b9c4a7c76b0678c1c1e74dcb0f5e8a4b1c001"
+	blobB := "2a77e62f6c4b62f1b5fa53f9af3cad5b8d87c1789d2d2f85edc1a6f9b5c2d002"
+
+	known := &rafs.Rafs{
+		SnapshotID:      "1",
+		FsDriver:        "fusedev",
+		UnderlyingFiles: []string{"/cache/" + blobA, "/cache/" + blobB + ".blob.meta"},
+	}
+	otherDriver := &rafs.Rafs{SnapshotID: "2", FsDriver: "blockdev"}
+
+	// All blobcache-backed instances report their files: the set is complete
+	// and safe to delete against.
+	used, complete := collectUsedCacheBlobIDs([]*rafs.Rafs{known, otherDriver})
+	assert.True(t, complete)
+	assert.Equal(t, map[string]bool{blobA: true, blobB: true}, used)
+
+	// An instance whose usage is not known yet (mounted, but Mounts() has not
+	// populated UnderlyingFiles) makes the set incomplete: deleting based on
+	// it would unlink cache files under a live daemon.
+	unknown := &rafs.Rafs{SnapshotID: "3", FsDriver: "fusedev"}
+	_, complete = collectUsedCacheBlobIDs([]*rafs.Rafs{known, unknown})
+	assert.False(t, complete)
+}
+
 func TestGetCleanupDirectoriesProtectsOnlyIDMappedInstances(t *testing.T) {
 	originalInstances := rafs.RafsGlobalCache.List()
 	rafs.RafsGlobalCache.SetIntances(make(map[string]*rafs.Rafs))


### PR DESCRIPTION
The cache GC computes its used-blob set solely from `UnderlyingFiles`, which is populated only when containerd calls `Mounts()` (`WaitUntilReady`). Every instance between `fs.Mount()` and its first `Mounts()` call — a window that always exists during pod startup — contributes nothing to the used set, so `getUnusedCacheBlobs` classifies the blobs its freshly started nydusd is already serving as unused, and `RemoveCache` unlinks blob data, chunk maps and blob.meta files under the live daemon. Unlinked-but-open files also keep consuming disk while being invisible to the GC's own accounting.

```mermaid
flowchart LR
    A["fs.Mount: nydusd started<br/>UnderlyingFiles = ∅"] --> B["GC fires in the window"]
    B --> C["instance contributes nothing<br/>to the used set"]
    C --> D["🗑️ blob, chunk_map, blob.meta<br/>unlinked under a live daemon"]
    D --> E["💥 cache thrash · EIO ·<br/>unlinked-but-open files hide<br/>disk usage from GC itself"]
```

Treat unknown as in-use: extract the used-set computation into `collectUsedCacheBlobIDs`, which reports whether the set is complete, and skip the GC round entirely when any blobcache-backed instance has no usage information yet. The gap self-heals once `Mounts()` populates the instance, so pausing one round is safe; deleting on incomplete knowledge is not. Before taking the write transaction, the GC re-queries cache metrics for instances with no usage info yet, checking the daemon socket exists first since `Daemon.GetClient` can poll for it for up to 10s. The round is only skipped if usage is still unknown after that.

Consequently `WaitUntilReady` no longer fails the mount when the one-shot cache metrics fetch errors: the daemon is already verified RUNNING, the metrics only feed GC accounting, and GC now degrades safely when the information is missing.

Fixes #762

