### PR TITLE
fix(manager): quarantine damaged daemon records instead of aborting recovery

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -311,6 +311,12 @@ func (m *Manager) cleanUpDaemonResources(d *daemon.Daemon) {
 
 func (m *Manager) recoverDaemons(ctx context.Context,
 	recoveringDaemons *map[string]*daemon.Daemon, liveDaemons *map[string]*daemon.Daemon) error {
+	// Records whose on-disk artifacts are damaged — e.g. a daemon that was
+	// persisted but whose config file never made it to disk. One damaged
+	// record must not abort the whole walk: returning an error here fails
+	// NewSnapshotter, and since the record is never pruned the snapshotter
+	// crash-loops on every restart until the database is repaired by hand.
+	var quarantined []*daemon.Daemon
 	if err := m.store.WalkDaemons(ctx, func(s *daemon.ConfigState) error {
 		if s.FsDriver != m.FsDriver {
 			return nil
@@ -334,8 +340,10 @@ func (m *Manager) recoverDaemons(ctx context.Context,
 		if d.States.FsDriver == config.FsDriverFusedev {
 			cfg, err := daemonconfig.NewDaemonConfig(d.States.FsDriver, d.ConfigFile(""))
 			if err != nil {
-				log.L.Errorf("Failed to reload daemon configuration %s, %s", d.ConfigFile(""), err)
-				return err
+				log.L.Errorf("Quarantining daemon %s: failed to reload configuration %s, %s", d.ID(), d.ConfigFile(""), err)
+				quarantined = append(quarantined, d)
+				//nolint:nilerr
+				return nil
 			}
 
 			d.Config = cfg
@@ -385,6 +393,18 @@ func (m *Manager) recoverDaemons(ctx context.Context,
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk daemons to reconnect")
+	}
+
+	// Prune quarantined records outside the walk since the bucket must not be
+	// mutated during ForEach. A daemon without its configuration cannot be
+	// recovered or managed; dropping the record keeps the next restart from
+	// tripping over it again, and orphan process cleanup is handled by the
+	// regular vestige clearing.
+	for _, d := range quarantined {
+		m.daemonCache.Remove(d)
+		if err := m.store.DeleteDaemon(d.ID()); err != nil {
+			log.L.WithError(err).Warnf("failed to prune quarantined daemon record %s", d.ID())
+		}
 	}
 
 	return nil

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -314,9 +314,9 @@ func (m *Manager) recoverDaemons(ctx context.Context,
 	// Records whose on-disk artifacts are damaged — e.g. a daemon that was
 	// persisted but whose config file never made it to disk. One damaged
 	// record must not abort the whole walk: returning an error here fails
-	// NewSnapshotter, and since the record is never pruned the snapshotter
-	// crash-loops on every restart until the database is repaired by hand.
-	var quarantined []*daemon.Daemon
+	// NewSnapshotter, crash-looping the snapshotter on every restart until
+	// the database is repaired by hand. The record itself is kept: restoring
+	// the config file lets a later restart re-adopt the daemon.
 	if err := m.store.WalkDaemons(ctx, func(s *daemon.ConfigState) error {
 		if s.FsDriver != m.FsDriver {
 			return nil
@@ -340,8 +340,8 @@ func (m *Manager) recoverDaemons(ctx context.Context,
 		if d.States.FsDriver == config.FsDriverFusedev {
 			cfg, err := daemonconfig.NewDaemonConfig(d.States.FsDriver, d.ConfigFile(""))
 			if err != nil {
-				log.L.Errorf("Quarantining daemon %s: failed to reload configuration %s, %s", d.ID(), d.ConfigFile(""), err)
-				quarantined = append(quarantined, d)
+				log.L.Errorf("Skipping recovery of daemon %s: failed to reload configuration %s, %s", d.ID(), d.ConfigFile(""), err)
+				m.daemonCache.Remove(d)
 				//nolint:nilerr
 				return nil
 			}
@@ -393,18 +393,6 @@ func (m *Manager) recoverDaemons(ctx context.Context,
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk daemons to reconnect")
-	}
-
-	// Prune quarantined records outside the walk since the bucket must not be
-	// mutated during ForEach. A daemon without its configuration cannot be
-	// recovered or managed; dropping the record keeps the next restart from
-	// tripping over it again, and orphan process cleanup is handled by the
-	// regular vestige clearing.
-	for _, d := range quarantined {
-		m.daemonCache.Remove(d)
-		if err := m.store.DeleteDaemon(d.ID()); err != nil {
-			log.L.WithError(err).Warnf("failed to prune quarantined daemon record %s", d.ID())
-		}
 	}
 
 	return nil

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/store"
 )
 
-func TestRecoverDaemonsQuarantinesRecordsWithoutConfig(t *testing.T) {
+func TestRecoverDaemonsSkipsRecordsWithoutConfig(t *testing.T) {
 	rootDir := t.TempDir()
 	db, err := store.NewDatabase(rootDir)
 	require.NoError(t, err)
@@ -69,14 +69,22 @@ func TestRecoverDaemonsQuarantinesRecordsWithoutConfig(t *testing.T) {
 	assert.Empty(t, recovering)
 	assert.Empty(t, live)
 
-	// The damaged records are pruned so the next restart does not trip over
-	// them again; the unrelated record is untouched.
+	// The damaged records stay in the store: a missing config file does not
+	// prove the daemon is dead, and keeping the record lets a later restart
+	// re-adopt the daemon once the file is restored.
 	remaining := make(map[string]string)
 	require.NoError(t, m.store.WalkDaemons(context.Background(), func(s *daemon.ConfigState) error {
 		remaining[s.ID] = s.FsDriver
 		return nil
 	}))
-	assert.Equal(t, map[string]string{other.ID(): config.FsDriverFscache}, remaining)
+	expected := map[string]string{other.ID(): config.FsDriverFscache}
+	for _, d := range poisoned {
+		expected[d.ID()] = config.FsDriverFusedev
+	}
+	assert.Equal(t, expected, remaining)
+
+	// Only the in-memory registration is dropped, so no half-initialized
+	// daemon without its configuration lingers in the cache.
 	for _, d := range poisoned {
 		assert.Nil(t, m.daemonCache.GetByDaemonID(d.ID(), nil))
 	}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/containerd/nydus-snapshotter/pkg/store"
+)
+
+func TestRecoverDaemonsQuarantinesRecordsWithoutConfig(t *testing.T) {
+	rootDir := t.TempDir()
+	db, err := store.NewDatabase(rootDir)
+	require.NoError(t, err)
+
+	m, err := NewManager(Opt{
+		Database:      db,
+		RootDir:       rootDir,
+		FsDriver:      config.FsDriverFusedev,
+		RecoverPolicy: config.RecoverPolicyRestart,
+	})
+	require.NoError(t, err)
+
+	// Two fusedev daemon records persisted without their config file on disk,
+	// as left behind by a crash (or full disk) between persisting the record
+	// and dumping the configuration.
+	poisoned := make([]*daemon.Daemon, 0, 2)
+	for range 2 {
+		d, err := daemon.NewDaemon(
+			daemon.WithSocketDir(rootDir),
+			daemon.WithConfigDir(rootDir),
+			daemon.WithLogDir(rootDir),
+			daemon.WithFsDriver(config.FsDriverFusedev),
+			daemon.WithDaemonMode(config.DaemonModeDedicated),
+		)
+		require.NoError(t, err)
+		require.NoError(t, m.AddDaemon(d))
+		poisoned = append(poisoned, d)
+	}
+
+	// A record of another fs driver must be ignored by this manager and
+	// survive untouched.
+	other, err := daemon.NewDaemon(
+		daemon.WithSocketDir(rootDir),
+		daemon.WithConfigDir(rootDir),
+		daemon.WithLogDir(rootDir),
+		daemon.WithFsDriver(config.FsDriverFscache),
+		daemon.WithDaemonMode(config.DaemonModeShared),
+	)
+	require.NoError(t, err)
+	require.NoError(t, m.AddDaemon(other))
+
+	// Recovery must not abort on the damaged records: returning an error here
+	// fails NewSnapshotter on every restart, permanently crash-looping the
+	// snapshotter until the database is repaired by hand.
+	recovering := make(map[string]*daemon.Daemon)
+	live := make(map[string]*daemon.Daemon)
+	require.NoError(t, m.recoverDaemons(context.Background(), &recovering, &live))
+	assert.Empty(t, recovering)
+	assert.Empty(t, live)
+
+	// The damaged records are pruned so the next restart does not trip over
+	// them again; the unrelated record is untouched.
+	remaining := make(map[string]string)
+	require.NoError(t, m.store.WalkDaemons(context.Background(), func(s *daemon.ConfigState) error {
+		remaining[s.ID] = s.FsDriver
+		return nil
+	}))
+	assert.Equal(t, map[string]string{other.ID(): config.FsDriverFscache}, remaining)
+	for _, d := range poisoned {
+		assert.Nil(t, m.daemonCache.GetByDaemonID(d.ID(), nil))
+	}
+}


### PR DESCRIPTION
A persisted fusedev daemon record whose `config.json` cannot be reloaded made `recoverDaemons` return an error, aborting the whole `WalkDaemons` pass and failing `NewSnapshotter`. Since daemon records are never pruned, one damaged record crash-loops the snapshotter on every restart until the boltdb is repaired by hand.

Such records are easy to acquire: `createDaemon` persists the record before the configuration is dumped to disk, so a crash or a full disk (the likeliest cause, since the blob cache shares the volume) in that window leaves a record without a config file; a power loss can truncate an existing config the same way.

```mermaid
flowchart LR
    A["record persisted,<br/>config.json missing"] --> B["restart → recovery walk"]
    B --> C["config reload fails →<br/>whole walk aborts"]
    C --> D["NewSnapshotter fails →<br/>snapshotter exits"]
    D --> B
    C --> E["💥 crash loop until manual<br/>boltdb surgery"]
```

Make recovery fault-isolated per record: skip records whose configuration cannot be reloaded — log and continue recovering everything else. The record stays in the store, so restoring the config file lets a later restart re-adopt the daemon.

Persisting the record only after its configuration is on disk is a worthwhile follow-up hardening; this change makes recovery robust to such damage regardless of how it was produced.

