### PR TITLE
fix: two data races between background goroutines and their readers

### DIFF
--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -354,11 +354,11 @@ func (fs *Filesystem) RefreshUnderlyingFiles(instance *racache.Rafs) error {
 	}
 	log.L.Debugf("Found %d underlying files for rafs instance %s", len(cacheMetrics.UnderlyingFiles), instance.SnapshotID)
 
-	// Lock the daemon's RafsCache when modifying rafs fields to prevent
-	// race conditions with concurrent reads (e.g., during cache cleanup)
-	d.RafsCache.Lock()
-	instance.UnderlyingFiles = cacheMetrics.UnderlyingFiles
-	d.RafsCache.Unlock()
+	// This instance is handed out by two registries — RafsGlobalCache
+	// (snapshot cleanup) and the daemon's RafsCache (cache GC, metrics) —
+	// whose deep-copying readers each hold only their own cache's mutex,
+	// so the update must exclude both.
+	instance.UpdateUnderlyingFiles(cacheMetrics.UnderlyingFiles, &d.RafsCache)
 
 	return nil
 }

--- a/pkg/metrics/types/types.go
+++ b/pkg/metrics/types/types.go
@@ -8,6 +8,7 @@ package fs
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -55,6 +56,10 @@ type MetricHistogram struct {
 	Buckets     []uint64
 	GetCounters GetCountersFn
 
+	// Guards constHists: Clear/Save run on the metrics collection goroutine
+	// while Collect is invoked by the Prometheus registry from HTTP scrape
+	// goroutines.
+	mu sync.Mutex
 	// Save the last generated histogram metric
 	constHists []prometheus.Metric
 }
@@ -83,10 +88,14 @@ func (h *MetricHistogram) ToConstHistogram(m *types.FsMetrics, imageRef string) 
 }
 
 func (h *MetricHistogram) Clear() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.constHists = nil
 }
 
 func (h *MetricHistogram) Save(m prometheus.Metric) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.constHists = append(h.constHists, m)
 }
 
@@ -98,9 +107,9 @@ func (h *MetricHistogram) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (h *MetricHistogram) Collect(ch chan<- prometheus.Metric) {
-	if h.constHists != nil {
-		for _, hist := range h.constHists {
-			ch <- hist
-		}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, hist := range h.constHists {
+		ch <- hist
 	}
 }

--- a/pkg/metrics/types/types_test.go
+++ b/pkg/metrics/types/types_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Exercises the collection loop (Clear/Save) concurrently with a Prometheus
+// scrape (Collect). Meaningful under the race detector: the two run on
+// different goroutines in the snapshotter and used to share constHists with
+// no synchronization.
+func TestMetricHistogramConcurrentCollectAndScrape(t *testing.T) {
+	h := &MetricHistogram{
+		Desc: prometheus.NewDesc("test_hist", "test histogram", nil, nil),
+	}
+	metric := prometheus.MustNewConstMetric(
+		prometheus.NewDesc("test_metric", "test metric", nil, nil),
+		prometheus.CounterValue, 1,
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			h.Clear()
+			h.Save(metric)
+			h.Save(metric)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		ch := make(chan prometheus.Metric, 16)
+		done := make(chan struct{})
+		go func() {
+			for range ch {
+			}
+			close(done)
+		}()
+		for range 1000 {
+			h.Collect(ch)
+		}
+		close(ch)
+		<-done
+	}()
+	wg.Wait()
+}

--- a/pkg/rafs/rafs.go
+++ b/pkg/rafs/rafs.go
@@ -144,6 +144,27 @@ func NewRafs(snapshotID, imageID, fsDriver string) (*Rafs, error) {
 	return rafs, nil
 }
 
+// UpdateUnderlyingFiles replaces r.UnderlyingFiles while holding both the
+// global RAFS cache lock and, when given, the owning daemon's cache lock.
+//
+// The same *Rafs is registered in RafsGlobalCache and in the daemon's
+// RafsCache, and each cache's List() deep-copies the instance — reading every
+// field — under that cache's own mutex. A writer that takes only one of the
+// two locks therefore still races with the other cache's readers. The global
+// lock is acquired first; no other code path nests the two locks in the
+// opposite order.
+func (r *Rafs) UpdateUnderlyingFiles(files []string, daemonCache *Cache) {
+	RafsGlobalCache.Lock()
+	if daemonCache != nil {
+		daemonCache.Lock()
+	}
+	r.UnderlyingFiles = files
+	if daemonCache != nil {
+		daemonCache.Unlock()
+	}
+	RafsGlobalCache.Unlock()
+}
+
 func (r *Rafs) AddAnnotation(k, v string) {
 	r.Annotations[k] = v
 }

--- a/pkg/rafs/rafs_test.go
+++ b/pkg/rafs/rafs_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package rafs
+
+import (
+	"sync"
+	"testing"
+)
+
+// Exercises UpdateUnderlyingFiles concurrently with the deep-copying List()
+// readers of both registries that hand out the same *Rafs. Meaningful under
+// the race detector: the writer used to hold only the daemon cache's mutex,
+// racing with RafsGlobalCache.List() (e.g. snapshot cleanup).
+func TestUpdateUnderlyingFilesConcurrentWithListReaders(t *testing.T) {
+	original := RafsGlobalCache.List()
+	RafsGlobalCache.SetIntances(make(map[string]*Rafs))
+	t.Cleanup(func() {
+		RafsGlobalCache.SetIntances(original)
+	})
+
+	instance := &Rafs{
+		SnapshotID:  "1",
+		Annotations: map[string]string{},
+	}
+	RafsGlobalCache.Add(instance)
+	daemonCache := NewRafsCache()
+	daemonCache.Add(instance)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := range 1000 {
+			files := []string{"/cache/blob-a", "/cache/blob-b"}[:1+i%2]
+			instance.UpdateUnderlyingFiles(files, &daemonCache)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			for _, r := range RafsGlobalCache.List() {
+				_ = len(r.UnderlyingFiles)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			for _, r := range daemonCache.List() {
+				_ = len(r.UnderlyingFiles)
+			}
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
Both races are regularly flagged by the `run-e2e-for-cgroups-*` race-enabled jobs and intermittently fail CI for unrelated pull requests (e.g. [this run](https://github.com/containerd/nydus-snapshotter/actions/runs/29733098208/job/88321970728)).

**1. Metrics histogram** — `MetricHistogram.constHists` is rebuilt by the collection loop (`Clear`/`Save`) while the Prometheus registry concurrently ranges over it in `Collect` from HTTP scrape goroutines, with no synchronization. A scrape can observe a torn slice header or a half-rebuilt histogram set. Guarded with a mutex.

**2. RAFS UnderlyingFiles** — `WaitUntilReady` wrote `rafs.UnderlyingFiles` while holding only the daemon's `RafsCache` mutex, but the same `*Rafs` is also handed out by `RafsGlobalCache`, whose `List()` deep-copies every field of the instance under the *global* cache's own mutex (e.g. the snapshot cleanup path). Two different mutexes exclude nothing: the deep copy races with the write, and the torn result feeds cleanup decisions. The update now goes through `Rafs.UpdateUnderlyingFiles`, which takes both cache locks (global first; nothing nests the two locks in the opposite order).

```mermaid
flowchart LR
    W["writer: WaitUntilReady<br/>🔒 d.RafsCache only"] -- writes --> S["shared *Rafs.UnderlyingFiles"]
    R["reader: cleanup via<br/>RafsGlobalCache.List() deepcopy<br/>🔒 global mutex only"] -- reads --> S
    S --> X["⚠️ different mutexes →<br/>no exclusion → torn read"]
```

Both fixes come with tests that fail under `-race` against the previous code (3 and 7 detector reports respectively) and pass now.
