### PR TITLE
fix(snapshot): clean up orphaned RAFS configurations

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -134,6 +134,49 @@ func (d *Daemon) ConfigFile(instanceID string) string {
 	return filepath.Join(d.States.ConfigDir, instanceID, "config.json")
 }
 
+// CleanupOrphanedRafsConfigs removes configurations which no longer have a persisted
+// RAFS instance. This reclaims entries left behind by older snapshotter versions.
+func (d *Daemon) CleanupOrphanedRafsConfigs() error {
+	if !d.IsSharedDaemon() {
+		return nil
+	}
+
+	entries, err := os.ReadDir(d.States.ConfigDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	active := d.RafsCache.List()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, ok := active[entry.Name()]; ok {
+			continue
+		}
+
+		configFile := filepath.Join(d.States.ConfigDir, entry.Name(), "config.json")
+		info, err := os.Stat(configFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Dir(configFile)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // NydusdThreadNum returns how many working threads are needed of a single nydusd
 func (d *Daemon) NydusdThreadNum() int {
 	return d.States.ThreadNum

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -177,3 +177,28 @@ func TestRemoveRafsInstanceRefcount(t *testing.T) {
 	assert.Equal(t, int32(0), d.GetRef())
 	assert.Equal(t, 0, d.RafsCache.Len())
 }
+
+func TestCleanupOrphanedRafsConfigs(t *testing.T) {
+	configDir := t.TempDir()
+	d := &Daemon{
+		States: ConfigState{
+			ConfigDir:  configDir,
+			DaemonMode: config.DaemonModeShared,
+		},
+		RafsCache: rafs.NewRafsCache(),
+	}
+	d.RafsCache.Add(&rafs.Rafs{SnapshotID: "active"})
+
+	for _, id := range []string{"active", "orphan"} {
+		dir := filepath.Join(configDir, id)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0o644))
+	}
+	otherDir := filepath.Join(configDir, "not-a-rafs-config")
+	require.NoError(t, os.MkdirAll(otherDir, 0o755))
+
+	require.NoError(t, d.CleanupOrphanedRafsConfigs())
+	assert.DirExists(t, filepath.Join(configDir, "active"))
+	assert.NoDirExists(t, filepath.Join(configDir, "orphan"))
+	assert.DirExists(t, otherDir)
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -129,7 +129,26 @@ func (m *Manager) Recover(ctx context.Context,
 	if err := m.recoverRafsInstances(ctx, recoveringDaemons, liveDaemons); err != nil {
 		return errors.Wrapf(err, "recover RAFS instances")
 	}
+	m.cleanupOrphanedRafsConfigs(*recoveringDaemons, *liveDaemons)
 	return nil
+}
+
+func (m *Manager) cleanupOrphanedRafsConfigs(daemonSets ...map[string]*daemon.Daemon) {
+	seen := make(map[string]struct{})
+	for _, daemonSet := range daemonSets {
+		for _, d := range daemonSet {
+			if d.States.FsDriver != m.FsDriver {
+				continue
+			}
+			if _, ok := seen[d.ID()]; ok {
+				continue
+			}
+			seen[d.ID()] = struct{}{}
+			if err := d.CleanupOrphanedRafsConfigs(); err != nil {
+				log.L.WithError(err).Warnf("failed to clean orphaned RAFS configurations for daemon %s", d.ID())
+			}
+		}
+	}
 }
 
 func (m *Manager) AddRafsInstance(r *rafs.Rafs) error {


### PR DESCRIPTION
Reconcile shared-daemon configuration directories after restoring persisted RAFS instances. Remove stale per-instance configurations left by interrupted cleanup or older snapshotter versions while preserving active instances and unrelated files.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)
