### PR TITLE
fix(manager): start failover daemon in upgrade mode

### DIFF
--- a/pkg/manager/daemon_adaptor.go
+++ b/pkg/manager/daemon_adaptor.go
@@ -36,7 +36,13 @@ const endpointGetBackend string = "/api/v1/daemons/%s/backend"
 //     ensure the daemon has reached specified state.
 //   - `d` may have not been inserted into daemonStates and store yet.
 func (m *Manager) StartDaemon(d *daemon.Daemon) error {
-	cmd, err := m.BuildDaemonCommand(d, "", false)
+	return m.startDaemon(d, false)
+}
+
+// startDaemon spawns nydusd in the requested startup mode. Failover uses
+// upgrade mode so the replacement waits in INIT until takeover completes.
+func (m *Manager) startDaemon(d *daemon.Daemon, upgrade bool) error {
+	cmd, err := m.BuildDaemonCommand(d, "", upgrade)
 	if err != nil {
 		return errors.Wrapf(err, "create command for daemon %s", d.ID())
 	}

--- a/pkg/manager/daemon_adaptor_test.go
+++ b/pkg/manager/daemon_adaptor_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+)
+
+func TestStartDaemonUpgradeMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		upgrade     bool
+		wantUpgrade bool
+	}{
+		{
+			name:        "normal start",
+			upgrade:     false,
+			wantUpgrade: false,
+		},
+		{
+			name:        "failover start",
+			upgrade:     true,
+			wantUpgrade: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			cfg := &config.SnapshotterConfig{
+				Root:       root,
+				DaemonMode: string(config.DaemonModeShared),
+				DaemonConfig: config.DaemonConfig{
+					FsDriver: config.FsDriverFscache,
+				},
+			}
+			require.NoError(t, config.ProcessConfigurations(cfg))
+
+			argsFile := filepath.Join(root, "args.txt")
+			scriptPath := filepath.Join(root, "fake-nydusd.sh")
+			script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"" + argsFile + "\"\n"
+			require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0755))
+
+			manager := &Manager{
+				cacheDir:         root,
+				daemonCache:      newDaemonCache(),
+				NydusdBinaryPath: scriptPath,
+			}
+			d := &daemon.Daemon{
+				States: daemon.ConfigState{
+					ID:          "test-daemon",
+					APISocket:   filepath.Join(root, "api.sock"),
+					FsDriver:    config.FsDriverFscache,
+					LogLevel:    "info",
+					LogToStdout: true,
+				},
+			}
+
+			require.NoError(t, manager.startDaemon(d, tc.upgrade))
+
+			var args string
+			require.Eventually(t, func() bool {
+				content, err := os.ReadFile(argsFile)
+				if err != nil {
+					return false
+				}
+				args = strings.TrimSpace(string(content))
+				return true
+			}, time.Second, 10*time.Millisecond)
+			if tc.wantUpgrade {
+				require.Contains(t, args, "--upgrade")
+			} else {
+				require.NotContains(t, args, "--upgrade")
+			}
+		})
+	}
+}

--- a/pkg/manager/daemon_event.go
+++ b/pkg/manager/daemon_event.go
@@ -88,7 +88,7 @@ func (m *Manager) doDaemonFailover(d *daemon.Daemon) {
 
 	// Failover nydusd still depends on the old supervisor
 
-	if err := m.StartDaemon(d); err != nil {
+	if err := m.startDaemon(d, true); err != nil {
 		log.L.Errorf("fail to start daemon %s when recovering", d.ID())
 		return
 	}


### PR DESCRIPTION
## Overview
Failover waits for the replacement nydusd to reach INIT before takeover, but the normal startup path does not pass --upgrade.

Use upgrade mode for failover startup while keeping normal startup unchanged, so the replacement remains in INIT until takeover completes.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)