### PR TITLE
fix: recover fscache mounts after daemon restart

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -659,12 +659,12 @@ func (d *Daemon) Wait() error {
 func (d *Daemon) ClearVestige() {
 	mounter := mount.Mounter{}
 	if d.States.FsDriver == config.FsDriverFscache {
-		instances := d.RafsCache.List()
-		for _, i := range instances {
-			if err := mounter.Umount(i.GetMountpoint()); err != nil {
-				log.L.Warnf("Can't umount %s, %v", d.States.Mountpoint, err)
-			}
-		}
+		// Keep per-RAFS EROFS mounts while replacing a dead nydusd. The
+		// replacement daemon rebinds each blob to the existing mount after it
+		// reaches RUNNING, so unmounting here would defeat mount recovery.
+		// Snapshot removal still unmounts these resources through SharedUmount;
+		// this skip only applies to daemon restart recovery.
+		log.L.Infof("Skip unmounting fscache RAFS mountpoints when clearing daemon %s vestige", d.ID())
 	} else {
 		log.L.Infof("Unmounting %s when clear vestige", d.HostMountpoint())
 		if err := mounter.Umount(d.HostMountpoint()); err != nil {

--- a/pkg/manager/daemon_event.go
+++ b/pkg/manager/daemon_event.go
@@ -125,17 +125,13 @@ func (m *Manager) doDaemonRestart(d *daemon.Daemon) {
 		return
 	}
 
-	// Mount rafs instance by http API
-	instances := d.RafsCache.List()
-	for _, r := range instances {
-		// For dedicated nydusd daemon, Rafs has already been mounted during starting nydusd
-		if d.HostMountpoint() == r.GetMountpoint() {
-			break
-		}
+	if err := d.WaitUntilState(types.DaemonStateRunning); err != nil {
+		log.L.WithError(err).Errorf("daemon %s is not managed to reach RUNNING state", d.ID())
+		return
+	}
 
-		if err := d.SharedMount(r); err != nil {
-			log.L.Warnf("Failed to mount rafs instance, %v", err)
-		}
+	if err := d.RecoverRafsInstances(); err != nil {
+		log.L.Warnf("Failed to recover RAFS mounts for daemon %s, %v", d.ID(), err)
 	}
 }
 


### PR DESCRIPTION
## Overview
Keep fscache RAFS mounts while restarting a dead nydusd and recover them after the replacement reaches RUNNING.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)
