### PR TITLE
fix(supervisor): bound daemon state synchronization

### DIFF
--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -59,6 +59,9 @@ const (
 	jsonContentType = "application/json"
 )
 
+// Bound best-effort daemon state sync so it does not stall mount/unmount paths for too long.
+var sendFdRequestTimeout = 5 * time.Second
+
 // Nydusd HTTP client to query nydusd runtime status, operate file system instances.
 // Control nydusd workflow like failover and upgrade.
 type NydusdClient interface {
@@ -102,10 +105,9 @@ func (c *nydusdClient) url(path string, query query) (url string) {
 
 // A simple http client request wrapper with capability to take
 // request body and handle or process http response if result is expected.
-func (c *nydusdClient) request(method string, url string,
+func (c *nydusdClient) requestWithContext(ctx context.Context, method string, url string,
 	body io.Reader, respHandler func(resp *http.Response) error) error {
-
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return errors.Wrapf(err, "construct request %s", url)
 	}
@@ -130,6 +132,11 @@ func (c *nydusdClient) request(method string, url string,
 	}
 
 	return parseErrorMessage(resp)
+}
+
+func (c *nydusdClient) request(method string, url string,
+	body io.Reader, respHandler func(resp *http.Response) error) error {
+	return c.requestWithContext(context.Background(), method, url, body, respHandler)
 }
 
 func succeeded(resp *http.Response) bool {
@@ -345,8 +352,10 @@ func (c *nydusdClient) TakeOver() error {
 }
 
 func (c *nydusdClient) SendFd() error {
+	ctx, cancel := context.WithTimeout(context.Background(), sendFdRequestTimeout)
+	defer cancel()
 	url := c.url(endpointSendFd, query{})
-	return c.request(http.MethodPut, url, nil, nil)
+	return c.requestWithContext(ctx, http.MethodPut, url, nil, nil)
 }
 
 func (c *nydusdClient) Start() error {

--- a/pkg/daemon/client_test.go
+++ b/pkg/daemon/client_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -145,4 +146,36 @@ func TestUpdateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSendFdTimeout(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "api.sock")
+
+	oldTimeout := sendFdRequestTimeout
+	sendFdRequestTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		sendFdRequestTimeout = oldTimeout
+	})
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, endpointSendFd, r.URL.Path)
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	ts.Listener = listener
+	ts.Start()
+	defer ts.Close()
+
+	client, err := NewNydusClient(sock)
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = client.SendFd()
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), time.Second)
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -432,6 +432,10 @@ func (d *Daemon) SendStates() {
 			return nil
 		})
 		if err != nil {
+			if errors.Is(err, supervisor.ErrFetchDaemonStatesSkipped) {
+				log.L.Debugf("skip daemon %s state sync: %v", d.ID(), err)
+				return
+			}
 			log.L.Warnf("Daemon %s does not support sending states, %v", d.ID(), err)
 		}
 	}

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -22,10 +22,17 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 	"github.com/pkg/errors"
 
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/sys/unix"
 )
+
+// Keep mount/unmount paths from waiting indefinitely on supervisor state sync.
+var fetchDaemonStatesAcquireTimeout = 200 * time.Millisecond
+var fetchDaemonStatesTimeout = 5 * time.Second
+
+// ErrFetchDaemonStatesSkipped indicates that a best-effort state sync was skipped
+// because another supervisor operation held the semaphore too long.
+var ErrFetchDaemonStatesSkipped = errors.New("fetch daemon states skipped")
 
 type StatesStorage interface {
 	// Save state to storage space.
@@ -177,13 +184,10 @@ func send(uc *net.UnixConn, data []byte, fd int) error {
 	return nil
 }
 
-// There are several stages from different goroutines to trigger sending daemon states
-// the waiter will overlap each other causing the UDS being deleted.
-// But we don't want to keep the server listen for ever.
-// `to` equal to zero indicates that caller should call the receiver the receive stats
-// when it thinks is appropriate. `to` is not zero, no receiver callback will be returned.
-// Then this method is responsible to receive states inside.
-func (su *Supervisor) waitStatesTimeout(to time.Duration) (func() error, error) {
+// There are several stages from different goroutines to trigger sending daemon states,
+// so the listener should not be left around forever. Positive timeout bounds both
+// Accept() and the subsequent receive on the accepted connection.
+func (su *Supervisor) waitStatesTimeout(to time.Duration) (func() error, func(), error) {
 	if err := os.Remove(su.path); err != nil {
 		if !os.IsNotExist(err) {
 			log.L.Warnf("Unable to remove existed socket file %s, %s", su.path, err)
@@ -192,11 +196,26 @@ func (su *Supervisor) waitStatesTimeout(to time.Duration) (func() error, error) 
 
 	listener, err := net.Listen("unix", su.path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "listen on socket %s", su.path)
+		return nil, nil, errors.Wrapf(err, "listen on socket %s", su.path)
+	}
+
+	var closeOnce sync.Once
+	cancel := func() {
+		closeOnce.Do(func() {
+			_ = listener.Close()
+		})
 	}
 
 	receiver := func() error {
-		defer func() { _ = listener.Close() }()
+		defer cancel()
+
+		if to > 0 {
+			if deadlineListener, ok := listener.(interface{ SetDeadline(time.Time) error }); ok {
+				if err := deadlineListener.SetDeadline(time.Now().Add(to)); err != nil {
+					return errors.Wrap(err, "set listener deadline")
+				}
+			}
+		}
 
 		// After the listener is closed, Accept() wakes up
 		conn, err := listener.Accept()
@@ -205,7 +224,14 @@ func (su *Supervisor) waitStatesTimeout(to time.Duration) (func() error, error) 
 		}
 		defer func() { _ = conn.Close() }()
 
-		data, fd, err := recv(conn.(*net.UnixConn))
+		unixConn := conn.(*net.UnixConn)
+		if to > 0 {
+			if err := unixConn.SetDeadline(time.Now().Add(to)); err != nil {
+				return errors.Wrap(err, "set receiver deadline")
+			}
+		}
+
+		data, fd, err := recv(unixConn)
 		if err != nil {
 			return err
 		}
@@ -216,39 +242,21 @@ func (su *Supervisor) waitStatesTimeout(to time.Duration) (func() error, error) 
 		return nil
 	}
 
-	cancelTimer := make(chan int, 1)
-	// Once timeouts, stop waiting for states
-	if to > 0 {
-		timer := time.NewTimer(to)
-		go func() {
-			select {
-			case <-timer.C:
-				log.L.Warnf("Receiving state timeouts after %s", to)
-				// Wake up the blocking `Accept`
-				_ = listener.Close()
-			case <-cancelTimer:
-			}
-
-		}()
-
-		go func() {
-			if err := receiver(); err != nil {
-				log.L.Errorf("receiver fails, %s", err)
-			}
-			if to > 0 {
-				cancelTimer <- 1
-			}
-		}()
-
-		// With non-zero timeout parameter, call should be aware that receiver is nil
-		//nolint: nilnil
-		return nil, nil
-	}
-
-	return receiver, nil
+	return receiver, cancel, nil
 }
 
 func (su *Supervisor) SendStatesTimeout(to time.Duration) error {
+	if err := su.sem.Acquire(context.Background(), 1); err != nil {
+		return err
+	}
+
+	releaseSem := true
+	defer func() {
+		if releaseSem {
+			su.sem.Release(1)
+		}
+	}()
+
 	// It is used to receive before
 	if err := os.Remove(su.path); err != nil {
 		if !os.IsNotExist(err) {
@@ -263,6 +271,7 @@ func (su *Supervisor) SendStatesTimeout(to time.Duration) error {
 
 	sender := func() error {
 		defer func() { _ = listener.Close() }()
+		defer su.sem.Release(1)
 
 		conn, err := listener.Accept()
 		if err != nil {
@@ -295,7 +304,6 @@ func (su *Supervisor) SendStatesTimeout(to time.Duration) error {
 				_ = listener.Close()
 			case <-cancelTimer:
 			}
-
 		}()
 	}
 
@@ -310,34 +318,55 @@ func (su *Supervisor) SendStatesTimeout(to time.Duration) error {
 		}
 	}()
 
+	releaseSem = false
+
 	return nil
 }
 
 func (su *Supervisor) FetchDaemonStates(trigger func() error) error {
-	if err := su.sem.Acquire(context.TODO(), 1); err != nil {
+	acquireCtx, cancelAcquire := context.WithTimeout(context.Background(), fetchDaemonStatesAcquireTimeout)
+	defer cancelAcquire()
+
+	if err := su.sem.Acquire(acquireCtx, 1); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.L.Warnf("Supervisor %s skips FetchDaemonStates because semaphore is busy after %s",
+				su.id, fetchDaemonStatesAcquireTimeout)
+			return errors.Wrapf(ErrFetchDaemonStatesSkipped, "supervisor %s semaphore busy after %s",
+				su.id, fetchDaemonStatesAcquireTimeout)
+		}
 		return err
 	}
 
 	defer su.sem.Release(1)
 
-	receiver, err := su.waitStatesTimeout(0)
+	receiverCtx, cancelReceiverCtx := context.WithTimeout(context.Background(), fetchDaemonStatesTimeout)
+	defer cancelReceiverCtx()
+
+	receiver, cancelReceiver, err := su.waitStatesTimeout(fetchDaemonStatesTimeout)
 	if err != nil {
 		return errors.Wrapf(err, "wait states on %s", su.Sock())
 	}
+	defer cancelReceiver()
 
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		err := trigger()
+	receiverErrCh := make(chan error, 1)
+	go func() {
+		receiverErrCh <- errors.Wrapf(receiver(), "receiver on %s", su.Sock())
+	}()
+
+	if err := trigger(); err != nil {
+		cancelReceiver()
+		<-receiverErrCh
 		return errors.Wrapf(err, "trigger on %s", su.Sock())
-	})
+	}
 
-	eg.Go(func() error {
-		err := receiver()
-		return errors.Wrapf(err, "receiver on %s", su.Sock())
-	})
-
-	// FIXME: With Timeout context!
-	return eg.Wait()
+	select {
+	case err := <-receiverErrCh:
+		return err
+	case <-receiverCtx.Done():
+		cancelReceiver()
+		<-receiverErrCh
+		return errors.Wrapf(receiverCtx.Err(), "fetch daemon states on %s", su.Sock())
+	}
 }
 
 // The unix domain socket on which nydus daemon is connected to

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -7,6 +7,7 @@
 package supervisor
 
 import (
+	"context"
 	"crypto/rand"
 	"net"
 	"os"
@@ -106,4 +107,99 @@ func TestSupervisorTimeout(t *testing.T) {
 
 	_, err = net.DialUnix("unix", nil, addr)
 	assert.NotNil(t, err, "%v", err)
+}
+
+func TestFetchDaemonStatesReturnsOnTriggerError(t *testing.T) {
+	rootDir := t.TempDir()
+	oldTimeout := fetchDaemonStatesTimeout
+	fetchDaemonStatesTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		fetchDaemonStatesTimeout = oldTimeout
+	})
+
+	supervisorSet, err := NewSupervisorSet(rootDir)
+	assert.NoError(t, err)
+	su := supervisorSet.NewSupervisor("su1")
+	assert.NotNil(t, su)
+
+	start := time.Now()
+	err = su.FetchDaemonStates(func() error {
+		return assert.AnError
+	})
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestFetchDaemonStatesTimesOut(t *testing.T) {
+	rootDir := t.TempDir()
+	oldTimeout := fetchDaemonStatesTimeout
+	fetchDaemonStatesTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		fetchDaemonStatesTimeout = oldTimeout
+	})
+
+	supervisorSet, err := NewSupervisorSet(rootDir)
+	assert.NoError(t, err)
+	su := supervisorSet.NewSupervisor("su1")
+	assert.NotNil(t, su)
+
+	start := time.Now()
+	err = su.FetchDaemonStates(func() error {
+		return nil
+	})
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestFetchDaemonStatesSkipsWhenSemaphoreBusy(t *testing.T) {
+	rootDir := t.TempDir()
+	oldAcquireTimeout := fetchDaemonStatesAcquireTimeout
+	fetchDaemonStatesAcquireTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		fetchDaemonStatesAcquireTimeout = oldAcquireTimeout
+	})
+
+	supervisorSet, err := NewSupervisorSet(rootDir)
+	assert.NoError(t, err)
+	su := supervisorSet.NewSupervisor("su1")
+	assert.NotNil(t, su)
+
+	err = su.sem.Acquire(context.Background(), 1)
+	assert.NoError(t, err)
+	defer su.sem.Release(1)
+
+	start := time.Now()
+	err = su.FetchDaemonStates(func() error {
+		t.Fatal("trigger should not run when semaphore acquisition times out")
+		return nil
+	})
+	assert.ErrorIs(t, err, ErrFetchDaemonStatesSkipped)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestSendStatesTimeoutBlocksFetchDaemonStates(t *testing.T) {
+	rootDir := t.TempDir()
+	oldAcquireTimeout := fetchDaemonStatesAcquireTimeout
+	fetchDaemonStatesAcquireTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		fetchDaemonStatesAcquireTimeout = oldAcquireTimeout
+	})
+
+	supervisorSet, err := NewSupervisorSet(rootDir)
+	assert.NoError(t, err)
+	su := supervisorSet.NewSupervisor("su1")
+	assert.NotNil(t, su)
+
+	err = su.SendStatesTimeout(200 * time.Millisecond)
+	assert.NoError(t, err)
+
+	start := time.Now()
+	err = su.FetchDaemonStates(func() error {
+		t.Fatal("trigger should not run while SendStatesTimeout is holding the semaphore")
+		return nil
+	})
+	assert.ErrorIs(t, err, ErrFetchDaemonStatesSkipped)
+	assert.Less(t, time.Since(start), time.Second)
+
+	time.Sleep(250 * time.Millisecond)
 }


### PR DESCRIPTION
## Overview
Keep daemon state transfer from blocking mount and umount paths indefinitely. Bound supervisor socket waits and SendFd requests, and skip a state sync when the supervisor is busy.

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [x] Performance Improvement
- [ ] Other (please describe)