### PR TITLE
fix: retry fscache blob cull until cachefiles completes

### DIFF
--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -53,6 +53,8 @@ const (
 	// --- V2 API begins
 	// Add/remove blobs managed by the blob cache manager.
 	endpointBlobs = "/api/v2/blobs"
+	// Reclaim a blob from the kernel fscache with completion status.
+	endpointCullBlob = "/api/v2/blobs/cull"
 
 	defaultHTTPClientTimeout = 30 * time.Second
 
@@ -69,6 +71,8 @@ type NydusdClient interface {
 
 	BindBlob(daemonConfig string) error
 	UnbindBlob(domainID, blobID string) error
+	CullBlob(blobID string, background bool) (CullBlobResult, error)
+	PendingCulls(ctx context.Context) (map[string]string, error)
 
 	GetFsMetrics(sid string) (*types.FsMetrics, error)
 	GetInflightMetrics() (*types.InflightMetrics, error)
@@ -80,6 +84,18 @@ type NydusdClient interface {
 	SendFd() error
 	Start() error
 	Exit() error
+}
+
+type CullBlobStatus string
+
+const (
+	CullBlobDone    CullBlobStatus = "done"
+	CullBlobPending CullBlobStatus = "pending"
+)
+
+type CullBlobResult struct {
+	Status CullBlobStatus
+	Reason string
 }
 
 // Nydusd API server http client used to command nydusd's action and
@@ -275,6 +291,56 @@ func (c *nydusdClient) UnbindBlob(domainID, blobID string) error {
 	url := c.url(endpointBlobs, query)
 
 	return c.request(http.MethodDelete, url, nil, nil)
+}
+
+// CullBlob interprets 204 as done and the new endpoint's structured 200 response as pending.
+// Background requests remain owned by nydusd; foreground requests are retried by a later GC pass.
+func (c *nydusdClient) CullBlob(blobID string, background bool) (CullBlobResult, error) {
+	query := query{}
+	query.Add("blob_id", blobID)
+	if background {
+		query.Add("background", "true")
+	}
+	url := c.url(endpointCullBlob, query)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+	if err != nil {
+		return CullBlobResult{}, errors.Wrapf(err, "construct request %s", url)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return CullBlobResult{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return CullBlobResult{Status: CullBlobDone}, nil
+	case http.StatusOK:
+		var result struct {
+			Status string `json:"status"`
+			Reason string `json:"reason"`
+		}
+		if err := decode(resp, &result); err != nil {
+			return CullBlobResult{}, errors.Wrap(err, "decode cull response")
+		}
+		if result.Status != string(CullBlobPending) {
+			return CullBlobResult{}, errors.Errorf("unexpected cull response status %q", result.Status)
+		}
+		return CullBlobResult{Status: CullBlobPending, Reason: result.Reason}, nil
+	default:
+		return CullBlobResult{}, parseErrorMessage(resp)
+	}
+}
+
+func (c *nydusdClient) PendingCulls(_ context.Context) (map[string]string, error) {
+	url := c.url(endpointCullBlob, query{})
+	pending := make(map[string]string)
+	if err := c.request(http.MethodGet, url, nil, func(resp *http.Response) error {
+		return decode(resp, &pending)
+	}); err != nil {
+		return nil, err
+	}
+	return pending, nil
 }
 
 func (c *nydusdClient) GetFsMetrics(sid string) (*types.FsMetrics, error) {

--- a/pkg/daemon/client_test.go
+++ b/pkg/daemon/client_test.go
@@ -7,6 +7,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -68,6 +69,89 @@ func TestNydusClient_CheckStatus(t *testing.T) {
 	assert.Equal(t, info.DaemonState(), types.DaemonStateRunning)
 	assert.Equal(t, "testid", info.ID)
 	assert.Equal(t, BTI, info.Version)
+}
+
+func TestCullBlob(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantStatus CullBlobStatus
+		wantReason string
+		background bool
+		wantErr    bool
+	}{
+		{name: "done", statusCode: http.StatusNoContent, wantStatus: CullBlobDone},
+		{name: "pending", statusCode: http.StatusOK, wantStatus: CullBlobPending, wantReason: "open", background: true},
+		{name: "unexpected accepted", statusCode: http.StatusAccepted, wantErr: true},
+		{name: "daemon error", statusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sock := filepath.Join(dir, "api.sock")
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, endpointCullBlob, r.URL.Path)
+				assert.Equal(t, "test-blob", r.URL.Query().Get("blob_id"))
+				if tt.background {
+					assert.Equal(t, "true", r.URL.Query().Get("background"))
+				} else {
+					assert.Empty(t, r.URL.Query().Get("background"))
+				}
+				if tt.statusCode == http.StatusInternalServerError {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(tt.statusCode)
+					_, _ = w.Write([]byte(`{"code":"EIO","message":"cull failed"}`))
+					return
+				}
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK {
+					_, _ = w.Write([]byte(`{"status":"pending","reason":"open"}`))
+				}
+			}))
+			listener, err := net.Listen("unix", sock)
+			require.NoError(t, err)
+			ts.Listener = listener
+			ts.Start()
+			defer ts.Close()
+
+			client, err := NewNydusClient(sock)
+			require.NoError(t, err)
+			result, err := client.CullBlob("test-blob", tt.background)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			assert.Equal(t, tt.wantReason, result.Reason)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPendingCulls(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "api.sock")
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, endpointCullBlob, r.URL.Path)
+		_, _ = w.Write([]byte(`{"blob-a":"open","blob-b":"awaiting cachefiles commit"}`))
+	}))
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	ts.Listener = listener
+	ts.Start()
+	defer ts.Close()
+
+	client, err := NewNydusClient(sock)
+	require.NoError(t, err)
+	pending, err := client.PendingCulls(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"blob-a": "open",
+		"blob-b": "awaiting cachefiles commit",
+	}, pending)
 }
 
 func TestUpdateConfig(t *testing.T) {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -360,13 +360,34 @@ func (d *Daemon) SharedUmount(rafs *rafs.Rafs) error {
 }
 
 func (d *Daemon) sharedErofsUmount(ra *rafs.Rafs) error {
-	c, err := d.GetClient()
-	if err != nil {
-		return errors.Wrapf(err, "unbind blob %s", d.ID())
-	}
+	return d.sharedErofsUmountWith(ra, mount.IsMountpoint, erofs.Umount)
+}
+
+func (d *Daemon) sharedErofsUmountWith(
+	ra *rafs.Rafs,
+	isMountpoint func(string) (bool, error),
+	umount func(string) error,
+) error {
 	domainID := ra.Annotations[rafs.AnnoFsCacheDomainID]
 	fscacheID := ra.Annotations[rafs.AnnoFsCacheID]
+	mountpoint := ra.GetMountpoint()
+	mounted, err := isMountpoint(mountpoint)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrapf(err, "check erofs mountpoint %s", mountpoint)
+		}
+		mounted = false
+	}
+	if mounted {
+		if err := umount(mountpoint); err != nil {
+			return errors.Wrapf(err, "umount erofs mountpoint %s", mountpoint)
+		}
+	}
 
+	c, err := d.GetClient()
+	if err != nil {
+		return errors.Wrapf(err, "get nydusd client for blob %s", d.ID())
+	}
 	if err := c.UnbindBlob(domainID, fscacheID); err != nil {
 		if !isBlobCacheEntryNotFound(err) {
 			return errors.Wrapf(err, "request to unbind fscache blob, domain %s, fscache %s", domainID, fscacheID)
@@ -374,15 +395,12 @@ func (d *Daemon) sharedErofsUmount(ra *rafs.Rafs) error {
 		log.L.Warnf("ignore missing blob cache entry while unbinding domain %s, fscache %s", domainID, fscacheID)
 	}
 
-	mountpoint := ra.GetMountpoint()
-	if err := erofs.Umount(mountpoint); err != nil {
-		return errors.Wrapf(err, "umount erofs %s mountpoint, %s", err, mountpoint)
+	result, err := c.CullBlob(fscacheID, true)
+	if err != nil {
+		return errors.Wrapf(err, "request to cull bootstrap fscache blob %s", fscacheID)
 	}
-
-	// delete fscache bootstrap cache file
-	// erofs generate fscache cache file for bootstrap with fscacheID
-	if err := c.UnbindBlob("", fscacheID); err != nil {
-		log.L.Warnf("delete bootstrap %s err %s", fscacheID, err)
+	if result.Status == CullBlobPending {
+		return &errdefs.FscacheCullPendingError{BlobID: fscacheID, Reason: result.Reason}
 	}
 
 	return nil

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -8,6 +8,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -21,8 +22,31 @@ import (
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
 	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 	"github.com/containerd/nydus-snapshotter/pkg/rafs"
+	"golang.org/x/sys/unix"
 )
+
+type teardownClient struct {
+	NydusdClient
+	calls     *[]string
+	cullDone  bool
+	unbindErr error
+	cullErr   error
+}
+
+func (c *teardownClient) UnbindBlob(domainID, blobID string) error {
+	*c.calls = append(*c.calls, fmt.Sprintf("unbind:%s:%s", domainID, blobID))
+	return c.unbindErr
+}
+
+func (c *teardownClient) CullBlob(blobID string, background bool) (CullBlobResult, error) {
+	*c.calls = append(*c.calls, fmt.Sprintf("cull:%s:%t", blobID, background))
+	if c.cullDone {
+		return CullBlobResult{Status: CullBlobDone}, c.cullErr
+	}
+	return CullBlobResult{Status: CullBlobPending, Reason: "open"}, c.cullErr
+}
 
 func TestMain(m *testing.M) {
 	// Initialize global config so DumpFile does not panic.
@@ -176,4 +200,98 @@ func TestRemoveRafsInstanceRefcount(t *testing.T) {
 	d.RemoveRafsInstance(r.SnapshotID)
 	assert.Equal(t, int32(0), d.GetRef())
 	assert.Equal(t, 0, d.RafsCache.Len())
+}
+
+func TestSharedErofsUmountOrderAndRetry(t *testing.T) {
+	tests := []struct {
+		name      string
+		mounted   bool
+		umountErr error
+		cullDone  bool
+		unbindErr error
+		cullErr   error
+		wantErr   bool
+		wantCalls []string
+	}{
+		{
+			name:      "mounted teardown follows reverse creation order",
+			mounted:   true,
+			cullDone:  true,
+			wantCalls: []string{"check", "umount", "unbind:domain:cookie", "cull:cookie:true"},
+		},
+		{
+			name:      "busy mount does not mutate daemon state",
+			mounted:   true,
+			umountErr: unix.EBUSY,
+			cullDone:  true,
+			wantErr:   true,
+			wantCalls: []string{"check", "umount"},
+		},
+		{
+			name:      "retry skips an already unmounted mountpoint",
+			cullDone:  true,
+			wantCalls: []string{"check", "unbind:domain:cookie", "cull:cookie:true"},
+		},
+		{
+			name:      "pending bootstrap cull retains teardown state",
+			wantErr:   true,
+			wantCalls: []string{"check", "unbind:domain:cookie", "cull:cookie:true"},
+		},
+		{
+			name:      "domain unbind failure remains visible",
+			unbindErr: fmt.Errorf("unbind failed"),
+			wantErr:   true,
+			wantCalls: []string{"check", "unbind:domain:cookie"},
+		},
+		{
+			name:      "bootstrap cull failure remains visible",
+			cullErr:   fmt.Errorf("cull failed"),
+			wantErr:   true,
+			wantCalls: []string{"check", "unbind:domain:cookie", "cull:cookie:true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := []string{}
+			client := &teardownClient{
+				calls:     &calls,
+				cullDone:  tt.cullDone,
+				unbindErr: tt.unbindErr,
+				cullErr:   tt.cullErr,
+			}
+			d := &Daemon{client: client}
+			ra := &rafs.Rafs{
+				SnapshotID: "snapshot",
+				Mountpoint: "/mountpoint",
+				Annotations: map[string]string{
+					rafs.AnnoFsCacheDomainID: "domain",
+					rafs.AnnoFsCacheID:       "cookie",
+				},
+			}
+			isMountpoint := func(string) (bool, error) {
+				calls = append(calls, "check")
+				return tt.mounted, nil
+			}
+			umount := func(string) error {
+				calls = append(calls, "umount")
+				return tt.umountErr
+			}
+
+			err := d.sharedErofsUmountWith(ra, isMountpoint, umount)
+			assert.Equal(t, tt.wantCalls, calls)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.name == "pending bootstrap cull retains teardown state" {
+					require.ErrorIs(t, err, errdefs.ErrFscacheCullPending)
+					var pending *errdefs.FscacheCullPendingError
+					require.ErrorAs(t, err, &pending)
+					require.Equal(t, "cookie", pending.BlobID)
+					require.Equal(t, "open", pending.Reason)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -8,6 +8,7 @@ package errdefs
 
 import (
 	stderrors "errors"
+	"fmt"
 	"net"
 	"syscall"
 
@@ -22,7 +23,23 @@ var (
 	ErrUnavailable     = errors.New("unavailable")
 	ErrNotImplemented  = errors.New("not implemented") // represents not supported and unimplemented
 	ErrDeviceBusy      = errors.New("device busy")     // represents not supported and unimplemented
+	// ErrFscacheCullPending means the filesystem was unmounted and unbound, but
+	// cachefiles still needs to finish reclaiming the bootstrap cookie.
+	ErrFscacheCullPending = errors.New("fscache cull pending")
 )
+
+type FscacheCullPendingError struct {
+	BlobID string
+	Reason string
+}
+
+func (e *FscacheCullPendingError) Error() string {
+	return fmt.Sprintf("fscache blob %s cull is pending: %s", e.BlobID, e.Reason)
+}
+
+func (e *FscacheCullPendingError) Unwrap() error {
+	return ErrFscacheCullPending
+}
 
 // IsAlreadyExists returns true if the error is due to already exists
 func IsAlreadyExists(err error) bool {

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
+	"sort"
 	"sync"
 
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -58,6 +60,155 @@ type Filesystem struct {
 	nydusdBinaryPath    string
 	rootMountpoint      string
 	snapshotMutexMap    sync.Map
+	fscacheLifecycle    fscacheBlobLifecycle
+}
+
+type fscacheBlobState struct {
+	publishers    int
+	gcActive      bool
+	lastPublished uint64
+}
+
+type fscacheBlobLifecycle struct {
+	mu          sync.Mutex
+	cond        *sync.Cond
+	epoch       uint64
+	activeScans map[uint64]int
+	blobs       map[string]*fscacheBlobState
+}
+
+func normalizeBlobIDs(blobIDs []string) []string {
+	ids := append([]string(nil), blobIDs...)
+	sort.Strings(ids)
+	return slices.Compact(ids)
+}
+
+func (m *fscacheBlobLifecycle) initLocked() {
+	if m.cond == nil {
+		m.cond = sync.NewCond(&m.mu)
+	}
+	if m.activeScans == nil {
+		m.activeScans = make(map[uint64]int)
+	}
+	if m.blobs == nil {
+		m.blobs = make(map[string]*fscacheBlobState)
+	}
+}
+
+func (m *fscacheBlobLifecycle) beginPublication(blobIDs []string) func(bool) {
+	ids := normalizeBlobIDs(blobIDs)
+	m.mu.Lock()
+	m.initLocked()
+	for _, blobID := range ids {
+		if blobID == "" {
+			continue
+		}
+		state := m.blobs[blobID]
+		if state == nil {
+			state = &fscacheBlobState{}
+			m.blobs[blobID] = state
+		}
+		state.publishers++
+	}
+	for {
+		blocked := false
+		for _, blobID := range ids {
+			if state := m.blobs[blobID]; state != nil && state.gcActive {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			break
+		}
+		m.cond.Wait()
+	}
+	m.mu.Unlock()
+
+	var once sync.Once
+	return func(published bool) {
+		once.Do(func() {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			if published {
+				m.epoch++
+			}
+			for _, blobID := range ids {
+				if blobID == "" {
+					continue
+				}
+				state := m.blobs[blobID]
+				state.publishers--
+				if published {
+					state.lastPublished = m.epoch
+				}
+			}
+			m.pruneLocked()
+			m.cond.Broadcast()
+		})
+	}
+}
+
+func (m *fscacheBlobLifecycle) beginScan() (uint64, func()) {
+	m.mu.Lock()
+	m.initLocked()
+	epoch := m.epoch
+	m.activeScans[epoch]++
+	m.mu.Unlock()
+
+	var once sync.Once
+	return epoch, func() {
+		once.Do(func() {
+			m.mu.Lock()
+			m.activeScans[epoch]--
+			if m.activeScans[epoch] == 0 {
+				delete(m.activeScans, epoch)
+			}
+			m.pruneLocked()
+			m.mu.Unlock()
+		})
+	}
+}
+
+func (m *fscacheBlobLifecycle) tryBeginGC(blobID string, scanEpoch uint64) (func(), bool) {
+	m.mu.Lock()
+	m.initLocked()
+	state := m.blobs[blobID]
+	if state == nil {
+		state = &fscacheBlobState{}
+		m.blobs[blobID] = state
+	}
+	if state.publishers != 0 || state.gcActive || state.lastPublished > scanEpoch {
+		m.mu.Unlock()
+		return func() {}, false
+	}
+	state.gcActive = true
+	m.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			m.mu.Lock()
+			state.gcActive = false
+			m.pruneLocked()
+			m.cond.Broadcast()
+			m.mu.Unlock()
+		})
+	}, true
+}
+
+func (m *fscacheBlobLifecycle) pruneLocked() {
+	minScanEpoch := m.epoch
+	for epoch := range m.activeScans {
+		if epoch < minScanEpoch {
+			minScanEpoch = epoch
+		}
+	}
+	for blobID, state := range m.blobs {
+		if state.publishers == 0 && !state.gcActive && state.lastPublished <= minScanEpoch {
+			delete(m.blobs, blobID)
+		}
+	}
 }
 
 // NewFileSystem initialize Filesystem instance
@@ -454,9 +605,21 @@ func (fs *Filesystem) Mount(ctx context.Context, snapshotID string, labels map[s
 		// Nydusd uses cache manager's directory to store blob caches. So cache
 		// manager knows where to find those blobs.
 		cacheDir := fs.cacheMgr.CacheDir()
+		blobMetaFiles, blobIDs, err := listBlobMetaFiles(bootstrap)
+		if err != nil {
+			return errors.Wrapf(err, "list blob metadata for snapshot %s", snapshotID)
+		}
+		var finishPublication func(bool)
+		published := false
+		if fsDriver == config.FsDriverFscache {
+			finishPublication = fs.BeginFscachePublication(blobIDs)
+			defer func() { finishPublication(published) }()
+		}
 
-		if err := fs.copyBlobMetaFiles(bootstrap, cacheDir); err != nil {
-			log.L.Warnf("Failed to copy blob.meta files to cache: %v", err)
+		copyBlobMetaErr := fs.copyBlobMetaFilesFromList(blobMetaFiles, cacheDir)
+		published = fsDriver == config.FsDriverFscache
+		if copyBlobMetaErr != nil {
+			log.L.Warnf("Failed to copy blob.meta files to cache: %v", copyBlobMetaErr)
 		}
 
 		if useSharedDaemon {
@@ -591,14 +754,15 @@ func (fs *Filesystem) getSnapshotMutex(snapshotID string) *sync.Mutex {
 }
 
 func (fs *Filesystem) copyBlobMetaFiles(bootstrap, cacheDir string) error {
-	bootstrapDir := filepath.Dir(bootstrap)
-	pattern := filepath.Join(bootstrapDir, "*.blob.meta")
-	matches, err := filepath.Glob(pattern)
+	blobMetaFiles, _, err := listBlobMetaFiles(bootstrap)
 	if err != nil {
 		return errors.Wrap(err, "glob blob meta files")
 	}
+	return fs.copyBlobMetaFilesFromList(blobMetaFiles, cacheDir)
+}
 
-	for _, srcPath := range matches {
+func (fs *Filesystem) copyBlobMetaFilesFromList(blobMetaFiles []string, cacheDir string) error {
+	for _, srcPath := range blobMetaFiles {
 		fileName := filepath.Base(srcPath)
 		dstPath := filepath.Join(cacheDir, fileName)
 
@@ -609,6 +773,23 @@ func (fs *Filesystem) copyBlobMetaFiles(bootstrap, cacheDir string) error {
 	}
 
 	return nil
+}
+
+func listBlobMetaFiles(bootstrap string) ([]string, []string, error) {
+	bootstrapDir := filepath.Dir(bootstrap)
+	pattern := filepath.Join(bootstrapDir, "*.blob.meta")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	blobIDs := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if blobID := cache.ExtractBlobIDFromFilename(filepath.Base(match)); blobID != "" {
+			blobIDs = append(blobIDs, blobID)
+		}
+	}
+	return matches, blobIDs, nil
 }
 
 func (fs *Filesystem) copyFile(src, dst string) error {
@@ -800,11 +981,11 @@ func (fs *Filesystem) CacheUsage(ctx context.Context, blobDigest string) (snapsh
 	return fs.cacheMgr.CacheUsage(ctx, blobID)
 }
 
-func (fs *Filesystem) RemoveCache(blobDigest string) error {
+func (fs *Filesystem) RemoveCache(blobDigest string) (bool, error) {
 	log.L.Infof("remove cache %s", blobDigest)
 	digest := digest.Digest(blobDigest)
 	if err := digest.Validate(); err != nil {
-		return errors.Wrapf(err, "invalid blob digest from label %q, digest=%s",
+		return false, errors.Wrapf(err, "invalid blob digest from label %q, digest=%s",
 			snpkg.TargetLayerDigestLabel, blobDigest)
 	}
 	blobID := digest.Hex()
@@ -813,18 +994,53 @@ func (fs *Filesystem) RemoveCache(blobDigest string) error {
 		if fscacheManager != nil {
 			c, err := fs.fscacheSharedDaemon.GetClient()
 			if err != nil {
-				return err
+				return false, err
 			}
-			// delete fscache blob cache file
-			// TODO: skip error for blob not existing
-			if err := c.UnbindBlob("", blobID); err != nil {
-				return err
+			result, err := c.CullBlob(blobID, false)
+			if err != nil {
+				return false, err
 			}
-			return nil
+			if result.Status == daemon.CullBlobPending {
+				log.L.Infof("fscache cull pending for blob %s: %s", blobID, result.Reason)
+				return false, nil
+			}
+			if err := fs.cacheMgr.RemoveBlobCache(blobID); err != nil {
+				return false, err
+			}
+			return true, nil
 		}
 	}
 
-	return fs.cacheMgr.RemoveBlobCache(blobID)
+	if err := fs.cacheMgr.RemoveBlobCache(blobID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (fs *Filesystem) PendingCulls(ctx context.Context) (map[string]string, error) {
+	if fs.fscacheSharedDaemon == nil {
+		return nil, errors.New("fscache shared daemon is not initialized")
+	}
+	c, err := fs.fscacheSharedDaemon.GetClient()
+	if err != nil {
+		return nil, err
+	}
+	return c.PendingCulls(ctx)
+}
+
+// BeginFscachePublication registers metadata publication for a mount.
+func (fs *Filesystem) BeginFscachePublication(blobIDs []string) func(bool) {
+	return fs.fscacheLifecycle.beginPublication(blobIDs)
+}
+
+// BeginFscacheGCScan snapshots publication state for one cache GC pass.
+func (fs *Filesystem) BeginFscacheGCScan() (uint64, func()) {
+	return fs.fscacheLifecycle.beginScan()
+}
+
+// TryBeginFscacheBlobGC claims a blob when no overlapping mount can publish it.
+func (fs *Filesystem) TryBeginFscacheBlobGC(blobID string, scanEpoch uint64) (func(), bool) {
+	return fs.fscacheLifecycle.tryBeginGC(blobID, scanEpoch)
 }
 
 // WalkManagers iterates over all enabled managers and calls the provided function

--- a/pkg/filesystem/fs_test.go
+++ b/pkg/filesystem/fs_test.go
@@ -7,12 +7,19 @@
 package filesystem
 
 import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/pkg/cache"
 	"github.com/containerd/nydus-snapshotter/pkg/daemon"
 	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
@@ -86,4 +93,153 @@ func TestRefreshUnderlyingFilesFailsFastWithoutDaemonSocket(t *testing.T) {
 	require.True(t, errdefs.IsNotFound(err))
 	require.Less(t, time.Since(start), 5*time.Second)
 	require.Empty(t, instance.UnderlyingFiles)
+}
+
+func TestFscacheLifecycleAllowsConcurrentPublicationAndSkipsGC(t *testing.T) {
+	fs := &Filesystem{}
+	endFirst := fs.BeginFscachePublication([]string{"blob-a"})
+	secondStarted := make(chan func(bool), 1)
+	go func() {
+		secondStarted <- fs.BeginFscachePublication([]string{"blob-a"})
+	}()
+	var endSecond func(bool)
+	select {
+	case endSecond = <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("mounts publishing the same blob must remain concurrent")
+	}
+
+	scanEpoch, endScan := fs.BeginFscacheGCScan()
+	defer endScan()
+	if _, ok := fs.TryBeginFscacheBlobGC("blob-a", scanEpoch); ok {
+		t.Fatal("GC must skip a blob with active mount publication")
+	}
+
+	endFirst(true)
+	endSecond(true)
+	if _, ok := fs.TryBeginFscacheBlobGC("blob-a", scanEpoch); ok {
+		t.Fatal("GC must skip a blob published after its scan started")
+	}
+}
+
+func TestFscacheLifecycleOnlyBlocksMatchingPublicationDuringCull(t *testing.T) {
+	fs := &Filesystem{}
+	scanEpoch, endScan := fs.BeginFscacheGCScan()
+	defer endScan()
+	endBlobGC, ok := fs.TryBeginFscacheBlobGC("blob-a", scanEpoch)
+	require.True(t, ok)
+
+	matchingStarted := make(chan func(bool), 1)
+	go func() {
+		matchingStarted <- fs.BeginFscachePublication([]string{"blob-a"})
+	}()
+	select {
+	case <-matchingStarted:
+		t.Fatal("matching publication must wait while cull is active")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unrelatedStarted := fs.BeginFscachePublication([]string{"blob-b"})
+	unrelatedStarted(false)
+
+	endBlobGC()
+	select {
+	case endPublication := <-matchingStarted:
+		endPublication(true)
+	case <-time.After(time.Second):
+		t.Fatal("matching publication did not resume after cull ended")
+	}
+}
+
+func TestFscacheLifecycleWaitingPublicationPreventsAdditionalClaims(t *testing.T) {
+	fs := &Filesystem{}
+	scanEpoch, endScan := fs.BeginFscacheGCScan()
+	defer endScan()
+	endFirstGC, ok := fs.TryBeginFscacheBlobGC("blob-a", scanEpoch)
+	require.True(t, ok)
+
+	publicationStarted := make(chan func(bool), 1)
+	go func() {
+		publicationStarted <- fs.BeginFscachePublication([]string{"blob-a", "blob-b"})
+	}()
+	select {
+	case <-publicationStarted:
+		t.Fatal("publication must wait for the cull already active on blob-a")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if _, ok := fs.TryBeginFscacheBlobGC("blob-b", scanEpoch); ok {
+		t.Fatal("waiting publication must prevent GC from claiming another shared blob")
+	}
+	endFirstGC()
+
+	select {
+	case endPublication := <-publicationStarted:
+		endPublication(true)
+	case <-time.After(time.Second):
+		t.Fatal("publication did not resume after the active cull ended")
+	}
+}
+
+func TestFscacheLifecycleDoesNotProtectPastPublicationFromLaterScan(t *testing.T) {
+	fs := &Filesystem{}
+	endPublication := fs.BeginFscachePublication([]string{"blob-a"})
+	endPublication(true)
+
+	scanEpoch, endScan := fs.BeginFscacheGCScan()
+	defer endScan()
+	endBlobGC, ok := fs.TryBeginFscacheBlobGC("blob-a", scanEpoch)
+	require.True(t, ok, "a later scan must be able to reclaim an unused published blob")
+	endBlobGC()
+}
+
+func TestRemoveCacheKeepsMetadataUntilCullCompletes(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "api.sock")
+	var statusCode atomic.Int32
+	statusCode.Store(http.StatusOK)
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/api/v2/blobs/cull", r.URL.Path)
+		require.Empty(t, r.URL.Query().Get("background"))
+		status := int(statusCode.Load())
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = w.Write([]byte(`{"status":"pending","reason":"awaiting cachefiles commit"}`))
+		}
+	}))
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	ts.Listener = listener
+	ts.Start()
+	defer ts.Close()
+
+	cacheDir := filepath.Join(dir, "cache")
+	cacheMgr, err := cache.NewManager(cache.Opt{CacheDir: cacheDir})
+	require.NoError(t, err)
+	sharedDaemon := &daemon.Daemon{States: daemon.ConfigState{APISocket: sock}}
+	fs := &Filesystem{
+		fscacheSharedDaemon: sharedDaemon,
+		enabledManagers: map[string]*manager.Manager{
+			config.FsDriverFscache: {},
+		},
+		cacheMgr: cacheMgr,
+	}
+
+	blobID := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	metaPath := filepath.Join(cacheDir, blobID+".blob.meta")
+	require.NoError(t, os.WriteFile(metaPath, []byte("metadata"), 0o644))
+
+	done, err := fs.RemoveCache("sha256:" + blobID)
+	require.NoError(t, err)
+	require.False(t, done)
+	_, err = os.Stat(metaPath)
+	require.NoError(t, err, "pending cull must retain metadata for the next GC scan")
+
+	statusCode.Store(http.StatusNoContent)
+	done, err = fs.RemoveCache("sha256:" + blobID)
+	require.NoError(t, err)
+	require.True(t, done)
+	_, err = os.Stat(metaPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/snapshot/cleanup_queue.go
+++ b/snapshot/cleanup_queue.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
+	"github.com/pkg/errors"
 )
 
 type snapshotCleanupTask struct {
@@ -23,19 +25,21 @@ type snapshotCleanupTask struct {
 }
 
 type snapshotCleanupQueue struct {
-	mu      sync.Mutex
-	cond    *sync.Cond
-	tasks   []snapshotCleanupTask
-	head    int
-	pending map[string]chan struct{}
-	closed  bool
-	cleanup func(context.Context, string) error
+	mu       sync.Mutex
+	cond     *sync.Cond
+	tasks    []snapshotCleanupTask
+	head     int
+	pending  map[string]chan struct{}
+	deferred map[string]struct{}
+	closed   bool
+	cleanup  func(context.Context, string) error
 }
 
 func newSnapshotCleanupQueue(cleanup func(context.Context, string) error) *snapshotCleanupQueue {
 	q := &snapshotCleanupQueue{
-		pending: make(map[string]chan struct{}),
-		cleanup: cleanup,
+		pending:  make(map[string]chan struct{}),
+		deferred: make(map[string]struct{}),
+		cleanup:  cleanup,
 	}
 	q.cond = sync.NewCond(&q.mu)
 
@@ -53,11 +57,20 @@ func (q *snapshotCleanupQueue) enqueueAndWait(ctx context.Context, dir, key stri
 		return nil
 	}
 
+	start := time.Now()
+	snapshotID := filepath.Base(dir)
+	log.L.Debugf("snapshotCleanupQueue enqueueAndWait begin snapshot_id=%s dir=%s key=%s",
+		snapshotID, dir, key)
 	select {
 	case <-done:
+		log.L.Debugf("snapshotCleanupQueue enqueueAndWait done snapshot_id=%s dir=%s key=%s duration=%s",
+			snapshotID, dir, key, time.Since(start))
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		err := ctx.Err()
+		log.L.Debugf("snapshotCleanupQueue enqueueAndWait done snapshot_id=%s dir=%s key=%s duration=%s error=%v",
+			snapshotID, dir, key, time.Since(start), err)
+		return err
 	}
 }
 
@@ -77,20 +90,30 @@ func (q *snapshotCleanupQueue) enqueueTask(dir, key string) <-chan struct{} {
 	defer q.mu.Unlock()
 
 	if q.closed {
+		log.L.Debugf("snapshotCleanupQueue enqueue skipped snapshot_id=%s dir=%s key=%s reason=closed",
+			task.snapshotID, task.dir, task.key)
 		log.L.Warnf("snapshot cleanup queue is closed snapshot_id=%s dir=%s key=%s",
 			task.snapshotID, task.dir, task.key)
 		return nil
 	}
 
 	if done, ok := q.pending[task.snapshotID]; ok {
+		log.L.Debugf("snapshotCleanupQueue enqueue skipped snapshot_id=%s dir=%s key=%s reason=pending queue_depth=%d",
+			task.snapshotID, task.dir, task.key, len(q.tasks)-q.head)
 		log.L.Debugf("snapshot cleanup task already pending snapshot_id=%s dir=%s key=%s",
 			task.snapshotID, task.dir, task.key)
 		return done
 	}
 
+	if _, ok := q.deferred[task.snapshotID]; ok {
+		log.L.Debugf("snapshot cleanup task deferred snapshot_id=%s dir=%s key=%s reason=fscache-cull-pending",
+			task.snapshotID, task.dir, task.key)
+		return nil
+	}
+
 	q.pending[task.snapshotID] = task.done
 	q.tasks = append(q.tasks, task)
-	log.L.Infof("queued async snapshot cleanup snapshot_id=%s dir=%s key=%s queue_depth=%d",
+	log.L.Debugf("queued async snapshot cleanup snapshot_id=%s dir=%s key=%s queue_depth=%d",
 		task.snapshotID, task.dir, task.key, len(q.tasks)-q.head)
 	q.cond.Signal()
 	return task.done
@@ -101,7 +124,11 @@ func (q *snapshotCleanupQueue) close() {
 	defer q.mu.Unlock()
 
 	if !q.closed {
+		dropped := len(q.tasks) - q.head
+		log.L.Debugf("snapshotCleanupQueue close begin queue_depth=%d pending=%d",
+			dropped, len(q.pending))
 		q.closed = true
+		q.deferred = nil
 		for i := q.head; i < len(q.tasks); i++ {
 			task := q.tasks[i]
 			delete(q.pending, task.snapshotID)
@@ -110,16 +137,72 @@ func (q *snapshotCleanupQueue) close() {
 		q.tasks = nil
 		q.head = 0
 		q.cond.Broadcast()
+		log.L.Debugf("snapshotCleanupQueue close done dropped=%d pending=%d",
+			dropped, len(q.pending))
 	}
+}
+
+func (q *snapshotCleanupQueue) deferSnapshot(snapshotID string) {
+	if snapshotID == "" {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if !q.closed {
+		if q.deferred == nil {
+			q.deferred = make(map[string]struct{})
+		}
+		q.deferred[snapshotID] = struct{}{}
+	}
+}
+
+func (q *snapshotCleanupQueue) clearDeferred(snapshotID string) {
+	q.mu.Lock()
+	delete(q.deferred, snapshotID)
+	q.mu.Unlock()
+}
+
+func (q *snapshotCleanupQueue) resume(dir, reason string) bool {
+	if dir == "" {
+		return false
+	}
+
+	task := snapshotCleanupTask{
+		dir:        dir,
+		key:        reason,
+		snapshotID: filepath.Base(dir),
+		done:       make(chan struct{}),
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return false
+	}
+	if _, ok := q.pending[task.snapshotID]; ok {
+		return false
+	}
+
+	delete(q.deferred, task.snapshotID)
+	q.pending[task.snapshotID] = task.done
+	q.tasks = append(q.tasks, task)
+	q.cond.Signal()
+	log.L.Debugf("resumed snapshot cleanup snapshot_id=%s dir=%s reason=%s queue_depth=%d",
+		task.snapshotID, task.dir, task.key, len(q.tasks)-q.head)
+	return true
 }
 
 func (q *snapshotCleanupQueue) run() {
 	for {
 		task, ok := q.next()
 		if !ok {
+			log.L.Debug("snapshotCleanupQueue worker exit reason=closed")
 			return
 		}
 		if q.isClosed() {
+			log.L.Debugf("snapshotCleanupQueue worker skip task snapshot_id=%s dir=%s key=%s reason=closed",
+				task.snapshotID, task.dir, task.key)
 			q.finish(task)
 			return
 		}
@@ -158,16 +241,20 @@ func (q *snapshotCleanupQueue) runTask(task snapshotCleanupTask) {
 	defer q.finish(task)
 
 	start := time.Now()
-	log.L.Infof("async snapshot cleanup begin snapshot_id=%s dir=%s key=%s",
+	log.L.Debugf("async snapshot cleanup begin snapshot_id=%s dir=%s key=%s",
 		task.snapshotID, task.dir, task.key)
 
 	if err := q.cleanup(context.Background(), task.dir); err != nil {
+		log.L.Debugf("snapshotCleanupQueue runTask done snapshot_id=%s dir=%s key=%s duration=%s error=%v",
+			task.snapshotID, task.dir, task.key, time.Since(start), err)
+		if errors.Is(err, errdefs.ErrFscacheCullPending) {
+			return
+		}
 		log.L.WithError(err).Warnf("async snapshot cleanup failed snapshot_id=%s dir=%s key=%s duration=%s",
 			task.snapshotID, task.dir, task.key, time.Since(start))
 		return
 	}
-
-	log.L.Infof("async snapshot cleanup done snapshot_id=%s dir=%s key=%s duration=%s",
+	log.L.Debugf("async snapshot cleanup done snapshot_id=%s dir=%s key=%s duration=%s",
 		task.snapshotID, task.dir, task.key, time.Since(start))
 }
 

--- a/snapshot/cleanup_queue_test.go
+++ b/snapshot/cleanup_queue_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package snapshot
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSnapshotCleanupQueueResumesDeferredSnapshot(t *testing.T) {
+	cleaned := make(chan string, 2)
+	queue := newSnapshotCleanupQueue(func(_ context.Context, dir string) error {
+		cleaned <- dir
+		return nil
+	})
+	defer queue.close()
+
+	queue.deferSnapshot("42")
+	if done := queue.enqueueTask("/var/lib/nydus/snapshots/42", "cleanup"); done != nil {
+		t.Fatal("ordinary cleanup must stay deferred")
+	}
+	if !queue.resume("/var/lib/nydus/snapshots/42", "fscache-cull-complete") {
+		t.Fatal("completed fscache cull must release deferred cleanup")
+	}
+	select {
+	case got := <-cleaned:
+		if got != "/var/lib/nydus/snapshots/42" {
+			t.Fatalf("unexpected cleanup directory %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resumed cleanup did not run")
+	}
+
+	done := queue.enqueueTask("/var/lib/nydus/snapshots/42", "cleanup")
+	if done == nil {
+		t.Fatal("ordinary cleanup must be allowed after resume")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ordinary cleanup did not finish after resume")
+	}
+}
+
+func TestSnapshotCleanupQueueResumeWaitsForPendingTask(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	queue := newSnapshotCleanupQueue(func(context.Context, string) error {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		return nil
+	})
+	defer queue.close()
+
+	dir := "/var/lib/nydus/snapshots/42"
+	done := queue.enqueueTask(dir, "remove")
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("initial cleanup did not start")
+	}
+	queue.deferSnapshot("42")
+	if queue.resume(dir, "fscache-cull-complete") {
+		t.Fatal("resume must wait until the pending cleanup task exits")
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("initial cleanup did not finish")
+	}
+	if !queue.resume(dir, "fscache-cull-complete") {
+		t.Fatal("resume must succeed after the pending task exits")
+	}
+}

--- a/snapshot/pending_cull_tracker.go
+++ b/snapshot/pending_cull_tracker.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package snapshot
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/containerd/log"
+)
+
+const pendingCullPollInterval = time.Second
+
+type pendingCullCandidate struct {
+	dir    string
+	blobID string
+	reason string
+}
+
+type pendingCullTracker struct {
+	interval     time.Duration
+	pendingCulls func(context.Context) (map[string]string, error)
+	queue        *snapshotCleanupQueue
+
+	mu         sync.Mutex
+	candidates map[string]pendingCullCandidate
+	closed     bool
+	cancel     context.CancelFunc
+	done       chan struct{}
+}
+
+func newPendingCullTracker(
+	parent context.Context,
+	interval time.Duration,
+	pendingCulls func(context.Context) (map[string]string, error),
+	queue *snapshotCleanupQueue,
+) *pendingCullTracker {
+	ctx, cancel := context.WithCancel(parent)
+	t := &pendingCullTracker{
+		interval:     interval,
+		pendingCulls: pendingCulls,
+		queue:        queue,
+		candidates:   make(map[string]pendingCullCandidate),
+		cancel:       cancel,
+		done:         make(chan struct{}),
+	}
+	go t.run(ctx)
+	return t
+}
+
+func (t *pendingCullTracker) register(dir, blobID, reason string) {
+	snapshotID := filepath.Base(dir)
+	candidate := pendingCullCandidate{
+		dir:    filepath.Clean(dir),
+		blobID: blobID,
+		reason: reason,
+	}
+
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return
+	}
+	previous, existed := t.candidates[snapshotID]
+	t.candidates[snapshotID] = candidate
+	t.queue.deferSnapshot(snapshotID)
+	t.mu.Unlock()
+
+	if !existed || previous.blobID != blobID || previous.reason != reason {
+		log.L.Infof("tracking pending fscache cleanup snapshot_id=%s blob_id=%s reason=%s",
+			snapshotID, blobID, reason)
+	}
+}
+
+func (t *pendingCullTracker) forget(snapshotID string) {
+	t.mu.Lock()
+	delete(t.candidates, snapshotID)
+	t.queue.clearDeferred(snapshotID)
+	t.mu.Unlock()
+}
+
+func (t *pendingCullTracker) close() {
+	t.mu.Lock()
+	t.closed = true
+	t.mu.Unlock()
+	t.cancel()
+	<-t.done
+}
+
+func (t *pendingCullTracker) run(ctx context.Context) {
+	defer close(t.done)
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if t.candidateCount() == 0 {
+				continue
+			}
+			if err := t.reconcile(ctx); err != nil {
+				log.L.WithError(err).Warnf("failed to query pending fscache culls candidates=%d", t.candidateCount())
+			}
+		}
+	}
+}
+
+func (t *pendingCullTracker) reconcile(ctx context.Context) error {
+	pending, err := t.pendingCulls(ctx)
+	if err != nil {
+		return err
+	}
+
+	t.mu.Lock()
+	candidates := make(map[string]pendingCullCandidate, len(t.candidates))
+	for snapshotID, candidate := range t.candidates {
+		candidates[snapshotID] = candidate
+	}
+	t.mu.Unlock()
+
+	for snapshotID, candidate := range candidates {
+		if reason, ok := pending[candidate.blobID]; ok {
+			if reason != candidate.reason {
+				t.updateReason(snapshotID, candidate.blobID, reason)
+			}
+			continue
+		}
+
+		t.mu.Lock()
+		current, ok := t.candidates[snapshotID]
+		if !ok || current.blobID != candidate.blobID {
+			t.mu.Unlock()
+			continue
+		}
+		resumed := t.queue.resume(current.dir, "fscache-cull-complete")
+		if resumed {
+			delete(t.candidates, snapshotID)
+		}
+		t.mu.Unlock()
+		if !resumed {
+			continue
+		}
+
+		log.L.Infof("resumed pending fscache cleanup snapshot_id=%s blob_id=%s", snapshotID, candidate.blobID)
+	}
+	return nil
+}
+
+func (t *pendingCullTracker) updateReason(snapshotID, blobID, reason string) {
+	t.mu.Lock()
+	candidate, ok := t.candidates[snapshotID]
+	if ok && candidate.blobID == blobID {
+		candidate.reason = reason
+		t.candidates[snapshotID] = candidate
+	}
+	t.mu.Unlock()
+}
+
+func (t *pendingCullTracker) candidateCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.candidates)
+}

--- a/snapshot/pending_cull_tracker_test.go
+++ b/snapshot/pending_cull_tracker_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPendingCullTrackerResumesAfterNydusdCompletion(t *testing.T) {
+	dir := "/var/lib/nydus/snapshots/42"
+	cleaned := make(chan string, 1)
+	queue := newSnapshotCleanupQueue(func(_ context.Context, got string) error {
+		cleaned <- got
+		return nil
+	})
+	defer queue.close()
+
+	pending := map[string]string{"blob": "open"}
+	tracker := &pendingCullTracker{
+		pendingCulls: func(context.Context) (map[string]string, error) { return pending, nil },
+		queue:        queue,
+		candidates:   make(map[string]pendingCullCandidate),
+	}
+	tracker.register(dir, "blob", "awaiting cachefiles commit")
+
+	if err := tracker.reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if tracker.candidates["42"].reason != "open" {
+		t.Fatalf("pending reason was not updated: %+v", tracker.candidates["42"])
+	}
+	pending = map[string]string{}
+	if err := tracker.reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-cleaned:
+		if got != dir {
+			t.Fatalf("unexpected cleanup directory %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cleanup was not resumed after cull completion")
+	}
+	if len(tracker.candidates) != 0 {
+		t.Fatalf("completed candidate was retained: %+v", tracker.candidates)
+	}
+}
+
+func TestPendingCullTrackerUsesOneBatchQuery(t *testing.T) {
+	queue := newSnapshotCleanupQueue(func(context.Context, string) error { return nil })
+	defer queue.close()
+
+	queries := 0
+	tracker := &pendingCullTracker{
+		pendingCulls: func(context.Context) (map[string]string, error) {
+			queries++
+			return map[string]string{"blob-a": "open", "blob-b": "inuse"}, nil
+		},
+		queue:      queue,
+		candidates: make(map[string]pendingCullCandidate),
+	}
+	tracker.register("/snapshots/1", "blob-a", "open")
+	tracker.register("/snapshots/2", "blob-b", "inuse")
+
+	if err := tracker.reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if queries != 1 {
+		t.Fatalf("expected one batch query, got %d", queries)
+	}
+}
+
+func TestPendingCullTrackerRetainsCandidatesOnQueryError(t *testing.T) {
+	queue := newSnapshotCleanupQueue(func(context.Context, string) error { return nil })
+	defer queue.close()
+
+	tracker := &pendingCullTracker{
+		pendingCulls: func(context.Context) (map[string]string, error) {
+			return nil, errors.New("nydusd unavailable")
+		},
+		queue:      queue,
+		candidates: make(map[string]pendingCullCandidate),
+	}
+	tracker.register("/snapshots/1", "blob", "open")
+
+	if err := tracker.reconcile(context.Background()); err == nil {
+		t.Fatal("expected pending query error")
+	}
+	if len(tracker.candidates) != 1 {
+		t.Fatalf("candidate was lost after query error: %+v", tracker.candidates)
+	}
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -64,6 +64,7 @@ type snapshotter struct {
 	cleanupOnClose          bool
 	enableOverlayfsVolatile bool
 	cleanupQueue            *snapshotCleanupQueue
+	pendingCullTracker      *pendingCullTracker
 }
 
 func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapshots.Snapshotter, error) {
@@ -314,6 +315,12 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	if config.GetFsDriver() == config.FsDriverFscache && !syncRemove {
 		log.L.Infof("enable async snapshot cleanup for fscache mode")
 		sn.cleanupQueue = newSnapshotCleanupQueue(sn.cleanupSnapshotDirectory)
+		sn.pendingCullTracker = newPendingCullTracker(
+			ctx,
+			pendingCullPollInterval,
+			sn.fs.PendingCulls,
+			sn.cleanupQueue,
+		)
 	}
 
 	return sn, nil
@@ -330,7 +337,8 @@ func (o *snapshotter) Cleanup(ctx context.Context) error {
 		return err
 	}
 
-	log.L.Infof("[Cleanup] orphan directories %v", cleanup)
+	log.L.Infof("[Cleanup] orphan directories count=%d", len(cleanup))
+	log.L.Debugf("[Cleanup] orphan directories %v", cleanup)
 
 	for _, dir := range cleanup {
 		if o.cleanupQueue != nil {
@@ -344,21 +352,31 @@ func (o *snapshotter) Cleanup(ctx context.Context) error {
 		}
 	}
 
+	scanEpoch, endScan := o.fs.BeginFscacheGCScan()
+	defer endScan()
 	cleanup, err = o.getUnusedCacheBlobs(ctx)
 	if err != nil {
 		return err
 	}
-	log.L.Infof("[Cleanup] unused cache blobs %v", cleanup)
+	log.L.Infof("[Cleanup] unused cache blobs count=%d", len(cleanup))
+	log.L.Debugf("[Cleanup] unused cache blobs %v", cleanup)
 
 	for _, blob := range cleanup {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		endBlobGC, ok := o.fs.TryBeginFscacheBlobGC(blob, scanEpoch)
+		if !ok {
+			log.L.Infof("skip fscache blob %s cleanup due to concurrent mount publication", blob)
+			continue
+		}
 		// Add sha256: prefix to make it a valid blob digest
-		if err := o.fs.RemoveCache("sha256:" + blob); err != nil {
+		done, err := o.fs.RemoveCache("sha256:" + blob)
+		endBlobGC()
+		if err != nil {
 			log.L.WithError(err).Warnf("failed to remove cache blob %s", blob)
 			data.CacheBlobDeletionErrors.Inc()
-		} else {
+		} else if done {
 			data.CacheBlobsDeleted.Inc()
 		}
 	}
@@ -746,6 +764,9 @@ func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...str
 func (o *snapshotter) Close() error {
 	log.L.Info("[Close] shutdown snapshotter")
 
+	if o.pendingCullTracker != nil {
+		o.pendingCullTracker.close()
+	}
 	if o.cleanupQueue != nil {
 		o.cleanupQueue.close()
 	}
@@ -1368,9 +1389,16 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 	// For example: cleanupSnapshotDirectory /var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/34" dir=/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/34
 
 	snapshotID := filepath.Base(dir)
-	if err := o.fs.Umount(ctx, snapshotID); err != nil && !os.IsNotExist(err) {
-		log.G(ctx).WithError(err).WithField("dir", dir).Error("failed to unmount")
-		return errors.Wrapf(err, "unmount snapshot directory %q", dir)
+	if err := o.fs.Umount(ctx, snapshotID); err != nil {
+		if !os.IsNotExist(err) {
+			var pending *errdefs.FscacheCullPendingError
+			if errors.As(err, &pending) && o.pendingCullTracker != nil {
+				o.pendingCullTracker.register(dir, pending.BlobID, pending.Reason)
+			} else {
+				log.G(ctx).WithError(err).WithField("dir", dir).Error("failed to unmount")
+			}
+			return errors.Wrapf(err, "unmount snapshot directory %q", dir)
+		}
 	}
 
 	if o.fs.TarfsEnabled() {
@@ -1381,6 +1409,11 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 
 	if err := os.RemoveAll(dir); err != nil {
 		return errors.Wrapf(err, "remove directory %q", dir)
+	}
+	if o.pendingCullTracker != nil {
+		o.pendingCullTracker.forget(snapshotID)
+	} else if o.cleanupQueue != nil {
+		o.cleanupQueue.clearDeferred(snapshotID)
 	}
 
 	return nil


### PR DESCRIPTION
## Overview
Use nydusd's cull completion status during fscache teardown, and keep snapshot teardown state and blob metadata until cachefiles confirms reclamation.

Unmount EROFS before unbinding and culling, and make retries tolerate an already-unmounted mountpoint. Return a pending error without dropping the teardown marker when cull is incomplete.

Coordinate blob metadata publication with cache GC through a per-blob lifecycle. Skip a GC claim that overlaps a mount publication so a new mount cannot race with metadata removal.

Add client, teardown, pending-cull, and publication/GC lifecycle tests.

Related: [Nydusd: fix: report fscache blob cull completion status #1993](https://github.com/dragonflyoss/nydus/pull/1993)

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [x] Performance Improvement
- [ ] Other (please describe)