### PR TITLE
fix(auth): only warn when a stored credential fails to renew

### DIFF
--- a/pkg/auth/keychain.go
+++ b/pkg/auth/keychain.go
@@ -110,13 +110,21 @@ func getRegistryKeyChainFromProviders(ref string, labels map[string]string, prov
 		// If not available, request credentials valid until the next renewal tick.
 		authReq.ValidUntil = time.Now().Add(renewalStore.renewInterval)
 	}
-	return fetchFromProviders(authReq, providers)
+	kc, err := fetchFromProviders(authReq, providers)
+	if err != nil {
+		// On the pull path a miss is a real problem: the image is being
+		// fetched right now and no provider could authenticate it.
+		logger.WithError(err).Warn("Could not get registry credentials.")
+	}
+	return kc
 }
 
 // fetchFromProviders walks providers in order and returns credentials from the
 // first one that succeeds. If the winning provider is renewable and the renewal
-// store is active, the credentials are cached for periodic renewal.
-func fetchFromProviders(req *AuthRequest, providers []AuthProvider) *PassKeyChain {
+// store is active, the credentials are cached for periodic renewal. When no
+// provider returns credentials, the joined provider errors are returned so the
+// caller can decide how loudly to report the miss.
+func fetchFromProviders(req *AuthRequest, providers []AuthProvider) (*PassKeyChain, error) {
 	logger := log.L.WithField("ref", req.Ref)
 
 	var errs []error
@@ -134,14 +142,11 @@ func fetchFromProviders(req *AuthRequest, providers []AuthProvider) *PassKeyChai
 					renewalStore.Add(req.Ref, kc)
 				}
 			}
-			return kc
+			return kc, nil
 		}
 	}
 
-	if len(errs) > 0 {
-		logger.WithError(stderrors.Join(errs...)).Warn("Could not get registry credentials.")
-	}
-	return nil
+	return nil, stderrors.Join(errs...)
 }
 
 func GetKeyChainByRef(ref string, labels map[string]string) (*PassKeyChain, error) {

--- a/pkg/auth/renewal.go
+++ b/pkg/auth/renewal.go
@@ -37,18 +37,34 @@ func GetStoredCredential(ref string) *PassKeyChain {
 // RenewCredential fetches fresh credentials for ref from the renewable
 // provider list and caches them in the global store. Returns the keychain
 // on success or nil on failure. Emits renewal metrics.
+//
+// A miss only warrants a warning when a previously stored credential could
+// not be renewed: that entry is about to go stale. When the store never had
+// the ref — e.g. only non-renewable providers like the CRI keychain are
+// configured, where finding nothing is the expected outcome — the miss is
+// logged at debug level.
 func RenewCredential(ref string) *PassKeyChain {
-	kc := fetchFromProviders(
+	stored := GetStoredCredential(ref)
+	kc, err := fetchFromProviders(
 		&AuthRequest{Ref: ref, ValidUntil: time.Now().Add(renewalStore.renewInterval)},
 		renewableProviders(),
 	)
 	if kc != nil {
 		data.CredentialRenewals.WithLabelValues(ref, "success").Inc()
-	} else {
-		log.L.WithField("ref", ref).Warn("credential renewal returned no credentials from any provider")
-		data.CredentialRenewals.WithLabelValues(ref, "failure").Inc()
+		return kc
 	}
-	return kc
+
+	logger := log.L.WithField("ref", ref)
+	if err != nil {
+		logger = logger.WithError(err)
+	}
+	if stored != nil {
+		logger.Warn("stored credential could not be renewed from any provider")
+	} else {
+		logger.Debug("credential renewal returned no credentials from any provider")
+	}
+	data.CredentialRenewals.WithLabelValues(ref, "failure").Inc()
+	return nil
 }
 
 // EvictStaleCredentials removes store entries whose ref is not present in

--- a/pkg/auth/renewal_test.go
+++ b/pkg/auth/renewal_test.go
@@ -13,6 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/log"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -203,6 +206,54 @@ func TestCredentialStoreConcurrency(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+// --- renewal miss logging ---
+
+func TestRenewCredentialMissLogging(t *testing.T) {
+	const ref = "docker.io/library/nginx:latest"
+
+	setup := func(t *testing.T) *logtest.Hook {
+		oldRenewable := renewableProviders
+		oldStore := renewalStore
+		t.Cleanup(func() {
+			renewableProviders = oldRenewable
+			renewalStore = oldStore
+		})
+		renewableProviders = func() []AuthProvider {
+			return []AuthProvider{&mockProvider{err: fmt.Errorf("provider not configured")}}
+		}
+		renewalStore = newCredentialStore(5 * time.Minute)
+
+		hook := logtest.NewLocal(log.L.Logger)
+		t.Cleanup(hook.Reset)
+		return hook
+	}
+
+	warnings := func(hook *logtest.Hook) []string {
+		var msgs []string
+		for _, e := range hook.AllEntries() {
+			if e.Level == logrus.WarnLevel {
+				msgs = append(msgs, e.Message)
+			}
+		}
+		return msgs
+	}
+
+	t.Run("first-time miss is not warned", func(t *testing.T) {
+		hook := setup(t)
+
+		assert.Nil(t, RenewCredential(ref))
+		assert.Empty(t, warnings(hook))
+	})
+
+	t.Run("losing a stored credential warns", func(t *testing.T) {
+		hook := setup(t)
+		renewalStore.Add(ref, &PassKeyChain{Username: "user", Password: "pass"})
+
+		assert.Nil(t, RenewCredential(ref))
+		assert.Contains(t, warnings(hook), "stored credential could not be renewed from any provider")
+	})
 }
 
 // --- RenewCredential ---


### PR DESCRIPTION
The renewal loop warns twice per image ref on every reconcile pass — at startup and on every renewal tick — whenever no renewable provider returns credentials. With `enable_cri_keychain` and no renewable providers configured this is the expected outcome (CRI credentials are captured at pull time and cannot be re-fetched), so the warnings read like broken registry auth but signal nothing.

This keeps the initial reconciliation synchronous (unchanged) and fixes the logging instead:

- the image-pull path still warns on a miss (a real problem);
- renewal warns only when a previously stored credential fails to renew (about to go stale);
- a renewal miss for a ref never in the store logs at debug.

Replaces the original defer approach per review discussion.
