### PR TITLE
fix(daemon): stop waiting for the API socket when the daemon process is gone

### DIFF
--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -191,7 +191,10 @@ func WaitUntilSocketExisted(sock string, pid int) error {
 		retry.OnlyRetryIf(func(error) bool {
 			zombie, err := tool.IsZombieProcess(pid)
 			if err != nil {
-				return false
+				// The process is gone, so its socket will never show up.
+				// Stop retry immediately.
+				log.L.WithError(err).Errorf("Process %d is gone, giving up waiting for socket %s", pid, sock)
+				return true
 			}
 			// Stop retry if nydus daemon process is already in Zombie state.
 			if zombie {

--- a/pkg/daemon/client_test.go
+++ b/pkg/daemon/client_test.go
@@ -12,8 +12,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,6 +70,31 @@ func TestNydusClient_CheckStatus(t *testing.T) {
 	assert.Equal(t, info.DaemonState(), types.DaemonStateRunning)
 	assert.Equal(t, "testid", info.ID)
 	assert.Equal(t, BTI, info.Version)
+}
+
+func TestWaitUntilSocketExistedAbortsWhenProcessIsGone(t *testing.T) {
+	// A process that has exited and been reaped has no /proc entry anymore,
+	// so its socket can never appear.
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Wait())
+
+	sock := filepath.Join(t.TempDir(), "api.sock")
+
+	start := time.Now()
+	err := WaitUntilSocketExisted(sock, cmd.Process.Pid)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// Without the abort the retry loop burns all 100 attempts (~15s).
+	assert.Less(t, elapsed, 3*time.Second)
+}
+
+func TestWaitUntilSocketExistedReturnsWhenSocketExists(t *testing.T) {
+	sock, dispose := prepareNydusServer(t)
+	defer dispose()
+
+	require.NoError(t, WaitUntilSocketExisted(sock, os.Getpid()))
 }
 
 func TestUpdateConfig(t *testing.T) {


### PR DESCRIPTION
`WaitUntilSocketExisted` passes an abort callback to `retry.OnlyRetryIf` (return true = stop retrying). The callback returns `false` when `IsZombieProcess` errors — i.e. when the process is gone entirely — so waiting on a dead daemon runs all 100 attempts (~15s with jitter) instead of aborting on the first. A zombie aborts immediately; a fully gone process doesn't.

The impact is on startup: `recoverDaemons` → `GetState` → `GetClient` → `WaitUntilSocketExisted` runs serially for every recorded daemon before `Serve()`, so N dead daemon records (host reboot, daemons killed while the snapshotter was down) mean N×15s with no gRPC socket and containerd getting `Unavailable` for every snapshot RPC.

Measured on a test node with 8 dead daemon records, main @ 8a7cfda:

| | socket absent | pod created during the window |
|---|---|---|
| before | 120.3s | Running after 116s, 11 error events (9× FailedCreatePodSandBox) |
| after | 0.5s | Running after 5s, no error events |

Before — each daemon burns ~15s:
```
14:21:53.623 Recovering daemon ID d9l1sjgmf3lkti1guqog
14:22:08.736 Daemon d9l1sjgmf3lkti1guqog died somehow. Clean up its vestige!
14:22:08.736 Recovering daemon ID d9l1t90mf3lldd30og8g
14:22:23.859 Daemon d9l1t90mf3lldd30og8g died somehow. Clean up its vestige!
... (8 total)
```

After — all 8 handled within 1ms:
```
14:24:18.7935 Recovering daemon ID d9l1sjgmf3lkti1guqog
14:24:18.7936 Process 1836476 is gone, giving up waiting for socket ...
14:24:18.7936 Daemon d9l1sjgmf3lkti1guqog died somehow. Clean up its vestige!
... (8 total)
```

The regression test fails on main (runs the full 15s) and passes with the fix.

Related: #791 — this removes the pathological case of that startup window.
