### PR TITLE
add Zephyrcf as a reviewer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15,3 +15,4 @@ Fricounet, Baptiste Girard-Carrabin, baptiste.girardcarrabin@datadoghq.com
 # GitHub ID, Name, Email address
 sctb512, Bin Tang, tangbin.bin@bytedance.com
 BraveY, Kaiyong Yang, yangkaiyong.yky@antgroup.com
+Zephyrcf, Changfu Zhang, zinsist777@gmail.com


### PR DESCRIPTION
Changfu Zhang @Zephyrcf works at University of Science and Technology Beijing and is a core member of the nydus project, he has contributed valuable fixups / features to the nydus repo, it would be great to add him as a reviewer for the nydus-snapshotter project.

Maintainer Details:
- GitHub Username: Zephyrcf
- GitHub link: https://github.com/Zephyrcf
- Project: https://github.com/dragonflyoss
- Role: Maintainer, refer to https://github.com/dragonflyoss/community/blob/30ad71f4d4eb8201e59782975dccb27594d9f94c/roles/Maintainers.md?plain=1#L10
- CNCF Foundation Official Maintainer PR: https://github.com/cncf/foundation/pull/1480

Needs explicit LGTM from 2/3 of the nydus-snapshotter committers:

- [x]  @imeoer
- [ ]  @changweige
- [ ]  @eryugey

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [x] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.