### PR TITLE
feat(cmd): notify systemd readiness after the snapshotter starts serving

### DIFF
--- a/cmd/containerd-nydus-grpc/sdnotify.go
+++ b/cmd/containerd-nydus-grpc/sdnotify.go
@@ -25,10 +25,10 @@ func notifySystemd(state string) {
 	}
 }
 
-// notifyReady tells the service manager the snapshotter has finished recovery
-// and its gRPC socket is serving. With Type=notify, systemd keeps the unit in
-// "activating" until this point, so dependents can order on real readiness
-// instead of process start.
+// notifyReady tells the service manager that the snapshotter has finished
+// recovery and its gRPC socket is ready to accept connections. With
+// Type=notify, systemd keeps the unit "activating" until this point, allowing
+// dependents to wait for actual readiness instead of merely process startup.
 func notifyReady() {
 	notifySystemd(sd.SdNotifyReady)
 }

--- a/cmd/containerd-nydus-grpc/sdnotify.go
+++ b/cmd/containerd-nydus-grpc/sdnotify.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"github.com/containerd/log"
+	sd "github.com/coreos/go-systemd/v22/daemon"
+)
+
+// notifySystemd reports a lifecycle state to the service manager (sd_notify).
+// It is a no-op unless the snapshotter runs under systemd with Type=notify,
+// i.e. NOTIFY_SOCKET is set in the environment.
+func notifySystemd(state string) {
+	sent, err := sd.SdNotify(false, state)
+	if err != nil {
+		log.L.WithError(err).Warnf("failed to notify service manager: %s", state)
+		return
+	}
+	if sent {
+		log.L.Infof("notified service manager: %s", state)
+	}
+}
+
+// notifyReady tells the service manager the snapshotter has finished recovery
+// and its gRPC socket is serving. With Type=notify, systemd keeps the unit in
+// "activating" until this point, so dependents can order on real readiness
+// instead of process start.
+func notifyReady() {
+	notifySystemd(sd.SdNotifyReady)
+}
+
+// notifyStopping tells the service manager the snapshotter began shutting
+// down.
+func notifyStopping() {
+	notifySystemd(sd.SdNotifyStopping)
+}

--- a/cmd/containerd-nydus-grpc/sdnotify_test.go
+++ b/cmd/containerd-nydus-grpc/sdnotify_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotifySystemd(t *testing.T) {
+	t.Run("sends READY over NOTIFY_SOCKET", func(t *testing.T) {
+		sock := filepath.Join(t.TempDir(), "notify.sock")
+		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: sock, Net: "unixgram"})
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		t.Setenv("NOTIFY_SOCKET", sock)
+
+		notifyReady()
+
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(3*time.Second)))
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, "READY=1", string(buf[:n]))
+
+		notifyStopping()
+
+		n, err = conn.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, "STOPPING=1", string(buf[:n]))
+	})
+
+	t.Run("no-op without NOTIFY_SOCKET", func(t *testing.T) {
+		t.Setenv("NOTIFY_SOCKET", "")
+
+		notifyReady()
+	})
+}

--- a/cmd/containerd-nydus-grpc/snapshotter.go
+++ b/cmd/containerd-nydus-grpc/snapshotter.go
@@ -96,6 +96,7 @@ func Serve(ctx context.Context, sn snapshots.Snapshotter, options ServeOptions, 
 	go func() {
 		<-stop
 
+		notifyStopping()
 		log.L.Infof("Shutting down nydus-snapshotter!")
 
 		if err := sn.Close(); err != nil {
@@ -106,6 +107,10 @@ func Serve(ctx context.Context, sn snapshots.Snapshotter, options ServeOptions, 
 			log.L.Errorf("Failed to close listener %s, err: %v", options.ListeningSocketPath, err)
 		}
 	}()
+
+	// The listener accepts connections from this point on; recovery completed
+	// in NewSnapshotter before Serve was entered.
+	notifyReady()
 
 	return rpc.Serve(listener)
 }

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/containerd/stargz-snapshotter v0.15.2-0.20240709063920-1dac5ef89319
 	github.com/containerd/stargz-snapshotter/estargz v0.15.2-0.20240709063920-1dac5ef89319
 	github.com/containers/ocicrypt v1.2.1
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.4.0+incompatible
 	github.com/freddierice/go-losetup v0.0.0-20220711213114-2a14873012db
@@ -86,7 +87,6 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
-	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/misc/snapshotter/nydus-snapshotter.fscache.service
+++ b/misc/snapshotter/nydus-snapshotter.fscache.service
@@ -5,6 +5,10 @@ Before=containerd.service
 
 [Service]
 Type=simple
+# The snapshotter serves its gRPC socket only after recovering all daemon
+# state. Switch to Type=notify to keep the unit "activating" until then,
+# so dependents order on real readiness instead of process start.
+#Type=notify
 Environment=HOME=/root
 ExecStart=/usr/local/bin/containerd-nydus-grpc --config /etc/nydus/config.toml --fs-driver fscache --nydusd-config /etc/nydus/nydusd-config.fscache.json
 Restart=always

--- a/misc/snapshotter/nydus-snapshotter.fusedev.service
+++ b/misc/snapshotter/nydus-snapshotter.fusedev.service
@@ -5,6 +5,10 @@ Before=containerd.service
 
 [Service]
 Type=simple
+# The snapshotter serves its gRPC socket only after recovering all daemon
+# state. Switch to Type=notify to keep the unit "activating" until then,
+# so dependents order on real readiness instead of process start.
+#Type=notify
 Environment=HOME=/root
 ExecStart=/usr/local/bin/containerd-nydus-grpc --config /etc/nydus/config.toml
 Restart=always

--- a/misc/snapshotter/nydus-snapshotter.service
+++ b/misc/snapshotter/nydus-snapshotter.service
@@ -5,6 +5,10 @@ Before=containerd.service
 
 [Service]
 Type=simple
+# The snapshotter serves its gRPC socket only after recovering all daemon
+# state. Switch to Type=notify to keep the unit "activating" until then,
+# so dependents order on real readiness instead of process start.
+#Type=notify
 Environment=HOME=/root
 ExecStart=/usr/local/bin/containerd-nydus-grpc --config /etc/nydus/config-proxy.toml
 Restart=always


### PR DESCRIPTION
Implements 2(a) from #791.

The snapshotter serves its gRPC socket only after recovering all daemon state, but with `Type=simple` systemd marks the unit `active` the moment the process starts — the recovery window is invisible and nothing can order on it.

This sends `READY=1` right before the gRPC server starts serving, and `STOPPING=1` on shutdown. Both are no-ops unless `NOTIFY_SOCKET` is set, so nothing changes for existing deployments; the shipped unit files gain a commented `Type=notify` line to opt in. With `Type=notify`, the unit stays `activating` during recovery, `After=` dependents wait for actual readiness, and a crash loop during recovery shows as a unit that never reaches `active` instead of flapping `active`.

`coreos/go-systemd` was already an indirect dependency; promoted to direct.
