### PR TITLE
feat(manager): recover daemons concurrently

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -329,11 +329,19 @@ func (m *Manager) cleanUpDaemonResources(d *daemon.Daemon) {
 	log.L.Infof("Deleting resources %v", resource)
 }
 
-// recoverConcurrency bounds how many daemons are recovered at once. Recovery
-// is IO-bound (an HTTP request over each daemon's API socket), so a modest
+// recoverConcurrency bounds how many daemons are probed at once. Probing is
+// IO-bound (an HTTP request over each daemon's API socket), so a modest
 // fan-out bounds the pre-serving window by the slowest daemons instead of the
 // sum, without stampeding hosts that accumulated many daemons.
 const recoverConcurrency = 8
+
+// probedDaemon is the outcome of the concurrent, side-effect-free probe of
+// one persisted daemon record.
+type probedDaemon struct {
+	d     *daemon.Daemon
+	state types.DaemonState
+	dead  bool
+}
 
 func (m *Manager) recoverDaemons(ctx context.Context,
 	recoveringDaemons *map[string]*daemon.Daemon, liveDaemons *map[string]*daemon.Daemon) error {
@@ -351,27 +359,18 @@ func (m *Manager) recoverDaemons(ctx context.Context,
 		return errors.Wrapf(err, "walk daemons to reconnect")
 	}
 
-	// The daemon cache and the supervisor set take their own locks; the
-	// result maps are only guarded here.
-	var mu sync.Mutex
+	// Probe all daemons concurrently: rebuild the daemon object, reload its
+	// configuration and query its state. Probing mutates no shared state, so
+	// a failure here fails recovery without anything committed.
+	probed := make([]probedDaemon, len(states))
 	var eg errgroup.Group
 	eg.SetLimit(recoverConcurrency)
 
-	for _, s := range states {
+	for i, s := range states {
 		eg.Go(func() error {
 			opt := make([]daemon.NewDaemonOpt, 0)
 			var d, _ = daemon.NewDaemon(opt...)
 			d.States = *s
-
-			m.daemonCache.Update(d)
-
-			if m.SupervisorSet != nil {
-				su := m.SupervisorSet.NewSupervisor(d.ID())
-				if su == nil {
-					return errors.Errorf("create supervisor for daemon %s", d.ID())
-				}
-				d.Supervisor = su
-			}
 
 			if d.States.FsDriver == config.FsDriverFusedev {
 				cfg, err := daemonconfig.NewDaemonConfig(d.States.FsDriver, d.ConfigFile(""))
@@ -386,51 +385,73 @@ func (m *Manager) recoverDaemons(ctx context.Context,
 			state, err := d.GetState()
 			if err != nil {
 				log.L.Warnf("Daemon %s died somehow. Clean up its vestige!, %s", d.ID(), err)
-				mu.Lock()
-				(*recoveringDaemons)[d.ID()] = d
-				mu.Unlock()
+				probed[i] = probedDaemon{d: d, dead: true}
 				//nolint:nilerr
 				return nil
 			}
 
-			if state != types.DaemonStateRunning {
-				log.L.Warnf("daemon %s is not running: %s", d.ID(), state)
-				return nil
-			}
-
-			// FIXME: Should put the a daemon back file system shared damon field.
-			log.L.Infof("found RUNNING daemon %s during reconnecting", d.ID())
-			mu.Lock()
-			(*liveDaemons)[d.ID()] = d
-			mu.Unlock()
-
-			if m.CgroupMgr != nil {
-				if err := m.CgroupMgr.AddProc(d.States.ProcessID); err != nil {
-					return errors.Wrapf(err, "add daemon %s to cgroup failed", d.ID())
-				}
-			}
-			d.Lock()
-			collector.NewDaemonInfoCollector(&d.Version, 1).Collect()
-			d.Unlock()
-
-			go func() {
-				if err := daemon.WaitUntilSocketExisted(d.GetAPISock(), d.Pid()); err != nil {
-					log.L.Errorf("Nydusd %s probably not started", d.ID())
-					return
-				}
-
-				if err := m.SubscribeDaemonEvent(d); err != nil {
-					log.L.Errorf("Nydusd %s probably not started", d.ID())
-					return
-				}
-
-				// Snapshotter's lost the daemons' states after exit, refetch them.
-				d.SendStates()
-			}()
-
+			probed[i] = probedDaemon{d: d, state: state}
 			return nil
 		})
 	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
 
-	return eg.Wait()
+	// Commit the results serially: cache, supervisor, cgroup and the result
+	// maps only change once every probe has succeeded.
+	for i := range probed {
+		d := probed[i].d
+
+		m.daemonCache.Update(d)
+
+		if m.SupervisorSet != nil {
+			su := m.SupervisorSet.NewSupervisor(d.ID())
+			if su == nil {
+				return errors.Errorf("create supervisor for daemon %s", d.ID())
+			}
+			d.Supervisor = su
+		}
+
+		if probed[i].dead {
+			(*recoveringDaemons)[d.ID()] = d
+			continue
+		}
+
+		if probed[i].state != types.DaemonStateRunning {
+			log.L.Warnf("daemon %s is not running: %s", d.ID(), probed[i].state)
+			continue
+		}
+
+		// FIXME: Should put the a daemon back file system shared damon field.
+		log.L.Infof("found RUNNING daemon %s during reconnecting", d.ID())
+
+		if m.CgroupMgr != nil {
+			if err := m.CgroupMgr.AddProc(d.States.ProcessID); err != nil {
+				return errors.Wrapf(err, "add daemon %s to cgroup failed", d.ID())
+			}
+		}
+		(*liveDaemons)[d.ID()] = d
+
+		d.Lock()
+		collector.NewDaemonInfoCollector(&d.Version, 1).Collect()
+		d.Unlock()
+
+		go func() {
+			if err := daemon.WaitUntilSocketExisted(d.GetAPISock(), d.Pid()); err != nil {
+				log.L.Errorf("Nydusd %s probably not started", d.ID())
+				return
+			}
+
+			if err := m.SubscribeDaemonEvent(d); err != nil {
+				log.L.Errorf("Nydusd %s probably not started", d.ID())
+				return
+			}
+
+			// Snapshotter's lost the daemons' states after exit, refetch them.
+			d.SendStates()
+		}()
+	}
+
+	return nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/containerd/nydus-snapshotter/config"
 	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
@@ -328,83 +329,108 @@ func (m *Manager) cleanUpDaemonResources(d *daemon.Daemon) {
 	log.L.Infof("Deleting resources %v", resource)
 }
 
+// recoverConcurrency bounds how many daemons are recovered at once. Recovery
+// is IO-bound (an HTTP request over each daemon's API socket), so a modest
+// fan-out bounds the pre-serving window by the slowest daemons instead of the
+// sum, without stampeding hosts that accumulated many daemons.
+const recoverConcurrency = 8
+
 func (m *Manager) recoverDaemons(ctx context.Context,
 	recoveringDaemons *map[string]*daemon.Daemon, liveDaemons *map[string]*daemon.Daemon) error {
+	// Only collect records inside the walk: the per-daemon work must not run
+	// within the bolt transaction WalkDaemons holds open.
+	var states []*daemon.ConfigState
 	if err := m.store.WalkDaemons(ctx, func(s *daemon.ConfigState) error {
 		if s.FsDriver != m.FsDriver {
 			return nil
 		}
-
 		log.L.Debugf("found daemon states %#v", s)
-		opt := make([]daemon.NewDaemonOpt, 0)
-		var d, _ = daemon.NewDaemon(opt...)
-		d.States = *s
-
-		m.daemonCache.Update(d)
-
-		if m.SupervisorSet != nil {
-			su := m.SupervisorSet.NewSupervisor(d.ID())
-			if su == nil {
-				return errors.Errorf("create supervisor for daemon %s", d.ID())
-			}
-			d.Supervisor = su
-		}
-
-		if d.States.FsDriver == config.FsDriverFusedev {
-			cfg, err := daemonconfig.NewDaemonConfig(d.States.FsDriver, d.ConfigFile(""))
-			if err != nil {
-				log.L.Errorf("Failed to reload daemon configuration %s, %s", d.ConfigFile(""), err)
-				return err
-			}
-
-			d.Config = cfg
-		}
-
-		state, err := d.GetState()
-		if err != nil {
-			log.L.Warnf("Daemon %s died somehow. Clean up its vestige!, %s", d.ID(), err)
-			(*recoveringDaemons)[d.ID()] = d
-			//nolint:nilerr
-			return nil
-		}
-
-		if state != types.DaemonStateRunning {
-			log.L.Warnf("daemon %s is not running: %s", d.ID(), state)
-			return nil
-		}
-
-		// FIXME: Should put the a daemon back file system shared damon field.
-		log.L.Infof("found RUNNING daemon %s during reconnecting", d.ID())
-		(*liveDaemons)[d.ID()] = d
-
-		if m.CgroupMgr != nil {
-			if err := m.CgroupMgr.AddProc(d.States.ProcessID); err != nil {
-				return errors.Wrapf(err, "add daemon %s to cgroup failed", d.ID())
-			}
-		}
-		d.Lock()
-		collector.NewDaemonInfoCollector(&d.Version, 1).Collect()
-		d.Unlock()
-
-		go func() {
-			if err := daemon.WaitUntilSocketExisted(d.GetAPISock(), d.Pid()); err != nil {
-				log.L.Errorf("Nydusd %s probably not started", d.ID())
-				return
-			}
-
-			if err = m.SubscribeDaemonEvent(d); err != nil {
-				log.L.Errorf("Nydusd %s probably not started", d.ID())
-				return
-			}
-
-			// Snapshotter's lost the daemons' states after exit, refetch them.
-			d.SendStates()
-		}()
-
+		states = append(states, s)
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk daemons to reconnect")
 	}
 
-	return nil
+	// The daemon cache and the supervisor set take their own locks; the
+	// result maps are only guarded here.
+	var mu sync.Mutex
+	var eg errgroup.Group
+	eg.SetLimit(recoverConcurrency)
+
+	for _, s := range states {
+		eg.Go(func() error {
+			opt := make([]daemon.NewDaemonOpt, 0)
+			var d, _ = daemon.NewDaemon(opt...)
+			d.States = *s
+
+			m.daemonCache.Update(d)
+
+			if m.SupervisorSet != nil {
+				su := m.SupervisorSet.NewSupervisor(d.ID())
+				if su == nil {
+					return errors.Errorf("create supervisor for daemon %s", d.ID())
+				}
+				d.Supervisor = su
+			}
+
+			if d.States.FsDriver == config.FsDriverFusedev {
+				cfg, err := daemonconfig.NewDaemonConfig(d.States.FsDriver, d.ConfigFile(""))
+				if err != nil {
+					log.L.Errorf("Failed to reload daemon configuration %s, %s", d.ConfigFile(""), err)
+					return err
+				}
+
+				d.Config = cfg
+			}
+
+			state, err := d.GetState()
+			if err != nil {
+				log.L.Warnf("Daemon %s died somehow. Clean up its vestige!, %s", d.ID(), err)
+				mu.Lock()
+				(*recoveringDaemons)[d.ID()] = d
+				mu.Unlock()
+				//nolint:nilerr
+				return nil
+			}
+
+			if state != types.DaemonStateRunning {
+				log.L.Warnf("daemon %s is not running: %s", d.ID(), state)
+				return nil
+			}
+
+			// FIXME: Should put the a daemon back file system shared damon field.
+			log.L.Infof("found RUNNING daemon %s during reconnecting", d.ID())
+			mu.Lock()
+			(*liveDaemons)[d.ID()] = d
+			mu.Unlock()
+
+			if m.CgroupMgr != nil {
+				if err := m.CgroupMgr.AddProc(d.States.ProcessID); err != nil {
+					return errors.Wrapf(err, "add daemon %s to cgroup failed", d.ID())
+				}
+			}
+			d.Lock()
+			collector.NewDaemonInfoCollector(&d.Version, 1).Collect()
+			d.Unlock()
+
+			go func() {
+				if err := daemon.WaitUntilSocketExisted(d.GetAPISock(), d.Pid()); err != nil {
+					log.L.Errorf("Nydusd %s probably not started", d.ID())
+					return
+				}
+
+				if err := m.SubscribeDaemonEvent(d); err != nil {
+					log.L.Errorf("Nydusd %s probably not started", d.ID())
+					return
+				}
+
+				// Snapshotter's lost the daemons' states after exit, refetch them.
+				d.SendStates()
+			}()
+
+			return nil
+		})
+	}
+
+	return eg.Wait()
 }

--- a/pkg/manager/manager_recover_test.go
+++ b/pkg/manager/manager_recover_test.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/nydus-snapshotter/config"
+	"github.com/containerd/nydus-snapshotter/config/daemonconfig"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon"
+	"github.com/containerd/nydus-snapshotter/pkg/daemon/types"
+	"github.com/containerd/nydus-snapshotter/pkg/store"
+)
+
+// startMockNydusd serves a RUNNING DaemonInfo over a unix socket, delaying
+// each response by delay to emulate a slow daemon.
+func startMockNydusd(t *testing.T, sock string, delay time.Duration) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(delay)
+		w.Header().Set("Content-Type", "application/json")
+		info := types.DaemonInfo{ID: "testid", State: "RUNNING"}
+		j, _ := json.Marshal(info)
+		_, _ = w.Write(j)
+	}))
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	ts.Listener = listener
+	ts.Start()
+	t.Cleanup(ts.Close)
+}
+
+// newRecoverTestDaemon persists a fusedev daemon record whose API socket and
+// PID are the given ones.
+func newRecoverTestDaemon(t *testing.T, m *Manager, id, sock string, pid int) {
+	configDir := filepath.Join(t.TempDir(), id)
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	cfg := daemonconfig.FuseDaemonConfig{
+		Device: &daemonconfig.DeviceConfig{},
+		Mode:   "direct",
+	}
+	cfg.Device.Backend.BackendType = "registry"
+	b, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.json"), b, 0o644))
+
+	d, err := daemon.NewDaemon()
+	require.NoError(t, err)
+	d.States = daemon.ConfigState{
+		ID:         id,
+		ProcessID:  pid,
+		APISocket:  sock,
+		DaemonMode: config.DaemonModeDedicated,
+		FsDriver:   config.FsDriverFusedev,
+		ConfigDir:  configDir,
+	}
+	require.NoError(t, m.AddDaemon(d))
+}
+
+func TestRecoverDaemonsConcurrently(t *testing.T) {
+	db, err := store.NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	m, err := NewManager(Opt{
+		Database: db,
+		FsDriver: config.FsDriverFusedev,
+	})
+	require.NoError(t, err)
+
+	// A process that already exited and was reaped: its record must land in
+	// recoveringDaemons without stalling recovery.
+	gone := exec.Command("true")
+	require.NoError(t, gone.Start())
+	require.NoError(t, gone.Wait())
+
+	const liveCount = 6
+	const delay = 400 * time.Millisecond
+	sockDir := t.TempDir()
+	for i := range liveCount {
+		sock := filepath.Join(sockDir, fmt.Sprintf("live-%d.sock", i))
+		startMockNydusd(t, sock, delay)
+		newRecoverTestDaemon(t, m, fmt.Sprintf("live-%d", i), sock, os.Getpid())
+	}
+	newRecoverTestDaemon(t, m, "dead-0", filepath.Join(sockDir, "dead-0.sock"), gone.Process.Pid)
+	newRecoverTestDaemon(t, m, "dead-1", filepath.Join(sockDir, "dead-1.sock"), gone.Process.Pid)
+
+	recovering := make(map[string]*daemon.Daemon)
+	live := make(map[string]*daemon.Daemon)
+
+	start := time.Now()
+	require.NoError(t, m.recoverDaemons(context.Background(), &recovering, &live))
+	elapsed := time.Since(start)
+
+	assert.Len(t, live, liveCount)
+	for i := range liveCount {
+		assert.Contains(t, live, fmt.Sprintf("live-%d", i))
+	}
+	assert.Len(t, recovering, 2)
+	assert.Contains(t, recovering, "dead-0")
+	assert.Contains(t, recovering, "dead-1")
+
+	// Serially the six live daemons alone cost >= 6*delay (2.4s). Concurrent
+	// recovery is bounded by the slowest daemon; leave generous headroom for
+	// slow CI machines.
+	assert.Less(t, elapsed, 4*delay)
+}

--- a/pkg/manager/manager_recover_test.go
+++ b/pkg/manager/manager_recover_test.go
@@ -47,8 +47,8 @@ func startMockNydusd(t *testing.T, sock string, delay time.Duration) {
 }
 
 // newRecoverTestDaemon persists a fusedev daemon record whose API socket and
-// PID are the given ones.
-func newRecoverTestDaemon(t *testing.T, m *Manager, id, sock string, pid int) {
+// PID are the given ones, and returns the record's configuration directory.
+func newRecoverTestDaemon(t *testing.T, m *Manager, id, sock string, pid int) string {
 	configDir := filepath.Join(t.TempDir(), id)
 	require.NoError(t, os.MkdirAll(configDir, 0o755))
 	cfg := daemonconfig.FuseDaemonConfig{
@@ -71,6 +71,7 @@ func newRecoverTestDaemon(t *testing.T, m *Manager, id, sock string, pid int) {
 		ConfigDir:  configDir,
 	}
 	require.NoError(t, m.AddDaemon(d))
+	return configDir
 }
 
 func TestRecoverDaemonsConcurrently(t *testing.T) {
@@ -118,4 +119,32 @@ func TestRecoverDaemonsConcurrently(t *testing.T) {
 	// recovery is bounded by the slowest daemon; leave generous headroom for
 	// slow CI machines.
 	assert.Less(t, elapsed, 4*delay)
+}
+
+func TestRecoverDaemonsCommitsNothingOnProbeFailure(t *testing.T) {
+	db, err := store.NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	m, err := NewManager(Opt{
+		Database: db,
+		FsDriver: config.FsDriverFusedev,
+	})
+	require.NoError(t, err)
+
+	sockDir := t.TempDir()
+	sock := filepath.Join(sockDir, "live-0.sock")
+	startMockNydusd(t, sock, 0)
+	newRecoverTestDaemon(t, m, "live-0", sock, os.Getpid())
+
+	// A record whose configuration cannot be reloaded fails its probe.
+	configDir := newRecoverTestDaemon(t, m, "damaged-0", filepath.Join(sockDir, "damaged-0.sock"), os.Getpid())
+	require.NoError(t, os.Remove(filepath.Join(configDir, "config.json")))
+
+	recovering := make(map[string]*daemon.Daemon)
+	live := make(map[string]*daemon.Daemon)
+
+	require.Error(t, m.recoverDaemons(context.Background(), &recovering, &live))
+
+	// Recovery failed before the commit phase: no partial results.
+	assert.Empty(t, recovering)
+	assert.Empty(t, live)
 }


### PR DESCRIPTION
Implements 2(b) from #791 (endorsed there by @imeoer).

`recoverDaemons` did all per-daemon work (supervisor create, config load, `GetState` over the API socket) serially inside the `WalkDaemons` bolt transaction, so the pre-serving window scales with the sum of per-daemon costs. This collects the records during the walk (the transaction no longer wraps the recovery work), then recovers with a bounded fan-out of 8. The per-daemon logic is unchanged; the result maps are mutex-guarded, the daemon cache and supervisor set already take their own locks.

One behavioral difference: an error in one daemon's recovery no longer stops the remaining daemons from being processed — recovery still fails overall with the first error.

Test: 6 live mock daemons responding after 400ms each plus 2 dead records recover in well under the 2.4s serial cost, with the maps populated correctly.

Note: #780 touches the same function; happy to rebase whichever lands second.
