### PR TITLE
snapshotter: wait for nydus socket before restarting containerd

### DIFF
--- a/misc/snapshotter/snapshotter.sh
+++ b/misc/snapshotter/snapshotter.sh
@@ -183,9 +183,14 @@ function deploy_snapshotter() {
         sed -i "s|^ExecStart=.*$|ExecStart=$COMMANDLINE|" "${SNAPSHOTTER_SERVICE}"
         nsenter -t 1 -m systemctl daemon-reload
         nsenter -t 1 -m systemctl enable nydus-snapshotter.service
+        # A socket file left behind by a previous (crashed or cleaned-up)
+        # snapshotter process would satisfy the readiness check below against
+        # a dead listener, so drop it before (re)starting the service.
+        rm -f "${SNAPSHOTTER_GRPC_SOCKET}"
         wait_service_active 30 5 nydus-snapshotter
     else
         echo "running snapshotter as standalone process"
+        rm -f "${SNAPSHOTTER_GRPC_SOCKET}"
         ${COMMANDLINE} &
     fi
 
@@ -202,15 +207,19 @@ function deploy_snapshotter() {
 }
 
 # Wait until the nydus snapshotter gRPC socket exists (bound), up to a timeout.
+# Aborts deployment if the socket never appears: restarting containerd without
+# it takes the node down, while aborting keeps the currently running containerd
+# alive and surfaces the failure as a pod error.
 function wait_for_nydus_socket() {
-    local wait_time="${NYDUS_SOCKET_WAIT_TIMEOUT:-30}"
+    local timeout="${NYDUS_SOCKET_WAIT_TIMEOUT:-30}"
+    local wait_time="${timeout}"
     while [ "$wait_time" -gt 0 ] && [ ! -S "${SNAPSHOTTER_GRPC_SOCKET}" ]; do
         echo "waiting for nydus snapshotter socket ${SNAPSHOTTER_GRPC_SOCKET}"
         sleep 1
         wait_time=$((wait_time - 1))
     done
     if [ ! -S "${SNAPSHOTTER_GRPC_SOCKET}" ]; then
-        echo "WARNING: nydus snapshotter socket not ready after timeout"
+        die "nydus snapshotter socket ${SNAPSHOTTER_GRPC_SOCKET} not ready after ${timeout}s"
     fi
 }
 

--- a/misc/snapshotter/snapshotter.sh
+++ b/misc/snapshotter/snapshotter.sh
@@ -188,8 +188,30 @@ function deploy_snapshotter() {
         echo "running snapshotter as standalone process"
         ${COMMANDLINE} &
     fi
+
+    # containerd's CRI plugin resolves the default snapshotter at init. If
+    # containerd restarts before the nydus snapshotter has bound its gRPC socket,
+    # the CRI plugin fails to load with "failed to find snapshotter \"nydus\"" and
+    # the node goes NotReady ("container runtime is down"). This race shows up on
+    # every pod re-deploy / rolling update. Wait for the socket to be ready before
+    # restarting containerd.
+    wait_for_nydus_socket
+
     wait_service_active 30 5 ${CONTAINER_RUNTIME}
 
+}
+
+# Wait until the nydus snapshotter gRPC socket exists (bound), up to a timeout.
+function wait_for_nydus_socket() {
+    local wait_time="${NYDUS_SOCKET_WAIT_TIMEOUT:-30}"
+    while [ "$wait_time" -gt 0 ] && [ ! -S "${SNAPSHOTTER_GRPC_SOCKET}" ]; do
+        echo "waiting for nydus snapshotter socket ${SNAPSHOTTER_GRPC_SOCKET}"
+        sleep 1
+        wait_time=$((wait_time - 1))
+    done
+    if [ ! -S "${SNAPSHOTTER_GRPC_SOCKET}" ]; then
+        echo "WARNING: nydus snapshotter socket not ready after timeout"
+    fi
 }
 
 function remove_images() {


### PR DESCRIPTION
## Summary

Fixes #796. During nydus DaemonSet rolling updates / pod re-deploys, `deploy_snapshotter()`
restarts containerd the moment the nydus-snapshotter systemd service reports `is-active` —
which can be **before the nydus gRPC socket is bound**. containerd then starts with
`[proxy_plugins.nydus]` pointing at a not-yet-ready socket, the proxy plugin fails to register,
and the CRI plugin hard-fails with `failed to find snapshotter "nydus"`, taking the node down
(`container runtime is down` → NotReady).

Reproduces on containerd **1.7 and 2.x** once `snapshotter = "nydus"` is in effect. First install
usually survives (socket happens to be bound in time); rolling updates / re-deploys race and kill
the node (~10 nodes lost in a single representative rollout before it was stopped).

View of the failing containerd journal:

```
level=warning msg="failed to load plugin"
  error="failed to create CRI service: failed to find snapshotter \"nydus\""
  id=io.containerd.grpc.v1.cri
```

## Change

Add a bounded `wait_for_nydus_socket()` (socket exists, up to a 30s timeout) in
`deploy_snapshotter()` before restarting containerd, so the CRI plugin can resolve nydus at init.
Not added to the cleanup/`remove` path because that reverts the config to a non-nydus baseline
before restarting, so nydus isn't required there.

## Test plan
- [ ] Rolling update of a nydus DaemonSet no longer drops nodes (validated against containerd 2.3.3)
- [ ] `snapshotter.sh` still passes shellcheck/syntax